### PR TITLE
Allow "constructor" search param in URL

### DIFF
--- a/vike/utils/parseUrl.spec.ts
+++ b/vike/utils/parseUrl.spec.ts
@@ -125,28 +125,28 @@ describe('parseUrl', () => {
       searchAll: { q: ['apples'] },
       searchOriginal: '?q=apples'
     })
-    expect(parseUrl('/shop?fruits=apples&candies=chocolate,lolipop', '/')).toEqual({
+    expect(parseUrl('/shop?fruits=apples&candies=chocolate,lollipop', '/')).toEqual({
       ...resultBase,
       pathnameOriginal: '/shop',
       pathname: '/shop',
-      search: { fruits: 'apples', candies: 'chocolate,lolipop' },
-      searchAll: { fruits: ['apples'], candies: ['chocolate,lolipop'] },
-      searchOriginal: '?fruits=apples&candies=chocolate,lolipop'
+      search: { fruits: 'apples', candies: 'chocolate,lollipop' },
+      searchAll: { fruits: ['apples'], candies: ['chocolate,lollipop'] },
+      searchOriginal: '?fruits=apples&candies=chocolate,lollipop'
     })
-    const searchQuery = '?fruit=apples&fruit=bannanas&candy=chocolate&candy=lolipop&constructor=val1&constructor=val2'
+    const searchQuery = '?fruit=apples&fruit=bananas&candy=chocolate&candy=lollipop&constructor=val1&constructor=val2'
     const { searchOriginal } = parseUrl(`/shop${searchQuery}`, '/')
     assert(searchOriginal)
     const searchParams = new URLSearchParams(searchOriginal)
-    expect(searchParams.getAll('fruit')).toEqual(['apples', 'bannanas'])
-    expect(searchParams.getAll('candy')).toEqual(['chocolate', 'lolipop'])
+    expect(searchParams.getAll('fruit')).toEqual(['apples', 'bananas'])
+    expect(searchParams.getAll('candy')).toEqual(['chocolate', 'lollipop'])
     expect(parseUrl(`/shop${searchQuery}`, '/shop')).toEqual({
       ...resultBase,
       pathnameOriginal: '/shop',
       pathname: '/',
-      search: { fruit: 'bannanas', candy: 'lolipop', constructor: 'val2' },
+      search: { fruit: 'bananas', candy: 'lollipop', constructor: 'val2' },
       searchAll: {
-        fruit: ['apples', 'bannanas'],
-        candy: ['chocolate', 'lolipop'],
+        fruit: ['apples', 'bananas'],
+        candy: ['chocolate', 'lollipop'],
         constructor: ['val1', 'val2']
       },
       searchOriginal: searchQuery

--- a/vike/utils/parseUrl.spec.ts
+++ b/vike/utils/parseUrl.spec.ts
@@ -133,7 +133,7 @@ describe('parseUrl', () => {
       searchAll: { fruits: ['apples'], candies: ['chocolate,lolipop'] },
       searchOriginal: '?fruits=apples&candies=chocolate,lolipop'
     })
-    const searchQuery = '?fruit=apples&fruit=bannanas&candy=chocolate&candy=lolipop'
+    const searchQuery = '?fruit=apples&fruit=bannanas&candy=chocolate&candy=lolipop&constructor=val1&constructor=val2'
     const { searchOriginal } = parseUrl(`/shop${searchQuery}`, '/')
     assert(searchOriginal)
     const searchParams = new URLSearchParams(searchOriginal)
@@ -143,8 +143,12 @@ describe('parseUrl', () => {
       ...resultBase,
       pathnameOriginal: '/shop',
       pathname: '/',
-      search: { fruit: 'bannanas', candy: 'lolipop' },
-      searchAll: { fruit: ['apples', 'bannanas'], candy: ['chocolate', 'lolipop'] },
+      search: { fruit: 'bannanas', candy: 'lolipop', constructor: 'val2' },
+      searchAll: {
+        fruit: ['apples', 'bannanas'],
+        candy: ['chocolate', 'lolipop'],
+        constructor: ['val1', 'val2']
+      },
       searchOriginal: searchQuery
     })
   })

--- a/vike/utils/parseUrl.ts
+++ b/vike/utils/parseUrl.ts
@@ -77,7 +77,7 @@ function parseUrl(
   const searchAll: Record<string, string[]> = {}
   Array.from(new URLSearchParams(searchOriginal || '')).forEach(([key, val]) => {
     search[key] = val
-    searchAll[key] = [...(searchAll[key] || []), val]
+    searchAll[key] = [...(Array.isArray(searchAll[key]) ? searchAll[key]! : []), val]
   })
 
   // Origin + pathname

--- a/vike/utils/parseUrl.ts
+++ b/vike/utils/parseUrl.ts
@@ -77,7 +77,7 @@ function parseUrl(
   const searchAll: Record<string, string[]> = {}
   Array.from(new URLSearchParams(searchOriginal || '')).forEach(([key, val]) => {
     search[key] = val
-    searchAll[key] = [...(Array.isArray(searchAll[key]) ? searchAll[key]! : []), val]
+    searchAll[key] = [...(searchAll.hasOwnProperty(key) ? searchAll[key]! : []), val]
   })
 
   // Origin + pathname


### PR DESCRIPTION
This fixes https://github.com/vikejs/vike/issues/1205

### What I did
* I made sure search params with the `constructor` key in URLs don't make parseUrl() blow up.
* Also fixed a few typos

### How I did
In following code

```ts
searchAll[key] = [...(searchAll[key] || []), val]
```

when `searchAll[key]` is accessed the first time it is typically `undefined` and `searchAll[key] || []` evaluates as an empty array resulting in `searchAll[key] = [val]`. However, if `key` is `'constructor'` `searchAll['constructor']` is a function resulting `searchAll['constructor'] || []` to be a function, which is not iterable, hence `...(searchAll[key] || [])` throws an error.

One possible solution to the issue is checking if `searchAll[key]` is an array and spread it only if so, otherwise fall back to the empty array.
