### PR TITLE
injectBreakLines Regex Speedup

### DIFF
--- a/vike/node/runtime/html/injectAssets/injectHtmlTags.ts
+++ b/vike/node/runtime/html/injectAssets/injectHtmlTags.ts
@@ -118,7 +118,7 @@ function injectBreakLines(htmlFragment: string, before: string, after: string) {
   const whitespace = `${paddingParent}${whitespaceExtra}`
   const padding = `\n${whitespace}`
 
-  htmlFragment = htmlFragment.split(/<(?=[^\/])/).join(`${padding}<`)
+  htmlFragment = htmlFragment.replace(/<[^\/]/g, (match) => `${padding}${match}`)
   if (isBlankLine) {
     assert(htmlFragment.startsWith(padding), { htmlFragment })
     htmlFragment = whitespaceExtra + htmlFragment.slice(padding.length)


### PR DESCRIPTION
Using node --inspect & chrome debugger, I found that [this regex line](https://github.com/vikejs/vike/blob/74f8fadfd169b22f931072db1e9d65e2b702bc35/vike/node/runtime/html/injectAssets/injectHtmlTags.ts#L121) was taking ~20ms which is significant overhead.

I don't know the context of this function and if this is a sign that I don't have Vike setup correctly (injecting too many things?), but either way this Regex can be faster if we remove the lookahead and use `replace` instead of creating and joining an array.

Testing shows this PR brings `injectBreakLines` down to 0.1ms for my use case.

