### PR TITLE
make getCacheControl return defaultValue on 5xx server errors

### DIFF
--- a/vike/node/runtime/renderPage/createHttpResponse.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse.ts
@@ -63,7 +63,7 @@ async function createHttpResponsePage(
 
   const headers: ResponseHeaders = []
   assert(pageContext.pageId)
-  const cacheControl = getCacheControl(pageContext.pageId, pageContext._pageConfigs)
+  const cacheControl = getCacheControl(pageContext.pageId, pageContext._pageConfigs, statusCode)
   if (cacheControl) {
     headers.push(['Cache-Control', cacheControl])
   }

--- a/vike/node/runtime/renderPage/createHttpResponse/getCacheControl.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/getCacheControl.ts
@@ -1,14 +1,19 @@
 export { getCacheControl }
 
 import type { PageConfigRuntime } from '../../../../shared/page-configs/PageConfig.js'
+import type { HttpResponse } from '../createHttpResponse.js'
 import { getPageConfig } from '../../../../shared/page-configs/helpers.js'
 import { getConfigValueRuntime } from '../../../../shared/page-configs/getConfigValue.js'
 
+type StatusCode = HttpResponse['statusCode']
+
 const defaultValue = 'no-store, max-age=0'
 
-function getCacheControl(pageId: string, pageConfigs: PageConfigRuntime[]): string {
+function getCacheControl(pageId: string, pageConfigs: PageConfigRuntime[], statusCode: StatusCode): string {
   // TODO/v1-release: remove
   if (pageConfigs.length === 0) return defaultValue
+
+  if (statusCode > 499) return defaultValue
 
   const pageConfig = getPageConfig(pageId, pageConfigs)
   const configValue = getConfigValueRuntime(pageConfig, 'cacheControl', 'string')


### PR DESCRIPTION
Some cdn providers cache 5xx responses, so it's better to avoid it