### PR TITLE
Mediatype: add avif to mediatype inference

### DIFF
--- a/vike/node/runtime/renderPage/inferMediaType.ts
+++ b/vike/node/runtime/renderPage/inferMediaType.ts
@@ -21,6 +21,7 @@ type MediaType = null | {
   mediaType:
     | 'text/javascript'
     | 'text/css'
+    | 'image/avif'
     | 'image/jpeg'
     | 'image/png'
     | 'image/webp'
@@ -67,6 +68,9 @@ function inferMediaType(href: string): MediaType {
   }
   if (href.endsWith('.svg')) {
     return { assetType: 'image', mediaType: 'image/svg+xml' }
+  }
+  if (href.endsWith('.avif')) {
+    return { assetType: 'image', mediaType: 'image/avif' }
   }
 
   // Fonts


### PR DESCRIPTION
Adds `.avif` files to mediatype inference, as it was not previously contemplated by the logic.