### PR TITLE
fix: sort styles in dev

### DIFF
--- a/vike/node/runtime/renderPage/getPageAssets/retrieveAssetsDev.ts
+++ b/vike/node/runtime/renderPage/getPageAssets/retrieveAssetsDev.ts
@@ -27,7 +27,7 @@ async function retrieveAssetsDev(clientDependencies: ClientDependency[], viteDev
       collectCss(mod, assetUrls, visitedModules)
     })
   )
-  return Array.from(assetUrls)
+  return sortStyleUrls(Array.from(assetUrls))
 }
 
 // Collect the CSS to be injected to the HTML to avoid FLOUC
@@ -69,6 +69,18 @@ function isStyle(mod: ModuleNode) {
     return true
   }
   return false
+}
+
+function sortStyleUrls(styleUrls: string[]) {
+  styleUrls.sort((a, b) => {
+    const aIsVirtual = a.startsWith('/@id/')
+    const bIsVirtual = b.startsWith('/@id/')
+    if (aIsVirtual && !bIsVirtual) return 1
+    if (bIsVirtual && !aIsVirtual) return -1
+    return 0
+  })
+
+  return styleUrls
 }
 
 /*


### PR DESCRIPTION
The issue:
Virtual style modules are loaded too early, causing them to be overridden by other global styles.
For example, when using `vite-plugin-compiled-react` to override component level styles of Mantine:

```
    <head>
        <link rel="stylesheet" type="text/css" href="/@id/__x00__virtual:vite-plugin-compiled-react:b440be9.css?direct">
        <link rel="stylesheet" type="text/css" href="/@id/__x00__virtual:vite-plugin-compiled-react:78d174f.css?direct">
        <link rel="stylesheet" type="text/css" href="/@id/__x00__virtual:vite-plugin-compiled-react:dbd3697.css?direct">
        <link rel="stylesheet" type="text/css" href="/@id/__x00__virtual:vite-plugin-compiled-react:42b6e80.css?direct">
        <link rel="stylesheet" type="text/css" href="/@id/__x00__virtual:vite-plugin-compiled-react:6aac012.css?direct">
        <link rel="stylesheet" type="text/css" href="/@id/__x00__virtual:vite-plugin-compiled-react:65fa5c2.css?direct">
        <link rel="stylesheet" type="text/css" href="/@fs/src/node_modules/.pnpm/@mantine+core@7.4.1_@mantine+hooks@7.4.1_@types+react@18.2.47_react-dom@18.2.0_react@18.2.0/node_modules/@mantine/core/styles.css?direct">
    </head>
```