### PR TITLE
docs: minor fix

### DIFF
--- a/docs/pages/onBeforeRender/+Page.mdx
+++ b/docs/pages/onBeforeRender/+Page.mdx
@@ -219,7 +219,7 @@ export { onBeforeRender }
 
 import type { OnBeforeRenderAsync } from 'vike/types'
 
-const onBeforeRender: OnBeforeRenderAsync = async (
+export const onBeforeRender: OnBeforeRenderAsync = async (
   pageContext
 ): ReturnType<OnBeforeRenderAsync> => {
   // ...


### PR DESCRIPTION
There's no `export` in the TypeScript example code.