### PR TITLE
add vite-plugin-ssr prerender --outDir flag so that the output direct…

### DIFF
--- a/docs/pages/command-prerender.page.mdx
+++ b/docs/pages/command-prerender.page.mdx
@@ -10,6 +10,7 @@ Options:
  - `partial`: Allow only a subset of pages to be pre-rendered. (Pages with a parameterized route cannot be pre-rendered without `prerender()` hook; the `--partial` option suppresses the warning telling you about pages not being pre-rendered.)
  - `no-extra-dir`/`noExtraDir`: Do not create a new directory for each page, e.g. generate `dist/client/about.html` instead of `dist/client/about/index.html`.
  - `root`: The root directory of your project (where `vite.config.js` and `dist/` live). Default: `process.cwd()`.
+ - `outDir`: The build directoy of your project. Default: `dist`.
  - `parallel`: Number of concurrenlty running jobs. Default: [`os.cpus().length`](https://nodejs.org/api/os.html#os_os_cpus). Set to `1` to disable concurrency.
 
 Options are passed like this:

--- a/docs/pages/createPageRenderer.page.mdx
+++ b/docs/pages/createPageRenderer.page.mdx
@@ -14,6 +14,7 @@ const { createPageRenderer } = require('vite-plugin-ssr')
 const isProduction = process.env.NODE_ENV === 'production'
 const root = `${__dirname}/..`
 const base = '/'
+const outDir = `dist`
 
 startServer()
 
@@ -22,7 +23,7 @@ async function startServer() {
 
   let viteDevServer
   if (isProduction) {
-    app.use(express.static(`${root}/dist/client`))
+    app.use(express.static(`${root}/${outDir}/client`))
   } else {
     const vite = require('vite')
     viteDevServer = await vite.createServer({
@@ -32,7 +33,7 @@ async function startServer() {
     app.use(viteDevServer.middlewares)
   }
 
-  const renderPage = createPageRenderer({ viteDevServer, isProduction, root, base })
+  const renderPage = createPageRenderer({ viteDevServer, isProduction, root, outDir, base })
   app.get('*', async (req, res, next) => {
     const url = req.originalUrl
     const pageContextInit = { url }
@@ -50,6 +51,7 @@ async function startServer() {
 - `viteDevServer` is the Vite dev server.
 - `isProduction` is a boolean. When set to `true`, `vite-plugin-ssr` loads already-transpiled code from `dist/` instead of on-the-fly transpiling code.
 - `root` is the absolute path of our app's root directory. The `root` directory is usually the directory where `vite.config.js` lives. All our `.page.js` files need to be descendent of the `root` directory.
+- `outDir` is the build directory of your project. Default: `dist`.
 - `base` is the [Base URL](/base-url).
 - `pageContext.httpResponse` is `null` when a) an error occurred while rendering `_error.page.js`, or b) we didn't define the page `_error.page.js` and and an error occured.
 - `pageContext.httpResponse.statusCode` is either `200`, `404`, or `500`.

--- a/vite-plugin-ssr/node/cli/bin.ts
+++ b/vite-plugin-ssr/node/cli/bin.ts
@@ -16,6 +16,10 @@ cli
     '--root <path>',
     '[string] root directory of your project (where `vite.config.js` and `dist/` live) (default: `process.cwd()`)'
   )
+  .option(
+    '--outDir <path>',
+    '[string] build directory of your project (default: `dist`)'
+  )
   .option('--client-router', 'serialize `pageContext` to JSON files for Client Routing')
   .option('--base <path>', '[string] public base path (default: /)')
   .option(
@@ -23,10 +27,10 @@ cli
     '[number] Number of jobs running in parallel. Default: `os.cpus().length`. Set to `1` to disable concurrency.'
   )
   .action(async (options) => {
-    const { partial, extraDir, clientRouter, base, parallel } = options
+    const { partial, extraDir, clientRouter, base, parallel, outDir } = options
     const root = options.root && resolve(options.root)
     const noExtraDir = !extraDir
-    await prerender({ partial, noExtraDir, clientRouter, base, root, parallel })
+    await prerender({ partial, noExtraDir, clientRouter, base, root, parallel, outDir })
   })
 
 // Listen to unknown commands

--- a/vite-plugin-ssr/node/createPageRenderer.ts
+++ b/vite-plugin-ssr/node/createPageRenderer.ts
@@ -20,6 +20,7 @@ type RenderPage = typeof renderPage
 function createPageRenderer({
   viteDevServer,
   root,
+  outDir = 'dist',
   isProduction,
   base = '/'
 }: {
@@ -28,6 +29,7 @@ function createPageRenderer({
   viteDevServer?: ViteDevServer
   */
   root?: string
+  outDir?: string
   isProduction?: boolean
   base?: string
 }): RenderPage {
@@ -37,7 +39,7 @@ function createPageRenderer({
   )
   wasCalled = true
 
-  const ssrEnv = { viteDevServer, root, isProduction, baseUrl: base }
+  const ssrEnv = { viteDevServer, root, outDir, isProduction, baseUrl: base }
   assertArguments(ssrEnv, Array.from(arguments))
   setSsrEnv(ssrEnv)
 
@@ -48,15 +50,20 @@ function assertArguments(
   ssrEnv: {
     viteDevServer?: unknown
     root?: unknown
+    outDir?: unknown
     isProduction?: unknown
     baseUrl?: unknown
   },
   args: unknown[]
 ): asserts ssrEnv is SsrEnv {
-  const { viteDevServer, root, isProduction, baseUrl } = ssrEnv
+  const { viteDevServer, root, outDir, isProduction, baseUrl } = ssrEnv
   assertUsage(
     root === undefined || typeof root === 'string',
     '`createPageRenderer({ root })`: argument `root` should be a string.'
+  )
+  assertUsage(
+    typeof outDir === 'string',
+    '`createPageRenderer({ outDir })`: argument `outDir` should be a string.'
   )
   assertUsage(
     typeof baseUrl === 'string',
@@ -107,7 +114,7 @@ function assertArguments(
   assert(typeof args[0] === 'object' && args[0] !== null)
   Object.keys(args[0]).forEach((argName) => {
     assertUsage(
-      ['viteDevServer', 'root', 'isProduction', 'base'].includes(argName),
+      ['viteDevServer', 'root', 'outDir', 'isProduction', 'base'].includes(argName),
       '`createPageRenderer()`: Unknown argument `' + argName + '`.'
     )
   })

--- a/vite-plugin-ssr/node/getViteManifest.ts
+++ b/vite-plugin-ssr/node/getViteManifest.ts
@@ -27,9 +27,9 @@ function getViteManifest(): {
   clientManifestPath: string
   serverManifestPath: string
 } {
-  const { root } = getSsrEnv()
-  const clientManifestPath = `${root}/dist/client/manifest.json`
-  const serverManifestPath = `${root}/dist/server/manifest.json`
+  const { root, outDir } = getSsrEnv()
+  const clientManifestPath = `${root}/${outDir}/client/manifest.json`
+  const serverManifestPath = `${root}/${outDir}/server/manifest.json`
 
   if (!clientManifest) {
     try {

--- a/vite-plugin-ssr/node/page-files/setup.ts
+++ b/vite-plugin-ssr/node/page-files/setup.ts
@@ -12,9 +12,9 @@ async function setPageFiles(): Promise<unknown> {
 
   const viteEntryFile = 'pageFiles.js'
   assert(moduleExists(`./${viteEntryFile}`, __dirname))
-  const userDist = `${ssrEnv.root}/dist`
+  const userDist = `${ssrEnv.root}/${ssrEnv.outDir}`
   // Current directory: vite-plugin-ssr/dist/cjs/node/page-files/
-  const pluginDist = `../../../../dist`
+  const pluginDist = `../../../../${ssrEnv.outDir}`
   const prodPath = `${userDist}/server/${viteEntryFile}`
   const devPath = `${pluginDist}/esm/node/page-files/${viteEntryFile}`
 

--- a/vite-plugin-ssr/node/plugin/build.ts
+++ b/vite-plugin-ssr/node/plugin/build.ts
@@ -105,9 +105,9 @@ function getRoot(config: UserConfig): string {
 function getOutDir(config: UserConfig): string {
   let outDir = config.build?.outDir
   if (!outDir) {
-    outDir = config.build?.ssr ? 'dist/server' : 'dist/client'
+    outDir = 'dist'
   }
-  return outDir
+  return config.build?.ssr ? `${outDir}/server` : `${outDir}/client`
 }
 
 function posixPath(path: string): string {

--- a/vite-plugin-ssr/node/ssrEnv.ts
+++ b/vite-plugin-ssr/node/ssrEnv.ts
@@ -10,12 +10,14 @@ type SsrEnv =
       isProduction: false
       viteDevServer: ViteDevServer
       root: string
+      outDir: string
       baseUrl: string
     }
   | {
       isProduction: true
       viteDevServer: undefined
       root?: string | undefined
+      outDir: string
       baseUrl: string
     }
 


### PR DESCRIPTION
…ory can be specified

The flag seems to be working as expected with these changes. 

Most of the credit should go to the person who originally created this pull request: https://github.com/brillout/vite-plugin-ssr/pull/114

Please let me know about any changes or updates that should be made so that this can be merged.

thanks