### PR TITLE
run transformIndexHtml in prerender

### DIFF
--- a/examples/react-full/vite.config.ts
+++ b/examples/react-full/vite.config.ts
@@ -9,6 +9,12 @@ export default {
       prerender: true
     }),
     mdx(),
-    react()
+    react(),
+    {
+      name: 'html-minify',
+      transformIndexHtml(html) {
+        return html.replaceAll('\n', '')
+      }
+    }
   ]
 } as UserConfig


### PR DESCRIPTION
I'm not sure we should do it like this, what do you think?
Maybe it's not ok to call plugin.transformIndexHtml outside of vite.. But if the vite build and prerender runs in the same process, maybe we can bind the function to the vite instance.