### PR TITLE
examples: add type to guard hooks

### DIFF
--- a/examples/auth/pages/account/+guard.ts
+++ b/examples/auth/pages/account/+guard.ts
@@ -1,9 +1,10 @@
-export default guard
+// https://vike.dev/guard
+export { guard }
 
 import { render } from 'vike/abort'
-import type { PageContext } from 'vike/types'
+import type { GuardAsync } from 'vike/types'
 
-function guard(pageContext: PageContext) {
+const guard: GuardAsync = async (pageContext): ReturnType<GuardAsync> => {
   if (!pageContext.user) {
     throw render('/login')
   }

--- a/examples/auth/pages/admin/+guard.ts
+++ b/examples/auth/pages/admin/+guard.ts
@@ -1,9 +1,10 @@
-export default guard
+// https://vike.dev/guard
+export { guard }
 
 import { render } from 'vike/abort'
-import type { PageContext } from 'vike/types'
+import type { GuardAsync } from 'vike/types'
 
-function guard(pageContext: PageContext) {
+const guard: GuardAsync = async (pageContext): ReturnType<GuardAsync> => {
   if (!pageContext.user) {
     throw render('/login')
   }

--- a/examples/auth/tsconfig.json
+++ b/examples/auth/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "strict": true,
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "target": "ES2020",
     "skipLibCheck": true,
     "jsx": "preserve",
     "esModuleInterop": true,


### PR DESCRIPTION
#### From the commit message:

Note that tsconfig.json must contain

    "module": "ES2020",
    "moduleResolution": "Node",
    "target": "ES2020",

otherwise declarations like

    const guard: GuardAsync = async (pageContext): ReturnType<GuardAsync> => {

fail with

    Type 'ReturnType' is not a valid async function return type in
    ES5/ES3 because it does not refer to a Promise-compatible
    constructor value.