### PR TITLE
Fix `Could not load virtual:vike:pageConfigValuesAll`

### DIFF
--- a/vike/node/shared/extractAssetsQuery.ts
+++ b/vike/node/shared/extractAssetsQuery.ts
@@ -8,19 +8,21 @@ const query = 'extractAssets'
 
 function extractAssetsAddQuery(id: string): string {
   const fileExtension = getFileExtension(id)
-  assert(fileExtension || id.includes('virtual:vike:'))
-  if (!fileExtension) return `${id}?${query}`
-  if (id.includes('?')) {
-    id = id.replace('?', `?${query}&`)
+  if (!fileExtension || id.includes('virtual:vike:')) {
+    return `${id}?${query}`
   } else {
-    id = `${id}?${query}&lang.${fileExtension}`
+    if (!id.includes('?')) {
+      return `${id}?${query}&lang.${fileExtension}`
+    } else {
+      return id.replace('?', `?${query}&`)
+    }
   }
-  return id
 }
 
 function extractAssetsRemoveQuery(id: string): string {
+  if (!id.includes('?')) return id
+  const suffix = `?${query}`
   // Only supports 'virtual:vike:' IDs
-  return !id.includes('?')
-    ? id
-    : id.slice(0, id.indexOf('?'))
+  assert(id.endsWith(query))
+  return id.slice(0, -1 * suffix.length)
 }

--- a/vike/node/shared/extractAssetsQuery.ts
+++ b/vike/node/shared/extractAssetsQuery.ts
@@ -19,9 +19,8 @@ function extractAssetsAddQuery(id: string): string {
 }
 
 function extractAssetsRemoveQuery(id: string): string {
-  if (!id.includes('?')) return id
-  const suffix = `?${query}`
   // Only supports 'virtual:vike:' IDs
-  assert(id.endsWith(query))
-  return id.slice(0, -1 * suffix.length)
+  return !id.includes('?')
+    ? id
+    : id.slice(0, id.indexOf('?'))
 }


### PR DESCRIPTION
I'm not sure what `extractAssetsRemoveQuery()` functions should do exactly, but this fixes the problem reported in #1419 for me.

Fixes #1419 
