### PR TITLE
Fix PushState MonkeyPatch

### DIFF
--- a/vike/client/client-routing-runtime/history.ts
+++ b/vike/client/client-routing-runtime/history.ts
@@ -7,7 +7,10 @@ export {
   monkeyPatchHistoryPushState
 }
 
-import { assert, assertUsage, hasProp, isObject } from './utils.js'
+import { assert, assertUsage, getGlobalObject, hasProp, isObject } from './utils.js'
+const globalObject = getGlobalObject<{
+  pushStateOriginal?: PushStateOriginal
+}>('history.ts', {})
 
 // No way found to add TypeScript types to `history.state`: https://github.com/microsoft/TypeScript/issues/36178
 type HistoryState = {
@@ -16,12 +19,6 @@ type HistoryState = {
   triggeredBy?: 'user' | 'vike' | 'browser'
 }
 type ScrollPosition = { x: number; y: number }
-
-function isVikeHistoryState(state: unknown): state is HistoryState {
-  return (
-    !!state && typeof state === 'object' && 'timestamp' in state && 'scrollPosition' in state && 'triggeredBy' in state
-  )
-}
 
 // Fill missing state information:
 //  - `history.state` can uninitialized (i.e. `null`):
@@ -100,27 +97,27 @@ function replaceHistoryState(state: HistoryState, url?: string) {
   window.history.replaceState(state, '', url ?? /* Passing `undefined` chokes older Edge versions */ null)
 }
 function pushHistoryState(state: HistoryState, url: string) {
-  // Call history.pushState so that any other libraries that monkey patch pushState after Vike does will still run
-  window.history.pushState(state, '', url)
+  pushStateOriginal(state, '', url)
 }
 
 function monkeyPatchHistoryPushState() {
-  window.history.pushState = new Proxy(window.history.pushState, {
-    apply: (target, thisArg, [stateFromUser, unused, url]) => {
-      assertUsage(
-        null === stateFromUser || undefined === stateFromUser || isObject(stateFromUser),
-        'history.pushState(state) argument state must be an object'
-      )
-      const state: HistoryState = isVikeHistoryState(stateFromUser)
-        ? stateFromUser
-        : {
-            scrollPosition: getScrollPosition(),
-            timestamp: getTimestamp(),
-            ...stateFromUser,
-            // Don't allow user to overwrite triggeredBy as it would break Vike's handling of the 'popstate' event
-            triggeredBy: 'user'
-          }
-      target.apply(thisArg, [state, unused, url])
+  globalObject.pushStateOriginal = globalObject.pushStateOriginal ?? window.history.pushState
+  window.history.pushState = (stateFromUser: unknown = {}, ...rest) => {
+    assertUsage(
+      null === stateFromUser || undefined === stateFromUser || isObject(stateFromUser),
+      'history.pushState(state) argument state must be an object'
+    )
+    const state: HistoryState = {
+      scrollPosition: getScrollPosition(),
+      timestamp: getTimestamp(),
+      ...stateFromUser,
+      // Don't allow user to overwrite triggeredBy as it would break Vike's handling of the 'popstate' event
+      triggeredBy: 'user'
     }
-  })
+    return pushStateOriginal!(state, ...rest)
+  }
+}
+type PushStateOriginal = typeof history.pushState
+function pushStateOriginal(...args: Parameters<PushStateOriginal>): ReturnType<PushStateOriginal> {
+  globalObject.pushStateOriginal!.apply(history, args)
 }

--- a/vike/client/client-routing-runtime/history.ts
+++ b/vike/client/client-routing-runtime/history.ts
@@ -101,7 +101,7 @@ function pushHistoryState(state: HistoryState, url: string) {
 }
 
 function monkeyPatchHistoryPushState() {
-  const pushStateOriginal = window.history.pushState
+  const pushStateOriginal = window.history.pushState.bind(window.history)
   window.history.pushState = (stateOriginal: unknown = {}, ...rest) => {
     assertUsage(
       stateOriginal === undefined || stateOriginal === null || isObject(stateOriginal),


### PR DESCRIPTION
## Problem

When Vike monkey patches `history.pushState`, it saves the "original" pushState to call during Vike's routing. However, 3rd party libraries also monkey patch `pushState` in order to be informed when the page changes (in my case, [Amplitude](https://github.com/amplitude/Amplitude-TypeScript)). These libraries will not be informed when Vike navigates.

## Solution

This PR changes Vike's navigation to go through `history.pushState` so that any monkey patches that happen _after_ Vike's will still run. It detects whether Vike's own navigation is happening to no-op the monkey patch.