### PR TITLE
docs: add /vike-react

### DIFF
--- a/docs/headingsDetached.tsx
+++ b/docs/headingsDetached.tsx
@@ -348,7 +348,7 @@ const headingsDetached = [
     url: '/vike-packages'
   },
   {
-    title: 'Vike Extensions',
+    title: 'Vike extensions',
     url: '/extensions'
   },
   {
@@ -454,5 +454,9 @@ const headingsDetached = [
   {
     title: 'HTTP Headers',
     url: '/headers'
+  },
+  {
+    title: '`vike-react`',
+    url: '/vike-react'
   }
 ] satisfies HeadingDetachedDefinition[]

--- a/docs/pages/meta/+Page.mdx
+++ b/docs/pages/meta/+Page.mdx
@@ -2,8 +2,8 @@ import { UiFrameworkVikeExtension, UiFrameworkVikeExtensionNames } from '../../c
 import { Link, RepoLink } from '@brillout/docpress'
 
 > Using `meta` is an advanced and powerful technique which we recommend using only for advanced use cases. Consider using the following instead:
-> - <Link href="/extensions" noBreadcrumb={true} />
-> - <Link href="/file-env" noBreadcrumb={true} />
+> - <Link href="/extensions" noBreadcrumb={true} /> (which use `meta` under the hood).
+> - The file extensions <Link href="/file-env" noBreadcrumb={true} />.
 
 The `meta` settings enables you to create:
  - **New settings**.

--- a/docs/pages/react/+Page.mdx
+++ b/docs/pages/react/+Page.mdx
@@ -3,7 +3,7 @@ import { Example, UseBatiHint } from '../../components'
 
 ## `vike-react`
 
-We recommend using <Link href="/extensions">`vike-react`</Link> which integrates React in a full-fledged manner.
+We recommend using <Link href="/vike-react">`vike-react`</Link> which integrates React in a full-fledged manner.
 
 > <p><UseBatiHint feature={<code>vike-react</code>} /></p>
 
@@ -57,5 +57,7 @@ Community examples:
 
 ## See also
 
+- <Link href="/vike-react" />
+ - <Link href="/nextjs" />
  - <Link href="/vue" />
  - <Link href="/solid" />

--- a/docs/pages/streaming/+Page.mdx
+++ b/docs/pages/streaming/+Page.mdx
@@ -4,12 +4,12 @@ import { UseUiFrameworkVikeExtensionAnyHint, UiFrameworkVikeExtensionNames } fro
 
 Vike not only has first-class support for HTML streaming (aka SSR streaming), but also provides you with extensive control over the HTML stream.
 
-If you only want to enable/disable HTML streaming, see <Link href="/stream" /> instead.
-
-> **What is HTML Streaming?** If you're unfamiliar with HTML Streaming then check out [Dan Abramov's explanation of SSR, HTML Streaming, and Progressive Rendering](https://github.com/reactwg/react-18/discussions/37). (While it explains it in the context of React, we still recommend reading it if you use a UI framework other than React.)
+If you merely want to enable/disable HTML streaming, see the <Link href="/stream" /> setting instead.
 
 <UseUiFrameworkVikeExtensionAnyHint featureName="HTML streaming" />
-<Warning>The documentation on this page is meant for expert users who want to manually integrate HTML Streaming. If you use <UiFrameworkVikeExtensionNames /> then HTML Streaming is already completely integrated which means you can usually skip reading this page.</Warning>
+<Warning>The documentation on this page is meant for expert users who want to manually integrate HTML Streaming. If you use <UiFrameworkVikeExtensionNames /> then HTML Streaming is already built-in and you can skip reading this page.</Warning>
+
+> **What is HTML Streaming?** If you're unfamiliar with HTML Streaming then check out [Dan Abramov's explanation of SSR, HTML Streaming, and Progressive Rendering](https://github.com/reactwg/react-18/discussions/37). (While it explains it in the context of React, we still recommend reading it if you use a UI framework other than React.)
 
 ## Examples
 

--- a/docs/pages/vike-react/+Page.mdx
+++ b/docs/pages/vike-react/+Page.mdx
@@ -1,0 +1,67 @@
+import { Link } from '@brillout/docpress'
+import { UseBatiHint } from '../../components'
+
+`vike-react` is a <Link href="/extensions">Vike extension</Link> that integrates [React](https://react.dev) in a full-fledged manner, providing a DX similar to other React frameworks.
+
+> <p><UseBatiHint feature={<code>vike-react</code>} /></p>
+
+See also:
+- [GitHub > `vikejs/vike-react`](https://github.com/vikejs/vike-react)
+- [GitHub > `vikejs/vike-react` > `CHANGELOG.md`](https://github.com/vikejs/vike-react/blob/main/packages/vike-react/CHANGELOG.md)
+- <Link href="/react" />
+
+## Add to existing app
+
+To add `vike-react` to an existing Vike app: install the `vike-react` npm package (e.g. `$ npm install vike-react`) then extend your existing `+config.js` file (or create one) with `vike-react`:
+
+```js
+// /pages/+config.js
+
+import vikeReact from 'vike-react/config' // [!code ++]
+
+export default {
+  // ...
+  extends: [vikeReact] // [!code ++]
+}
+```
+
+You can then use <Link href="#under-the-hood">new settings introduced by `vike-react`</Link>:
+
+```js
+// /pages/+config.js
+
+import vikeReact from 'vike-react/config'
+
+export default {
+  // ...
+
+  // Setting to toggle SSR // [!code ++]
+  ssr: false, // [!code ++]
+
+  extends: [vikeReact]
+}
+```
+
+
+## Under the hood
+
+`vike-react` is only `494` lines of code ([as of April 2024](https://gist.github.com/brillout/6267ecb8c996fb4a401985106cc81936)).
+
+Browsing the source code of `vike-react` is therefore very much an option for deepening your understanding of Vike or for debugging.
+
+Basically `vike-react` does this:
+- Sets <Link href="/hooks">Vike hooks</Link> and <Link href="/settings">Vike settings</Link> on your behalf. (Most notably <Link href="/onRenderHtml">`onRenderHtml()`</Link> and <Link href="/onRenderClient">`onRenderClient()`</Link>, see their implementation at
+  [`/src/renderer/onRenderHtml.tsx`](https://github.com/vikejs/vike-react/blob/main/packages/vike-react/src/renderer/onRenderHtml.tsx)
+  and
+  [`/src/renderer/onRenderClient.tsx`](https://github.com/vikejs/vike-react/blob/main/packages/vike-react/src/renderer/onRenderClient.tsx).)
+- Introduces new <Link href="/meta">custom hooks</Link> (e.g. `onBeforeRenderClient()`) and <Link href="/meta">custom settings</Link> (e.g. <Link href="/Wrapper">`<Wrapper>`</Link> and <Link href="/stream">`stream`</Link>).
+- Introduces new component hooks (e.g. <Link href="/useData">`useData()`</Link> and <Link href="/usePageContext">`usePageContext()`</Link>).
+- Uses [`react-streaming`](https://github.com/brillout/react-streaming) for <Link href="/streaming">HTML Streaming</Link>.
+
+## See also
+
+- [GitHub > `vikejs/vike-react`](https://github.com/vikejs/vike-react)
+- [GitHub > `vikejs/vike-react` > `CHANGELOG.md`](https://github.com/vikejs/vike-react/blob/main/packages/vike-react/CHANGELOG.md)
+- <Link href="/react" />
+- <Link href="/nextjs" />
+- [Bati](https://batijs.dev)


### PR DESCRIPTION
FYI @4350pChris @magne4000 I moved the `README.md` content of `vike-react` to `vike.dev`. You can do the same but I think it's also fine if you keep things as they are.