### PR TITLE
support Electron by adding 'file://' protocol

### DIFF
--- a/vike/utils/parseUrl.ts
+++ b/vike/utils/parseUrl.ts
@@ -16,7 +16,7 @@ import { slice } from './slice.js'
 import { assert, assertUsage } from './assert.js'
 import pc from '@brillout/picocolors'
 
-const PROTOCOLS = ['http://', 'https://', 'tauri://']
+const PROTOCOLS = ['http://', 'https://', 'tauri://', 'file://']
 
 function isParsable(url: string): boolean {
   // `parseUrl()` works with these URLs


### PR DESCRIPTION
I've tested it in Electron, and work fine with 'file://' protocol.