### PR TITLE
refactor: update rollup warning types

### DIFF
--- a/vike/node/plugin/plugins/suppressRollupWarning.ts
+++ b/vike/node/plugin/plugins/suppressRollupWarning.ts
@@ -3,7 +3,7 @@
 export { suppressRollupWarning }
 
 import type { Plugin, Rollup } from 'vite'
-type RollupWarning = Rollup.RollupWarning
+type RollupLog = Rollup.RollupLog
 
 function suppressRollupWarning(): Plugin {
   return {
@@ -30,17 +30,17 @@ function suppressRollupWarning(): Plugin {
 }
 
 /** Suppress warning about Rollup removing the React Server Components `"use client";` directives */
-function suppressUseClientDirective(warning: RollupWarning) {
+function suppressUseClientDirective(warning: RollupLog) {
   return warning.code === 'MODULE_LEVEL_DIRECTIVE' && warning.message.includes('"use client"')
 }
 
 /** Suppress warning about generating emtpy chunks in dist/ */
-function suppressEmptyBundle(warning: RollupWarning) {
+function suppressEmptyBundle(warning: RollupLog) {
   return warning.code === 'EMPTY_BUNDLE'
 }
 
 /** Suppress warning about unused import statements */
-function suppressUnusedImport(warning: RollupWarning & { ids?: string[] }): boolean {
+function suppressUnusedImport(warning: RollupLog & { ids?: string[] }): boolean {
   if (warning.code !== 'UNUSED_EXTERNAL_IMPORT') return false
 
   // I guess it's expected that JSX contains unsused `import React from 'react'`


### PR DESCRIPTION
Since [Rollup 3.25.0](https://github.com/rollup/rollup/releases/tag/v3.25.0), it introduced the `RollupLog` type in favour of `RollupWarning` as it supports `this.info`, `this.warn`, etc. `RollupWarning` was made an alias of `RollupLog`.

In Rollup 4 which Vite 5 uses, `RollupWarning` was removed. In this PR, I updated to use `RollupLog` instead.