### PR TITLE
docs: replace deprecated Effect type with ConfigEffect

### DIFF
--- a/docs/pages/meta/+Page.mdx
+++ b/docs/pages/meta/+Page.mdx
@@ -369,7 +369,7 @@ If you want to change the `meta.env` on a page-by-page basis, you can use the th
 
 export { config }
 
-import type { Config, Effect } from 'vike/types'
+import type { Config, ConfigEffect } from 'vike/types'
 
 const config = {
   meta: {
@@ -380,7 +380,7 @@ const config = {
   }
 } satisfies Config
 
-const effect: Effect = ({ configDefinedAt, configValue }) => {
+const effect: ConfigEffect = ({ configDefinedAt, configValue }) => {
   if (typeof configValue !== 'boolean') {
     throw new Error(`${configDefinedAt} should be a boolean`)
   }


### PR DESCRIPTION
The `Effect` type is deprecated according to the code comments, so the examples in the docs should be updated accordingly.

https://github.com/vikejs/vike/blob/4dcddbc6b875a9da196747e939b9c8a6de70f5a0/vike/types/index.ts#L67-L74