### PR TITLE
fix: rename STREAM to HTML_STREAM

### DIFF
--- a/vike/node/runtime/html/injectAssets.ts
+++ b/vike/node/runtime/html/injectAssets.ts
@@ -45,7 +45,7 @@ async function injectHtmlTagsToString(
   let htmlString = htmlPartsToString(htmlParts, pageAssets)
   htmlString = injectToHtmlBegin(htmlString, htmlTags)
   htmlString = injectToHtmlEnd(htmlString, htmlTags)
-  assert(htmlTags.filter((snippet) => snippet.position === 'STREAM').length === 0)
+  assert(htmlTags.filter((snippet) => snippet.position === 'HTML_STREAM').length === 0)
   return htmlString
 }
 
@@ -81,7 +81,7 @@ function injectHtmlTagsToStream(
     // React has its own stream injection mechanism, see injectHtmlTagsUsingStream()
     if (streamFromReactStreamingPackage) return null
     assert(htmlTags)
-    const tags = htmlTags.filter((h) => h.position === 'STREAM')
+    const tags = htmlTags.filter((h) => h.position === 'HTML_STREAM')
     if (tags.length === 0) return null
     const htmlFragment = joinHtmlTags(tags)
     return htmlFragment

--- a/vike/node/runtime/html/injectAssets/getHtmlTags.ts
+++ b/vike/node/runtime/html/injectAssets/getHtmlTags.ts
@@ -38,7 +38,7 @@ type InjectFilterEntry = {
   inject: PreloadFilterInject
 }
 
-type Position = 'HTML_BEGIN' | 'HTML_END' | 'STREAM'
+type Position = 'HTML_BEGIN' | 'HTML_END' | 'HTML_STREAM'
 type HtmlTag = {
   htmlTag: string | (() => string)
   position: Position
@@ -61,7 +61,7 @@ function getHtmlTags(
       if (asset.isEntry && asset.assetType === 'script') {
         // We could allow the user to change the position of <script> but we currently don't:
         //  - Because of mergeScriptEntries()
-        //  - We would need to add STREAM to to PreloadFilterInject
+        //  - We would need to add HTML_STREAM to to PreloadFilterInject
         // To suppor this, we should add the JavaScript entry to injectFilterEntries (with an `src` value of `null`)
         return false
       }
@@ -145,7 +145,7 @@ function getHtmlTags(
           { onlyOnce: true }
         )
       }
-      if (injectScriptsAt === 'STREAM' && !isStream) {
+      if (injectScriptsAt === 'HTML_STREAM' && !isStream) {
         return positionJavaScriptDefault
       }
       return injectScriptsAt
@@ -158,7 +158,7 @@ function getHtmlTags(
     }
     if (streamFromReactStreamingPackage && !streamFromReactStreamingPackage.hasStreamEnded()) {
       // If there is a stream then, in order to support progressive hydration, inject the JavaScript during the stream after React(/Vue/Solid/...) resolved the first suspense boundary.
-      return 'STREAM'
+      return 'HTML_STREAM'
     }
     return positionJavaScriptDefault
   })()
@@ -197,7 +197,7 @@ function getHtmlTags(
       assert(!asset.isEntry) // Users cannot re-order JavaScript entries, see creation of injectFilterEntries
       const htmlTag = inferPreloadTag(asset)
       if (!asset.inject) return
-      // Ideally, instead of this conditional ternary operator, we should add STREAM to PreloadFilterInject (or a better fitting name such as HTML_STREAM)
+      // Ideally, instead of this conditional ternary operator, we should add HTML_STREAM to PreloadFilterInject
       const position = asset.inject === 'HTML_END' ? positionJavaScriptEntry : asset.inject
       htmlTags.push({ htmlTag, position })
     })
@@ -287,7 +287,7 @@ function getInjectScriptsAt(pageId: string, pageConfigs: PageConfigRuntime[]): n
     injectScriptsAt === null ||
       injectScriptsAt === 'HTML_BEGIN' ||
       injectScriptsAt === 'HTML_END' ||
-      injectScriptsAt === 'STREAM',
+      injectScriptsAt === 'HTML_STREAM',
     `${configDefinedAt} has an invalid value`
   )
   return injectScriptsAt

--- a/vike/node/runtime/html/injectAssets/injectHtmlTags.ts
+++ b/vike/node/runtime/html/injectAssets/injectHtmlTags.ts
@@ -27,7 +27,7 @@ function injectHtmlTagsUsingStream(
   htmlTags: HtmlTag[],
   streamFromReactStreamingPackage: StreamFromReactStreamingPackage
 ): void {
-  const htmlFragment = joinHtmlTags(htmlTags.filter((h) => h.position === 'STREAM'))
+  const htmlFragment = joinHtmlTags(htmlTags.filter((h) => h.position === 'HTML_STREAM'))
   if (htmlFragment) {
     assert(!streamFromReactStreamingPackage.hasStreamEnded())
     streamFromReactStreamingPackage.injectToStream(htmlFragment, { flush: true })

--- a/vike/shared/page-configs/Config.ts
+++ b/vike/shared/page-configs/Config.ts
@@ -423,7 +423,7 @@ type ConfigBuiltIn = {
    *
    * https://vike.dev/injectScriptsAt
    */
-  injectScriptsAt?: 'HTML_BEGIN' | 'HTML_END' | 'STREAM' | null
+  injectScriptsAt?: 'HTML_BEGIN' | 'HTML_END' | 'HTML_STREAM' | null
 
   /** Used by Vike extensions to set their name.
    *


### PR DESCRIPTION
@phonzammi I made it a hard breaking change, as I guess `vike-solid` is the only user using `injectScriptsAt: 'STREAM'`. Make to sure to update the `+require` value of `vike-solid` to the Vike version I'm about to release.