### PR TITLE
fix: PUBLIC variables now work on windows

### DIFF
--- a/vike/node/plugin/plugins/envVars.ts
+++ b/vike/node/plugin/plugins/envVars.ts
@@ -22,11 +22,10 @@ const PUBLIC_ENV_WHITELIST = [
 
 function isEnvNameInWhiteList(envName: string): boolean {
   // OS Windows reserved PUBLIC env variable
-  
-  if(process.platform === 'win32' && envName === 'PUBLIC') {
-    return true;
+  if (process.platform === 'win32' && envName === 'PUBLIC') {
+    return true
   }
-  return PUBLIC_ENV_WHITELIST.includes(envName);
+  return PUBLIC_ENV_WHITELIST.includes(envName)
 }
 
 function envVarsPlugin(): Plugin {

--- a/vike/node/plugin/plugins/envVars.ts
+++ b/vike/node/plugin/plugins/envVars.ts
@@ -20,6 +20,15 @@ const PUBLIC_ENV_WHITELIST = [
   'STORYBOOK'
 ]
 
+function isEnvNameInWhiteList(envName: string): boolean {
+  // OS Windows reserved PUBLIC env variable
+  
+  if(process.platform === 'win32' && envName === 'PUBLIC') {
+    return true;
+  }
+  return PUBLIC_ENV_WHITELIST.includes(envName);
+}
+
 function envVarsPlugin(): Plugin {
   let envsAll: Record<string, string>
   let config: ResolvedConfig
@@ -53,7 +62,7 @@ function envVarsPlugin(): Plugin {
           // Security check
           {
             const envStatement = getEnvStatement(envName)
-            const isPrivate = !envName.startsWith(PUBLIC_ENV_PREFIX) && !PUBLIC_ENV_WHITELIST.includes(envName)
+            const isPrivate = !envName.startsWith(PUBLIC_ENV_PREFIX) && !isEnvNameInWhiteList(envName)
             if (isPrivate && isClientSide) {
               if (!code.includes(envStatement)) return
               const modulePath = getModuleFilePath(id, config)


### PR DESCRIPTION
In Windows OS, the word `PUBLIC` is reserved in environment variables.
If I use `PUBLIC_ENV__xx` variables (e.g. in +client.ts), the project build will terminate with an error like this:

```bash
error during build:
[vike:envVars] [vike][Wrong Usage] import.meta.env.PUBLIC is used in client-side file /src/routes/+client.ts which means that the environment variable PUBLIC will be included in client-side bundles and, therefore, PUBLIC will be publicly exposed which can be a security leak. Use import.meta.env.PUBLIC only in server-side files, or rename PUBLIC to PUBLIC_ENV__PUBLIC, see https://vike.dev/env
```

This minor fix eliminates this error.
I did a check for windows only and only exact match with the word `PUBLIC`.
