### PR TITLE
Enable any protocol support for redirects

### DIFF
--- a/vike/node/runtime/renderPage/createHttpResponseObject/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponseObject/assertNoInfiniteHttpRedirect.ts
@@ -9,7 +9,7 @@ const globalObject = getGlobalObject<{ redirectGraph: Graph }>('assertNoInfinite
 })
 
 function assertNoInfiniteHttpRedirect(urlRedirectTarget: string, urlLogical: string) {
-  if (urlRedirectTarget.startsWith('http') || urlRedirectTarget.startsWith('mailto:')) {
+  if (/^[a-zA-Z]+:/.test(urlRedirectTarget)) {
     // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (in itself).
     //  - There isn't a reliable way to check whether the redirect points to an external origin or the same origin. For same origins, we assume/hope the user to pass the URL without origin.
     //    ```js

--- a/vike/node/runtime/renderPage/createHttpResponseObject/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponseObject/assertNoInfiniteHttpRedirect.ts
@@ -1,6 +1,6 @@
 export { assertNoInfiniteHttpRedirect }
 
-import { assert, assertUsage, getGlobalObject } from '../../utils.js'
+import { assert, assertUsage, getGlobalObject, isUriWithProtocol } from '../../utils.js'
 import pc from '@brillout/picocolors'
 
 type Graph = Record<string, Set<string>>
@@ -9,7 +9,7 @@ const globalObject = getGlobalObject<{ redirectGraph: Graph }>('assertNoInfinite
 })
 
 function assertNoInfiniteHttpRedirect(urlRedirectTarget: string, urlLogical: string) {
-  if (/^[a-zA-Z]+:/.test(urlRedirectTarget)) {
+  if (isUriWithProtocol(urlRedirectTarget)) {
     // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (in itself).
     //  - There isn't a reliable way to check whether the redirect points to an external origin or the same origin. For same origins, we assume/hope the user to pass the URL without origin.
     //    ```js

--- a/vike/node/runtime/renderPage/createHttpResponseObject/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponseObject/assertNoInfiniteHttpRedirect.ts
@@ -9,7 +9,7 @@ const globalObject = getGlobalObject<{ redirectGraph: Graph }>('assertNoInfinite
 })
 
 function assertNoInfiniteHttpRedirect(urlRedirectTarget: string, urlLogical: string) {
-  if (urlRedirectTarget.startsWith('http')) {
+  if (urlRedirectTarget.startsWith('http') || urlRedirectTarget.startsWith('mailto:')) {
     // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (in itself).
     //  - There isn't a reliable way to check whether the redirect points to an external origin or the same origin. For same origins, we assume/hope the user to pass the URL without origin.
     //    ```js

--- a/vike/shared/route/resolveRedirects.spec.ts
+++ b/vike/shared/route/resolveRedirects.spec.ts
@@ -25,7 +25,7 @@ describe('resolveRouteStringRedirect', () => {
     )
     expectErr(
       () => resolveRouteStringRedirect('/a', 'b', '/'),
-      '[vike][Wrong Usage][vite.config.js > vike({ redirects })] Invalid redirection target URL b: the target URL should start with /, a valid protocol, or be *'
+      '[vike][Wrong Usage][vite.config.js > vike({ redirects })] Invalid redirection target URL b: the target URL should start with /, a valid protocol (https:, http:, ipfs:, magnet:, ...), or be *'
     )
     expectErr(
       () => resolveRouteStringRedirect('/a', '/@i', '/'),

--- a/vike/shared/route/resolveRedirects.spec.ts
+++ b/vike/shared/route/resolveRedirects.spec.ts
@@ -54,6 +54,12 @@ describe('resolveRouteStringRedirect', () => {
     expect(resolveRouteStringRedirect('/a/*', 'http://a.org/b/c/d/*', '/a/1/2/3')).toEqual('http://a.org/b/c/d/1/2/3')
     expect(resolveRouteStringRedirect('/a/b/c', 'http://a.com', '/a/b/c')).toEqual('http://a.com')
   })
+  it('mailto redirects', () => {
+    expect(resolveRouteStringRedirect('/contact', 'mailto:foo@bar.test', '/contact')).toEqual('mailto:foo@bar.test')
+    expect(resolveRouteStringRedirect('/contact', 'mailto:foo@bar.test?subject=Hello', '/contact')).toEqual(
+      'mailto:foo@bar.test?subject=Hello'
+    )
+  })
 })
 
 function expectErr(fn: Function, errMsg: string) {

--- a/vike/shared/route/resolveRedirects.spec.ts
+++ b/vike/shared/route/resolveRedirects.spec.ts
@@ -25,7 +25,7 @@ describe('resolveRouteStringRedirect', () => {
     )
     expectErr(
       () => resolveRouteStringRedirect('/a', 'b', '/'),
-      '[vike][Wrong Usage][vite.config.js > vike({ redirects })] Invalid redirection target URL b: the target URL should start with /, http://, https://, or be *'
+      '[vike][Wrong Usage][vite.config.js > vike({ redirects })] Invalid redirection target URL b: the target URL should start with /, http://, https://, mailto:, or be *'
     )
     expectErr(
       () => resolveRouteStringRedirect('/a', '/@i', '/'),

--- a/vike/shared/route/resolveRedirects.spec.ts
+++ b/vike/shared/route/resolveRedirects.spec.ts
@@ -25,7 +25,7 @@ describe('resolveRouteStringRedirect', () => {
     )
     expectErr(
       () => resolveRouteStringRedirect('/a', 'b', '/'),
-      '[vike][Wrong Usage][vite.config.js > vike({ redirects })] Invalid redirection target URL b: the target URL should start with /, http://, https://, mailto:, or be *'
+      '[vike][Wrong Usage][vite.config.js > vike({ redirects })] Invalid redirection target URL b: the target URL should start with /, a valid protocol, or be *'
     )
     expectErr(
       () => resolveRouteStringRedirect('/a', '/@i', '/'),
@@ -54,10 +54,15 @@ describe('resolveRouteStringRedirect', () => {
     expect(resolveRouteStringRedirect('/a/*', 'http://a.org/b/c/d/*', '/a/1/2/3')).toEqual('http://a.org/b/c/d/1/2/3')
     expect(resolveRouteStringRedirect('/a/b/c', 'http://a.com', '/a/b/c')).toEqual('http://a.com')
   })
-  it('mailto redirects', () => {
+  it('any protocol redirects', () => {
     expect(resolveRouteStringRedirect('/contact', 'mailto:foo@bar.test', '/contact')).toEqual('mailto:foo@bar.test')
     expect(resolveRouteStringRedirect('/contact', 'mailto:foo@bar.test?subject=Hello', '/contact')).toEqual(
       'mailto:foo@bar.test?subject=Hello'
+    )
+    expect(resolveRouteStringRedirect('/ipfs', 'ipfs://example.com', '/ipfs')).toEqual('ipfs://example.com')
+    expect(resolveRouteStringRedirect('/ipns', 'ipns://example.com', '/ipns')).toEqual('ipns://example.com')
+    expect(resolveRouteStringRedirect('/magnet', 'magnet:?xt=urn:btih:example', '/magnet')).toEqual(
+      'magnet:?xt=urn:btih:example'
     )
   })
 })

--- a/vike/shared/route/resolveRedirects.ts
+++ b/vike/shared/route/resolveRedirects.ts
@@ -23,14 +23,10 @@ function resolveRedirects(redirects: Record<string, string>, urlPathname: string
 function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPathname: string): null | string {
   assertRouteString(urlSource, `${configSrc} Invalid`)
   assertUsage(
-    urlTarget.startsWith('/') ||
-      urlTarget.startsWith('http://') ||
-      urlTarget.startsWith('https://') ||
-      urlTarget.startsWith('mailto:') ||
-      urlTarget === '*',
+    urlTarget.startsWith('/') || /^[a-zA-Z]+:/.test(urlTarget) || urlTarget === '*',
     `${configSrc} Invalid redirection target URL ${pc.cyan(urlTarget)}: the target URL should start with ${pc.cyan(
       '/'
-    )}, ${pc.cyan('http://')}, ${pc.cyan('https://')}, ${pc.cyan('mailto:')}, or be ${pc.cyan('*')}`
+    )}, a valid protocol, or be ${pc.cyan('*')}`
   )
   assertParams(urlSource, urlTarget)
   const match = resolveRouteString(urlSource, urlPathname)
@@ -46,7 +42,7 @@ function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPat
     assertUsage(!urlResolved.includes('@'), 'URL should not contain "@" unless it is a mailto link.')
   }
   if (urlResolved === urlPathname) return null
-  assert(urlTarget.startsWith('/') || urlTarget.startsWith('http') || urlResolved.startsWith('mailto:'))
+  assert(urlTarget.startsWith('/') || /^[a-zA-Z]+:/.test(urlTarget))
   return urlResolved
 }
 

--- a/vike/shared/route/resolveRedirects.ts
+++ b/vike/shared/route/resolveRedirects.ts
@@ -4,6 +4,7 @@ export { resolveRedirects }
 export { resolveRouteStringRedirect }
 
 import { assertIsNotBrowser } from '../../utils/assertIsNotBrowser.js'
+import { isUriWithProtocol } from '../../utils/parseUrl-extras.js'
 import { assert, assertUsage } from '../utils.js'
 import { assertRouteString, resolveRouteString } from './resolveRouteString.js'
 import pc from '@brillout/picocolors'
@@ -23,10 +24,12 @@ function resolveRedirects(redirects: Record<string, string>, urlPathname: string
 function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPathname: string): null | string {
   assertRouteString(urlSource, `${configSrc} Invalid`)
   assertUsage(
-    urlTarget.startsWith('/') || /^[a-zA-Z]+:/.test(urlTarget) || urlTarget === '*',
+    urlTarget.startsWith('/') || isUriWithProtocol(urlTarget) || urlTarget === '*',
     `${configSrc} Invalid redirection target URL ${pc.cyan(urlTarget)}: the target URL should start with ${pc.cyan(
       '/'
-    )}, a valid protocol, or be ${pc.cyan('*')}`
+    )}, a valid protocol (${pc.cyan('https:')}, ${pc.cyan('http:')}, ${pc.cyan('ipfs:')}, ${pc.cyan(
+      'magnet:'
+    )}, ...), or be ${pc.cyan('*')}`
   )
   assertParams(urlSource, urlTarget)
   const match = resolveRouteString(urlSource, urlPathname)
@@ -42,7 +45,7 @@ function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPat
     assertUsage(!urlResolved.includes('@'), 'URL should not contain "@" unless it is a mailto link.')
   }
   if (urlResolved === urlPathname) return null
-  assert(urlTarget.startsWith('/') || /^[a-zA-Z]+:/.test(urlTarget))
+  assert(urlResolved.startsWith('/') || isUriWithProtocol(urlResolved))
   return urlResolved
 }
 

--- a/vike/shared/route/resolveRedirects.ts
+++ b/vike/shared/route/resolveRedirects.ts
@@ -26,10 +26,11 @@ function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPat
     urlTarget.startsWith('/') ||
       urlTarget.startsWith('http://') ||
       urlTarget.startsWith('https://') ||
+      urlTarget.startsWith('mailto:') ||
       urlTarget === '*',
     `${configSrc} Invalid redirection target URL ${pc.cyan(urlTarget)}: the target URL should start with ${pc.cyan(
       '/'
-    )}, ${pc.cyan('http://')}, ${pc.cyan('https://')}, or be ${pc.cyan('*')}`
+    )}, ${pc.cyan('http://')}, ${pc.cyan('https://')}, ${pc.cyan('mailto:')}, or be ${pc.cyan('*')}`
   )
   assertParams(urlSource, urlTarget)
   const match = resolveRouteString(urlSource, urlPathname)
@@ -41,9 +42,11 @@ function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPat
     }
     urlResolved = urlResolved.replaceAll(key, val)
   })
-  assert(!urlResolved.includes('@'))
+  if (!urlResolved.startsWith('mailto:')) {
+    assert(!urlResolved.includes('@'), 'URL should not contain "@" unless it is a mailto link.')
+  }
   if (urlResolved === urlPathname) return null
-  assert(urlTarget.startsWith('/') || urlTarget.startsWith('http'))
+  assert(urlTarget.startsWith('/') || urlTarget.startsWith('http') || urlResolved.startsWith('mailto:'))
   return urlResolved
 }
 

--- a/vike/shared/route/resolveRedirects.ts
+++ b/vike/shared/route/resolveRedirects.ts
@@ -46,7 +46,7 @@ function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPat
     assert(!urlResolved.includes('@'), 'URL should not contain "@" unless it is a mailto link.')
   }
   if (urlResolved === urlPathname) return null
-  assert(urlTarget.startsWith('/') || urlTarget.startsWith('http') || urlResolved.startsWith('mailto:'))
+  assertUsage(urlTarget.startsWith('/') || urlTarget.startsWith('http') || urlResolved.startsWith('mailto:'))
   return urlResolved
 }
 

--- a/vike/shared/route/resolveRedirects.ts
+++ b/vike/shared/route/resolveRedirects.ts
@@ -24,7 +24,10 @@ function resolveRedirects(redirects: Record<string, string>, urlPathname: string
 function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPathname: string): null | string {
   assertRouteString(urlSource, `${configSrc} Invalid`)
   assertUsage(
-    urlTarget.startsWith('/') || isUriWithProtocol(urlTarget) || urlTarget === '*',
+    urlTarget.startsWith('/') ||
+      // Is allowing any protocol a safety issue? https://github.com/vikejs/vike/pull/1292#issuecomment-1828043917
+      isUriWithProtocol(urlTarget) ||
+      urlTarget === '*',
     `${configSrc} Invalid redirection target URL ${pc.cyan(urlTarget)}: the target URL should start with ${pc.cyan(
       '/'
     )}, a valid protocol (${pc.cyan('https:')}, ${pc.cyan('http:')}, ${pc.cyan('ipfs:')}, ${pc.cyan(

--- a/vike/shared/route/resolveRedirects.ts
+++ b/vike/shared/route/resolveRedirects.ts
@@ -43,7 +43,7 @@ function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPat
     urlResolved = urlResolved.replaceAll(key, val)
   })
   if (!urlResolved.startsWith('mailto:')) {
-    assert(!urlResolved.includes('@'), 'URL should not contain "@" unless it is a mailto link.')
+    assertUsage(!urlResolved.includes('@'), 'URL should not contain "@" unless it is a mailto link.')
   }
   if (urlResolved === urlPathname) return null
   assert(urlTarget.startsWith('/') || urlTarget.startsWith('http') || urlResolved.startsWith('mailto:'))

--- a/vike/shared/route/resolveRedirects.ts
+++ b/vike/shared/route/resolveRedirects.ts
@@ -46,7 +46,7 @@ function resolveRouteStringRedirect(urlSource: string, urlTarget: string, urlPat
     assert(!urlResolved.includes('@'), 'URL should not contain "@" unless it is a mailto link.')
   }
   if (urlResolved === urlPathname) return null
-  assertUsage(urlTarget.startsWith('/') || urlTarget.startsWith('http') || urlResolved.startsWith('mailto:'))
+  assert(urlTarget.startsWith('/') || urlTarget.startsWith('http') || urlResolved.startsWith('mailto:'))
   return urlResolved
 }
 

--- a/vike/utils/parseUrl-extras.ts
+++ b/vike/utils/parseUrl-extras.ts
@@ -5,6 +5,7 @@ export { removeBaseServer }
 export { modifyUrlPathname }
 export { removeUrlOrigin }
 export { addUrlOrigin }
+export { isUriWithProtocol }
 
 import { assertUrlComponents, createUrlFromComponents, isBaseServer, parseUrl } from './parseUrl.js'
 import { assert } from './assert.js'
@@ -108,4 +109,9 @@ function addUrlOrigin(url: string, origin: string | null): string {
   assert(origin === null || origin.startsWith('http'))
   const urlModified = createUrlFromComponents(origin, pathnameOriginal, searchOriginal, hashOriginal)
   return urlModified
+}
+
+function isUriWithProtocol(uri: string): boolean {
+  // Is it correct to assume that all protocols (http:, https:, ipfs:, magnet:, ...) match this RegExp?
+  return /^[a-zA-Z]+:/.test(uri)
 }


### PR DESCRIPTION
resolves #1245

This PR introduces the capability to utilize the mailto protocol within the redirect configuration. 
This allows for configured path to be redirected to email addresses, triggering the opening of the user's default email client. 

config example
```javascript
// vite.config.js

import vike from 'vike/plugin'

export default {
  plugins: [
    vike({
      redirects: {
        '/email': 'mailto:foo@bar.test'
      }
    })
  ]
}
```