### PR TITLE
docs: improve `<CommunityNote>`

### DIFF
--- a/docs/components/CommunityNote.tsx
+++ b/docs/components/CommunityNote.tsx
@@ -1,10 +1,12 @@
 export { CommunityNote }
 
 import React from 'react'
-import { assert, Contribution, usePageContext } from '@brillout/docpress'
+import { assert, Contribution, usePageContext, Link } from '@brillout/docpress'
 
-function CommunityNote({ url }: { url: string }) {
-  assert(url, 'The `url` prop is required')
+type UIFramework = 'react' | 'solid' | 'vue' | false
+
+function CommunityNote({ tool, url, hasExtension }: { tool: string; url: string; hasExtension?: UIFramework }) {
+  assert(tool && url, 'Both the `tool` & `url` props are required')
   const pageContext = usePageContext()
   return (
     <>
@@ -18,6 +20,47 @@ function CommunityNote({ url }: { url: string }) {
         </a>{' '}
         to update or improve this page.
       </Contribution>
+      {hasExtension && <HasExtension toolName={tool} toolTitle={pageContext.pageTitle!} hasExtension={hasExtension} />}
+    </>
+  )
+}
+
+function HasExtension({
+  toolName,
+  toolTitle,
+  hasExtension
+}: { toolName: string; toolTitle: string; hasExtension: UIFramework }) {
+  if (hasExtension === false) {
+    return (
+      <Contribution>
+        There isn't a <Link href="/extensions">Vike extension</Link> for {toolTitle} yet, but{' '}
+        <a href="https://github.com/vikejs/vike/issues/1715">contributions welcome to create one</a>. In the meantime,
+        you can manually integrate {toolTitle}.
+      </Contribution>
+    )
+  }
+  return (
+    <>
+      <p>
+        If you are using <Link href={`/vike-${hasExtension}`}>vike-{hasExtension}</Link>, you can install{' '}
+        <code>
+          <a
+            href={`https://github.com/vikejs/vike-${hasExtension}/tree/main/packages/vike-${hasExtension}-${toolName}#readme`}
+          >
+            vike-{hasExtension}-{toolName}
+          </a>
+        </code>{' '}
+        for automatic integration.
+      </p>
+      <blockquote>
+        <p>
+          The <code>vike-{hasExtension}-antd</code> extension requires{' '}
+          <code>
+            <Link href={`/vike-${hasExtension}`}>vike-{hasExtension}</Link>
+          </code>
+          .
+        </p>
+      </blockquote>
     </>
   )
 }

--- a/docs/pages/antd/+Page.mdx
+++ b/docs/pages/antd/+Page.mdx
@@ -1,11 +1,7 @@
 import { Example, CommunityNote } from '../../components'
 import { Link } from '@brillout/docpress'
 
-<CommunityNote url="https://ant.design" />
-
-If you are using <Link href="/vike-react">vike-react</Link>, you can install [`vike-react-antd`](https://github.com/vikejs/vike-react/tree/main/packages/vike-react-antd#readme) for automatic integration.
-
-> The `vike-react-antd` extension requires <Link href="/vike-react">`vike-react`</Link>.
+<CommunityNote tool="antd" url="https://ant.design" hasExtension="react" />
 
 ## Manual integration
 


### PR DESCRIPTION
Hi Rom, 
Besides the `hasExtension` property you mentioned in your [comment](https://github.com/vikejs/vike/pull/1999#issuecomment-2520584070), I've also added the `tool` property.

Example: 
`tool` => `toolName` = `ant`
`toolTitle` from `pageContext.pageTitle` = `Ant Design`

Please take a look and review this PR.