### PR TITLE
Docs: fixed typo `stc`

### DIFF
--- a/docs/pages/preload.page.server.mdx
+++ b/docs/pages/preload.page.server.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 > **What is preloading?** Preloading denotes the practice of loading assets (JavaScript, CSS, images, etc.) before the browser discovers them in HTML/CSS/JavaScript code. That way we reduce the network round trips required before the browser starts discovering and loading all dependencies.
 
-By default, Vike automatically inject tags to our HTML, such as `<script type="module" stc="script.js">`, `<link rel="stylesheet" type="text/css" href="style.css">`, and `<link rel="preload" href="font.ttf" as="font" type="font/ttf">`. It does so using a preload strategy that works for most users, but we can use `injectFilter()` to implement a custom preload strategy.
+By default, Vike automatically inject tags to our HTML, such as `<script type="module" src="script.js">`, `<link rel="stylesheet" type="text/css" href="style.css">`, and `<link rel="preload" href="font.ttf" as="font" type="font/ttf">`. It does so using a preload strategy that works for most users, but we can use `injectFilter()` to implement a custom preload strategy.
 
 To improve preloading performance, we can use [Early Hints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103) which Vike automatically generates.
 


### PR DESCRIPTION
I collected typo `stc` to `src` at docs!