### PR TITLE
chore: Re-add clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,11 @@
     "format:prettier": "git ls-files | egrep '\\.(json|js|jsx|css|ts|tsx|vue|mjs|cjs)$' | grep --invert-match package.json | xargs pnpm exec prettier --write",
     "format:biome": "biome format --write .",
     "format:check": "biome format . || (echo 'Fix formatting by running `$ pnpm run -w format`.' && exit 1)",
+    "========= Clean": "",
+    "// Remove all generated files": "",
+    "clean": "git clean -Xdf",
     "========= Reset": "",
-    "reset": "git clean -Xdf && pnpm install && pnpm run build",
+    "reset": "pnpm run clean && pnpm install && pnpm run build",
     "========= Only allow pnpm; forbid yarn & npm": "",
     "preinstall": "npx only-allow pnpm"
   },


### PR DESCRIPTION
@brillout 

I just found out that the `pnpm dev:setup` script is still using the `pnpm run clean` command, but there is no such script or command available.
Here, I've put that script back. 

Feel free to merge or modify this PR as you see fit.