### PR TITLE
Correct typo in file-env

### DIFF
--- a/docs/pages/file-env/+Page.mdx
+++ b/docs/pages/file-env/+Page.mdx
@@ -6,7 +6,7 @@ The file extensions `.server.js` and `.client.js` enable you to ensure in what e
 // /server/database/credentials.server.js
 
 // This should *never* be imported by client-side code. We use .server.js to guarentee that.
-export deault {
+export default {
   password: 'WLa!9HW?E10a'
 }
 ```


### PR DESCRIPTION
line says `export deault` it seems like that was intended to be `export default`