### PR TITLE
i18n doc: pass query params to 'urlLogical'

### DIFF
--- a/docs/pages/i18n/+Page.mdx
+++ b/docs/pages/i18n/+Page.mdx
@@ -8,22 +8,20 @@ You can internationalize (i18n) your app by using the <Link text={<><code>onBefo
 export { onBeforeRoute }
 
 function onBeforeRoute(pageContext) {
-  const { urlWithoutLocale, locale } = extractLocale(pageContext.urlPathname)
-
-  const searchOriginal = pageContext.urlParsed.searchOriginal ?? "";
+  const { urlWithoutLocale, locale } = extractLocale(pageContext.urlParsed)
   
   return {
     pageContext: {
       // Make `locale` available as `pageContext.locale`
       locale,
       // Vike's router will use pageContext.urlLogical instead of pageContext.urlOriginal
-      urlLogical: urlWithoutLocale + searchOriginal
+      urlLogical: urlWithoutLocale
     }
   }
 }
 
 // You can also use a library instead of implementing your own locale retrieval mechanism
-function extractLocale(url) {
+function extractLocale(urlParsed) {
   // Determine the locale, for example:
   //  extractLocale('/en-US/film/42').locale === 'en-US'
   //  extractLocale('/de-DE/film/42').locale === 'de-DE'
@@ -34,6 +32,11 @@ function extractLocale(url) {
   //  extractLocale('/de-DE/film/42').urlWithoutLocale === '/film/42'
   //  ...
   urlWithoutLocale = /* ... */
+
+  // If you want to keep the query params
+  if (urlParsed.searchOriginal !== null) {
+    urlWithoutLocale += urlParsed.searchOriginal
+  }
 
   return { locale, urlWithoutLocale }
 }

--- a/docs/pages/i18n/+Page.mdx
+++ b/docs/pages/i18n/+Page.mdx
@@ -2,14 +2,16 @@ import { RepoLink, Link } from '@brillout/docpress'
 
 You can internationalize (i18n) your app by using the <Link text={<><code>onBeforeRoute()</code> hook</>} href="/onBeforeRoute" />.
 
-```js
+```ts
 // /renderer/+onBeforeRoute.js
 
 export { onBeforeRoute }
 
+import type { Url } from 'vike/types'
+
 function onBeforeRoute(pageContext) {
   const { urlWithoutLocale, locale } = extractLocale(pageContext.urlParsed)
-  
+
   return {
     pageContext: {
       // Make `locale` available as `pageContext.locale`
@@ -20,23 +22,23 @@ function onBeforeRoute(pageContext) {
   }
 }
 
-// You can also use a library instead of implementing your own locale retrieval mechanism
-function extractLocale(urlParsed) {
+// Or use a library instead of implementing your own locale retrieval mechanism
+function extractLocale(url: Url) {
+  const { pathname } = url
+
   // Determine the locale, for example:
-  //  extractLocale('/en-US/film/42').locale === 'en-US'
-  //  extractLocale('/de-DE/film/42').locale === 'de-DE'
+  //  /en-US/film/42 => en-US
+  //  /de-DE/film/42 => de-DE
   const locale = /* ... */
 
   // Remove the locale, for example:
-  //  extractLocale('/en-US/film/42').urlWithoutLocale === '/film/42'
-  //  extractLocale('/de-DE/film/42').urlWithoutLocale === '/film/42'
-  //  ...
-  urlWithoutLocale = /* ... */
+  //  /en-US/film/42 => /film/42
+  //  /de-DE/film/42 => /film/42
+  const pathnameWithoutLocale = /* ... */
 
-  // If you want to keep the query params
-  if (urlParsed.searchOriginal !== null) {
-    urlWithoutLocale += urlParsed.searchOriginal
-  }
+  // Reconstruct full URL
+  const { origin, searchOriginal, hashOriginal } = url
+  const urlWithoutLocale = `${origin || ''}${pathnameWithoutLocale}${searchOriginal || ''}${hashOriginal || ''}`
 
   return { locale, urlWithoutLocale }
 }

--- a/docs/pages/i18n/+Page.mdx
+++ b/docs/pages/i18n/+Page.mdx
@@ -9,12 +9,15 @@ export { onBeforeRoute }
 
 function onBeforeRoute(pageContext) {
   const { urlWithoutLocale, locale } = extractLocale(pageContext.urlPathname)
+
+  const searchOriginal = pageContext.urlParsed.searchOriginal ?? "";
+  
   return {
     pageContext: {
       // Make `locale` available as `pageContext.locale`
       locale,
       // Vike's router will use pageContext.urlLogical instead of pageContext.urlOriginal
-      urlLogical: urlWithoutLocale
+      urlLogical: urlWithoutLocale + searchOriginal
     }
   }
 }

--- a/vike/shared/addUrlComputedProps.ts
+++ b/vike/shared/addUrlComputedProps.ts
@@ -10,7 +10,7 @@ export type { Url }
 
 import { assert, parseUrl, assertWarning, isPlainObject, isPropertyGetter, isBrowser } from './utils.js'
 
-// Copy paste from https://vike.dev/pageContext
+// JSDocs copied from https://vike.dev/pageContext
 type Url = {
   /** The URL origin, e.g. `https://example.com` of `https://example.com/product/42?details=yes#reviews` */
   origin: null | string
@@ -24,14 +24,16 @@ type Url = {
   searchAll: Record<string, string[]>
   /** The URL search parameterer string, e.g. `?details=yes` of `https://example.com/product/42?details=yes#reviews` */
   searchOriginal: null | string
-  /** @deprecated */
-  searchString: null | string
   /** The URL hash, e.g. `reviews` of `https://example.com/product/42?details=yes#reviews` */
   hash: string
   /** The URL hash string, e.g. `#reviews` of `https://example.com/product/42?details=yes#reviews` */
   hashOriginal: null | string
+
+  // TODO/v1-release: remove
   /** @deprecated */
   hashString: null | string
+  /** @deprecated */
+  searchString: null | string
 }
 
 type PageContextUrlComputedPropsClient = {


### PR DESCRIPTION
Pass the query parameters to 'urlLogical' in the i18n doc.
So the pages can access the parameters.