### PR TITLE
docs: mention new extension `vike-react-antd`

### DIFF
--- a/docs/pages/antd/+Page.mdx
+++ b/docs/pages/antd/+Page.mdx
@@ -3,9 +3,22 @@ import { Link } from '@brillout/docpress'
 
 <CommunityNote />
 
+To use [Ant Design](https://ant.design/), you can use [`vike-react-antd`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-antd) for an automatic integration with Vike.
+
+> The `vike-react-antd` extension requires <Link href="/vike-react">`vike-react`</Link>.
+
+## Manual integration
+
+If you use <Link href="/vike-react">`vike-react`</Link>, you can manually integrate Ant Design using combination of these:
+- <Link href="/onBeforeRenderHtml" doNotInferSectionTitle />.
+- <Link href="/Wrapper" doNotInferSectionTitle />.
+- <Link href="/onAfterRenderHtml" doNotInferSectionTitle />.
+
 Examples of using Vike with [Ant Design](https://ant.design):
+ - <Example timestamp="2024.11" repo="phonzammi/vike-react-antd-example" /> - Using <Link href="/vike-react">`vike-react`</Link>
  - <Example timestamp="2024.08" repo="lewis-fidlers/vike-react-antd" /> - Using <Link href="/vike-react">`vike-react`</Link>
 
 ## See also
 
+- [Ant Design > Server Side Rendering](https://ant.design/docs/react/server-side-rendering)
 - [vike#1804 Some help with injecting styles](https://github.com/vikejs/vike/discussions/1804)

--- a/docs/pages/antd/+Page.mdx
+++ b/docs/pages/antd/+Page.mdx
@@ -9,7 +9,7 @@ To use [Ant Design](https://ant.design/), you can use [`vike-react-antd`](https:
 
 ## Manual integration
 
-If you use <Link href="/vike-react">`vike-react`</Link>, you can manually integrate Ant Design using combination of these:
+If you use <Link href="/vike-react">`vike-react`</Link>, you can manually integrate Ant Design using a combination of these:
 - <Link href="/onBeforeRenderHtml" doNotInferSectionTitle />.
 - <Link href="/Wrapper" doNotInferSectionTitle />.
 - <Link href="/onAfterRenderHtml" doNotInferSectionTitle />.

--- a/docs/pages/extensions/+Page.mdx
+++ b/docs/pages/extensions/+Page.mdx
@@ -10,6 +10,7 @@ Vike extensions integrate tools on your behalf.
  - [`vike-react-query`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-query#readme)
  - [`vike-react-apollo`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-apollo#readme)
  - [`vike-react-chakra`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-chakra#readme)
+ - [`vike-react-antd`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-antd#readme)
  - 🚧 [`vike-react-zustand`](https://github.com/vikejs/vike-react/pull/57)
 
 <Contribution>[Contributions welcome](https://github.com/vikejs/vike/issues/1715) to create extensions.</Contribution> 

--- a/docs/pages/releases/2024-09/+Page.mdx
+++ b/docs/pages/releases/2024-09/+Page.mdx
@@ -51,6 +51,7 @@ New <Link href="/extensions">Vike extensions</Link>:
  - [`vike-vue-naive-ui`](https://github.com/Jearce/vike-vue-naive-ui)
  - [`vike-solid-query`](https://github.com/vikejs/vike-solid/tree/main/packages/vike-solid-query#readme)
  - [`vike-react-chakra`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-chakra#readme)
+ - [`vike-react-antd`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-antd#readme)
 
 <Contribution>
   Author: [Jearce](https://github.com/Jearce), [`phonzammi`](https://github.com/phonzammi)


### PR DESCRIPTION
Docs updated :

> * vike.dev/antd
> * vike.dev/extensions

Please take a look and review it. 

I'm not sure about : 
> * vike.dev/releases/2024-09 (I should rename and publish it at some point 😅)
