### PR TITLE
feat: add cookie to pageContext for dev mode

### DIFF
--- a/vike/node/plugin/shared/addSsrMiddleware.ts
+++ b/vike/node/plugin/shared/addSsrMiddleware.ts
@@ -13,7 +13,8 @@ function addSsrMiddleware(middlewares: ConnectServer) {
     const userAgent = headers['user-agent']
     const pageContextInit = {
       urlOriginal: url,
-      userAgent
+      userAgent,
+      headers
     }
     let pageContext: Awaited<ReturnType<typeof renderPage>>
     try {

--- a/vike/node/plugin/shared/addSsrMiddleware.ts
+++ b/vike/node/plugin/shared/addSsrMiddleware.ts
@@ -2,6 +2,7 @@ export { addSsrMiddleware }
 
 import { renderPage } from '../../runtime/renderPage.js'
 import type { ViteDevServer } from 'vite'
+import { assertWarning } from '../utils.js'
 type ConnectServer = ViteDevServer['middlewares']
 
 function addSsrMiddleware(middlewares: ConnectServer) {
@@ -10,10 +11,15 @@ function addSsrMiddleware(middlewares: ConnectServer) {
     const url = req.originalUrl || req.url
     if (!url) return next()
     const { headers } = req
-    const userAgent = headers['user-agent']
     const pageContextInit = {
       urlOriginal: url,
-      userAgent,
+      get userAgent() {
+        assertWarning(false, "pageContext.userAgent is deprecated in favor of pageContext.headers['user-agent']", {
+          showStackTrace: true,
+          onlyOnce: true
+        })
+        return headers['user-agent']
+      },
       headers
     }
     let pageContext: Awaited<ReturnType<typeof renderPage>>

--- a/vike/node/runtime/renderPage.ts
+++ b/vike/node/runtime/renderPage.ts
@@ -416,12 +416,13 @@ async function getPageContextErrorPageInit(
   const pageContextInitEnhanced = getPageContextInitEnhancedSSR(pageContextInit, renderContext, null, httpRequestId)
 
   assert(errNominalPage)
-  const pageContext = {
-    ...pageContextInitEnhanced,
+  const pageContext = {}
+  objectAssign(pageContext, pageContextInitEnhanced)
+  objectAssign(pageContext, {
     is404: false,
     errorWhileRendering: errNominalPage as Error,
     routeParams: {} as Record<string, string>
-  }
+  })
 
   objectAssign(pageContext, {
     _debugRouteMatches:
@@ -498,7 +499,9 @@ function normalizeUrl(pageContextInit: { urlOriginal: string }, httpRequestId: n
     { url: urlNormalized, statusCode: 301 },
     pageContextInit.urlOriginal
   )
-  const pageContextHttpResponse = { ...pageContextInit, httpResponse }
+  const pageContextHttpResponse = {}
+  objectAssign(pageContextHttpResponse, pageContextInit)
+  objectAssign(pageContextHttpResponse, { httpResponse })
   return pageContextHttpResponse
 }
 
@@ -534,7 +537,9 @@ function getPermanentRedirect(pageContextInit: { urlOriginal: string }, httpRequ
     'info'
   )
   const httpResponse = createHttpResponseObjectRedirect({ url: urlTarget, statusCode: 301 }, urlWithoutBase)
-  const pageContextHttpResponse = { ...pageContextInit, httpResponse }
+  const pageContextHttpResponse = {}
+  objectAssign(pageContextHttpResponse, pageContextInit)
+  objectAssign(pageContextHttpResponse, { httpResponse })
   return pageContextHttpResponse
 }
 
@@ -572,11 +577,11 @@ async function handleAbortError(
         )} but you didn't define an error page, make sure to define one https://vike.dev/error-page`
       )
       const pageContext = {
-        _pageId: errorPageId,
-        ...pageContextAbort,
-        ...pageContextErrorPageInit,
-        ...renderContext
+        _pageId: errorPageId
       }
+      objectAssign(pageContext, pageContextAbort)
+      objectAssign(pageContext, pageContextErrorPageInit)
+      objectAssign(pageContext, renderContext)
       objectAssign(pageContext, await loadUserFilesServerSide(pageContext))
       // We include pageContextInit: we don't only serialize pageContextAbort because the error page may need to access pageContextInit
       pageContextSerialized = serializePageContextClientSide(pageContext)
@@ -597,10 +602,9 @@ async function handleAbortError(
     return { pageContextReturn }
   }
   if (pageContextAbort._urlRedirect) {
-    const pageContextReturn = {
-      ...pageContextInit,
-      ...pageContextAbort
-    }
+    const pageContextReturn = {}
+    objectAssign(pageContextReturn, pageContextInit)
+    objectAssign(pageContextReturn, pageContextAbort)
     const httpResponse = createHttpResponseObjectRedirect(
       pageContextAbort._urlRedirect,
       (() => {

--- a/vike/node/runtime/renderPage/renderPageAlreadyRouted.ts
+++ b/vike/node/runtime/renderPage/renderPageAlreadyRouted.ts
@@ -160,9 +160,9 @@ async function prerender404Page(renderContext: RenderContext, pageContextInit_: 
   }
 
   const pageContextInit = {
-    urlOriginal: '/fake-404-url', // A URL is needed for `applyViteHtmlTransform`
-    ...pageContextInit_
+    urlOriginal: '/fake-404-url' // A URL is needed for `applyViteHtmlTransform`
   }
+  objectAssign(pageContextInit, pageContextInit_)
   {
     const pageContextInitEnhanced = getPageContextInitEnhanced(pageContextInit, renderContext)
     objectAssign(pageContext, pageContextInitEnhanced)
@@ -196,8 +196,9 @@ function getPageContextInitEnhanced(
   assert(pageContextInit.urlOriginal)
 
   const globalContext = getGlobalContext()
-  const pageContextInitEnhanced = {
-    ...pageContextInit,
+  const pageContextInitEnhanced = {}
+  objectAssign(pageContextInitEnhanced, pageContextInit)
+  objectAssign(pageContextInitEnhanced, {
     _objectCreatedByVike: true,
     // The following is defined on `pageContext` because we can eventually make these non-global (e.g. sot that two pages can have different includeAssetsImportedByServer settings)
     _baseServer: globalContext.baseServer,
@@ -214,7 +215,7 @@ function getPageContextInitEnhanced(
     _urlRewrite: urlRewrite,
     _urlHandler: urlHandler,
     isClientSideNavigation
-  }
+  })
   addUrlComputedProps(pageContextInitEnhanced, !urlComputedPropsNonEnumerable)
 
   return pageContextInitEnhanced

--- a/vike/shared/sortPageContext.ts
+++ b/vike/shared/sortPageContext.ts
@@ -5,13 +5,8 @@ export { sortPageContext }
 // Sort `pageContext` keys alphabetically, in order to make reading `console.log(pageContext)` easier
 
 function sortPageContext(pageContext: Record<string, unknown>): void {
-  const entries = Object.entries(pageContext)
-  for (const key in pageContext) {
-    delete pageContext[key]
-  }
-  entries
-    .sort(([key1], [key2]) => compareString(key1, key2))
-    .forEach(([key, val]) => {
-      pageContext[key] = val
-    })
+  let descriptors = Object.getOwnPropertyDescriptors(pageContext)
+  for (const key of Object.keys(pageContext)) delete pageContext[key]
+  descriptors = Object.fromEntries(Object.entries(descriptors).sort(([key1], [key2]) => compareString(key1, key2)))
+  Object.defineProperties(pageContext, descriptors)
 }


### PR DESCRIPTION
In many cases we need to access cookie in SSR codes. You described correctly how we can pass it to `pageContext` in `server/index.ts` file. 
But it is just effective for production mode. I realized in dev mode, passing header items using Vike Vite plugin was applied for 'user-agent' only, but not for cookie.
I passed `cookie` to `pageContext` like `user-agent` in Vike plugin.

