### PR TITLE
examples: mark V0.4 examples as deprecated

### DIFF
--- a/examples/base-url-cdn/readme.md
+++ b/examples/base-url-cdn/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`base-url-cdn-v1`](../base-url-cdn-v1/) instead.
+
 Example of deploying static assets to a CDN.
 
 ```bash

--- a/examples/base-url-server/readme.md
+++ b/examples/base-url-server/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`base-url-server-v1`](../base-url-server-v1/) instead.
+
 Example of deploying static assets to a CDN + setting a Base URL for the server.
 
 ```bash

--- a/examples/base-url/readme.md
+++ b/examples/base-url/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`base-url-v1`](../base-url-v1/) instead.
+
 Example of changing the [Base URL](https://vike.dev/base-url).
 
 ```bash

--- a/examples/cloudflare-workers-react-full/readme.md
+++ b/examples/cloudflare-workers-react-full/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`cloudflare-workers-react-full-v1`](../cloudflare-workers-react-full-v1/) instead.
+
 [Cloudflare Workers](https://workers.cloudflare.com/) with:
  - Vite
  - Vike

--- a/examples/cloudflare-workers-react/readme.md
+++ b/examples/cloudflare-workers-react/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`cloudflare-workers-react-v1`](../cloudflare-workers-react-v1/) instead.
+
 [Cloudflare Workers](https://workers.cloudflare.com/) with:
  - Vite
  - Vike

--- a/examples/cloudflare-workers-vue/readme.md
+++ b/examples/cloudflare-workers-vue/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`cloudflare-workers-vue-v1`](../cloudflare-workers-vue-v1/) instead.
+
 [Cloudflare Workers](https://workers.cloudflare.com/) with:
  - Vite
  - Vike

--- a/examples/file-structure-domain-driven/readme.md
+++ b/examples/file-structure-domain-driven/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`file-structure-domain-driven-v1`](../file-structure-domain-driven-v1/) instead.
+
 Example of using Vike with [domain-driven file structure](https://vike.dev/file-structure#domain-driven).
 
 ```bash

--- a/examples/graphql-apollo-react/readme.md
+++ b/examples/graphql-apollo-react/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`graphql-apollo-react-v1`](../graphql-apollo-react-v1/) instead.
+
 Example of using Vike with Apollo GraphQL and React.
 
 ```bash

--- a/examples/graphql-apollo-vue/readme.md
+++ b/examples/graphql-apollo-vue/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`graphql-apollo-vue-v1`](../graphql-apollo-vue-v1/) instead.
+
 Example of using Vike with Vue and Apollo GraphQL.
 
 ```bash

--- a/examples/html-fragments/readme.md
+++ b/examples/html-fragments/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`html-fragments-v1`](../html-fragments-v1/) instead.
+
 Example of using [HTML fragments](https://vike.dev/escapeInject#html-fragments).
 
 ```bash

--- a/examples/i18n/readme.md
+++ b/examples/i18n/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`i18n-v1`](../i18n-v1/) instead.
+
 Example of internationalizing (i18n) a Vike app.
 
 See [Guides > Internationalization (i18n)](https://vike.dev/i18n).

--- a/examples/layouts-react/readme.md
+++ b/examples/layouts-react/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`layouts-react-v1`](../layouts-react-v1/) instead.
+
 Example of defining (nested) layouts.
 
 See [vike.dev/layouts](https://vike.dev/layouts).

--- a/examples/layouts-vue/readme.md
+++ b/examples/layouts-vue/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`layouts-vue-v1`](../layouts-vue-v1/) instead.
+
 Example of defining (nested) layouts.
 
 See [vike.dev/layouts](https://vike.dev/layouts).

--- a/examples/path-aliases/readme.md
+++ b/examples/path-aliases/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`path-aliases-v1`](../path-aliases-v1/) instead.
+
 Example of defining import path aliases for Vike apps.
 
 We use:

--- a/examples/react-full/readme.md
+++ b/examples/react-full/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`react-full-v1`](../react-full-v1/) instead.
+
 React example showcasing many features.
 
 For a simpler example, check out [/examples/react/](/examples/react/).

--- a/examples/react-streaming/readme.md
+++ b/examples/react-streaming/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`react-streaming-v1`](../react-streaming-v1/) instead.
+
 Example of using Vike with React and [react-streaming](https://github.com/brillout/react-streaming).
 
 ```bash

--- a/examples/react/readme.md
+++ b/examples/react/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`react-v1`](../react-v1/) instead.
+
 Example of using Vike with React.
 
 ```bash

--- a/examples/render-modes/readme.md
+++ b/examples/render-modes/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`render-modes-v1`](../render-modes-v1/) instead.
+
 Example of using all [Render Modes](https://vike.dev/render-modes).
 
 ```bash

--- a/examples/telefunc/readme.md
+++ b/examples/telefunc/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`telefunc-v1`](../telefunc-v1/) instead.
+
 Example of using Vike with [Telefunc](https://telefunc.com).
 
 To run it:

--- a/examples/vue-full/readme.md
+++ b/examples/vue-full/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`vue-full-v1`](../vue-full-v1/) instead.
+
 Example of using Vike with Vue that showcases many features.
 
 For a simpler example, check out [/examples/vue/](/examples/vue/).

--- a/examples/vue/readme.md
+++ b/examples/vue/readme.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> This example is deprecated. See [`vue-v1`](../vue-v1/) instead.
+
 Example of using Vike with Vue.
 
 ```bash


### PR DESCRIPTION
This is a common source of confusion for newcomers.