### PR TITLE
fix: add `.pnpm-store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+/.pnpm-store/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
+# https://github.com/vikejs/vike/pull/1997
 /.pnpm-store/


### PR DESCRIPTION
## Summary

Depending on your checkout method and setup (for example, within a VS Code DevContainer), `pnpm` creates a `.pnpm-store` folder at the root of your workspace that should be ignored by `git`.

Not ignoring it can cause quite a headache and >10,000 untracked changes due to files in `.pnpm-store`.