### PR TITLE
chore: replace fast-glob with tinyglobby

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1713,6 +1713,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.7
+      tinyglobby:
+        specifier: ^0.2.6
+        version: 0.2.6
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -4594,6 +4597,14 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fdir@6.3.0:
+    resolution: {integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -5958,6 +5969,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pinia@2.1.7:
     resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
     peerDependencies:
@@ -6625,6 +6640,10 @@ packages:
 
   tinybench@2.8.0:
     resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
+
+  tinyglobby@0.2.6:
+    resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.0.1:
     resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
@@ -10522,6 +10541,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fdir@6.3.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -12373,6 +12396,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pinia@2.1.7(typescript@5.6.2)(vue@3.4.27(typescript@5.6.2)):
     dependencies:
       '@vue/devtools-api': 6.6.2
@@ -13152,6 +13177,11 @@ snapshots:
   through@2.3.8: {}
 
   tinybench@2.8.0: {}
+
+  tinyglobby@0.2.6:
+    dependencies:
+      fdir: 6.3.0(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinypool@1.0.1: {}
 

--- a/vike/node/plugin/plugins/importUserCode/v1-design/getVikeConfig/crawlPlusFiles.ts
+++ b/vike/node/plugin/plugins/importUserCode/v1-design/getVikeConfig/crawlPlusFiles.ts
@@ -14,7 +14,7 @@ import {
 import path from 'path'
 import fs from 'fs/promises'
 import type { Stats } from 'fs'
-import glob from 'fast-glob'
+import { glob } from 'tinyglobby'
 import { exec } from 'child_process'
 import { promisify } from 'util'
 import pc from '@brillout/picocolors'
@@ -196,7 +196,7 @@ async function gitLsFiles(
 }
 // Same as gitLsFiles() but using fast-glob
 async function fastGlob(userRootDir: string, outDirRelativeFromUserRootDir: string | null): Promise<string[]> {
-  const files = await glob(`**/+*.${scriptFileExtensions}`, {
+  const files = await glob([`**/+*.${scriptFileExtensions}`], {
     ignore: getIgnoreAsPatterns(outDirRelativeFromUserRootDir),
     cwd: userRootDir,
     dot: false

--- a/vike/node/plugin/shared/findPageFiles.ts
+++ b/vike/node/plugin/shared/findPageFiles.ts
@@ -1,6 +1,6 @@
 export { findPageFiles }
 
-import glob from 'fast-glob'
+import { glob } from 'tinyglobby'
 import type { ResolvedConfig } from 'vite'
 import { assertWarning, toPosixPath, scriptFileExtensions, getOutDirs } from '../utils.js'
 import type { FileType } from '../../../shared/getPageFiles/fileTypes.js'

--- a/vike/package.json
+++ b/vike/package.json
@@ -236,7 +236,7 @@
     "cac": "^6.7.14",
     "es-module-lexer": "^1.4.1",
     "esbuild": "^0.23.0",
-    "fast-glob": "^3.3.2",
+    "tinyglobby": "^0.2.6",
     "react-streaming": "^0.3.43",
     "rimraf": "^5.0.5",
     "semver": "^7.6.3",


### PR DESCRIPTION
Replace `fast-glob` with [tinyglobby](https://github.com/SuperchupuDev/tinyglobby)