### PR TITLE
chore: Documentation update about routing

### DIFF
--- a/docs/pages/route-string/+Page.mdx
+++ b/docs/pages/route-string/+Page.mdx
@@ -17,6 +17,9 @@ export default '/film/@filmId'
 
 The value of `filmId` is available at `pageContext.routeParams.filmId`.
 
+> To get the `routeParams` context value on client side, follow <Link href='/passToClient'>this page</Link>
+
+
 You can define:
  - Multiple parameters, for example `/film/@category/@name`.
  - <Link href="#globs">Globs</Link>, for example `/product/*`.


### PR DESCRIPTION
Hi folks!

I'd like to submit an addition to the doc, an idea directly coming from a personal frustration. I was trying to find out why I wasn't getting the `routeParams` on client side and then, I realized that I actually need to use the `passToClient` option. 

I think it would save tons of time to colocate this piece of information with the routing doc.

What do y'all think?

Thanks for your time!