### PR TITLE
Add preload tags to `injectFilter`

### DIFF
--- a/docs/pages/preload.page.server.mdx
+++ b/docs/pages/preload.page.server.mdx
@@ -28,7 +28,7 @@ type PageContext = {
   httpResponse: {
     earlyHints: {
       earlyHintLink: string, // Header Line for the Early Hint Header
-      assetType: "image" | "script" | "font" | "style" | null
+      assetType: "image" | "script" | "font" | "style" | "audio" | "video" | "document" | "fetch" | "track" | "worker" | "embed" | "object" | null
       mediaType: string // MIME type
       src: string // Asset's URL
       isEntry: boolean // true  ⇒ asset is an entry

--- a/vike/node/runtime/renderPage/getPageAssets/sortPageAssetsForEarlyHintsHeader.ts
+++ b/vike/node/runtime/renderPage/getPageAssets/sortPageAssetsForEarlyHintsHeader.ts
@@ -24,6 +24,10 @@ function sortPageAssetsForEarlyHintsHeader(pageAssets: PageAsset[]) {
       priority--
       if (assetType === 'image') return priority
       priority--
+      if (assetType === 'video') return priority
+      priority--
+      if (assetType === 'audio') return priority
+      priority--
 
       // Others
       if (assetType !== 'script') return priority

--- a/vike/node/runtime/renderPage/inferMediaType.ts
+++ b/vike/node/runtime/renderPage/inferMediaType.ts
@@ -5,7 +5,19 @@ import { styleFileRE, isScriptFile } from '../utils.js'
 
 type MediaType = null | {
   // List of `as` values: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-as
-  assetType: 'image' | 'script' | 'font' | 'style'
+  assetType:
+    | 'image'
+    | 'script'
+    | 'font'
+    | 'style'
+    | 'audio'
+    | 'video'
+    | 'document'
+    | 'fetch'
+    | 'track'
+    | 'worker'
+    | 'embed'
+    | 'object'
   mediaType:
     | 'text/javascript'
     | 'text/css'
@@ -17,6 +29,18 @@ type MediaType = null | {
     | 'font/ttf'
     | 'font/woff'
     | 'font/woff2'
+    | 'video/mp4'
+    | 'video/webm'
+    | 'video/ogg'
+    | 'video/mpeg'
+    | 'video/x-msvideo'
+    | 'video/quicktime'
+    | 'audio/mpeg'
+    | 'audio/wav'
+    | 'audio/ogg'
+    | 'audio/aac'
+    | 'audio/midi'
+    | 'audio/flac'
 }
 
 function inferMediaType(href: string): MediaType {
@@ -54,6 +78,46 @@ function inferMediaType(href: string): MediaType {
   }
   if (href.endsWith('.woff2')) {
     return { assetType: 'font', mediaType: 'font/woff2' }
+  }
+
+  // Videos
+  if (href.endsWith('.mp4')) {
+    return { assetType: 'video', mediaType: 'video/mp4' }
+  }
+  if (href.endsWith('.webm')) {
+    return { assetType: 'video', mediaType: 'video/webm' }
+  }
+  if (href.endsWith('.ogv')) {
+    return { assetType: 'video', mediaType: 'video/ogg' }
+  }
+  if (href.endsWith('.mpeg') || href.endsWith('.mpg')) {
+    return { assetType: 'video', mediaType: 'video/mpeg' }
+  }
+  if (href.endsWith('.avi')) {
+    return { assetType: 'video', mediaType: 'video/x-msvideo' }
+  }
+  if (href.endsWith('.mov') || href.endsWith('.qt')) {
+    return { assetType: 'video', mediaType: 'video/quicktime' }
+  }
+
+  // Audios
+  if (href.endsWith('.mp3')) {
+    return { assetType: 'audio', mediaType: 'audio/mpeg' }
+  }
+  if (href.endsWith('.wav')) {
+    return { assetType: 'audio', mediaType: 'audio/wav' }
+  }
+  if (href.endsWith('.ogg')) {
+    return { assetType: 'audio', mediaType: 'audio/ogg' }
+  }
+  if (href.endsWith('.m4a')) {
+    return { assetType: 'audio', mediaType: 'audio/aac' }
+  }
+  if (href.endsWith('midi') || href.endsWith('.mid')) {
+    return { assetType: 'audio', mediaType: 'audio/midi' }
+  }
+  if (href.endsWith('.flac')) {
+    return { assetType: 'audio', mediaType: 'audio/flac' }
   }
 
   return null

--- a/vike/node/runtime/renderPage/loadPageFilesServerSide.ts
+++ b/vike/node/runtime/renderPage/loadPageFilesServerSide.ts
@@ -67,7 +67,7 @@ async function loadPageFilesServerSide(pageContext: { _pageId: string } & PageCo
         src: string
         assetType: 'script' | 'style' | 'preload'
         mediaType: null | NonNullable<MediaType>['mediaType']
-        preloadType: null | 'image' | 'script' | 'font' | 'style'
+        preloadType: null | NonNullable<MediaType>['assetType']
       }[] = []
 
       ;(await pageContextAddendum.__getPageAssets()).forEach((p) => {


### PR DESCRIPTION
Issue: https://github.com/vikejs/vike/issues/1299

I've added preload tags such as `video`, `audio` and more (all from [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-as)

If there are something wrong or missing, i'd be happy if you let me know...!!