### PR TITLE
fix: improve the server assets logic

### DIFF
--- a/vike/node/plugin/plugins/buildConfig.ts
+++ b/vike/node/plugin/plugins/buildConfig.ts
@@ -66,10 +66,10 @@ function buildConfig(): Plugin[] {
           addLogHook()
           outDirs = getOutDirs(config)
           {
-            isServerAssetsFixEnabled = fixServerAssets_isEnabled() && (await isV1Design(config))
+            // https://github.com/vikejs/vike/issues/1339
+            // https://github.com/vikejs/vike/issues/2093
+            isServerAssetsFixEnabled = config.build.ssrEmitAssets && fixServerAssets_isEnabled() && (await isV1Design(config))
             if (isServerAssetsFixEnabled) {
-              // https://github.com/vikejs/vike/issues/1339
-              config.build.ssrEmitAssets = true
               // Required if `ssrEmitAssets: true`, see https://github.com/vitejs/vite/pull/11430#issuecomment-1454800934
               config.build.cssMinify = 'esbuild'
               fixServerAssets_assertCssTarget_populate(config)

--- a/vike/node/plugin/plugins/extractAssetsPlugin.ts
+++ b/vike/node/plugin/plugins/extractAssetsPlugin.ts
@@ -162,7 +162,8 @@ function extractAssetsPlugin(): Plugin[] {
       async configResolved(config_) {
         config = config_
         vikeConfig = await getVikeConfig(config)
-        isServerAssetsFixEnabled = fixServerAssets_isEnabled() && (await isV1Design(config))
+        // https://github.com/vikejs/vike/issues/2093
+        isServerAssetsFixEnabled = config.build.ssrEmitAssets && fixServerAssets_isEnabled() && (await isV1Design(config))
         if (!isServerAssetsFixEnabled) {
           // https://github.com/vikejs/vike/issues/1060
           assertUsage(


### PR DESCRIPTION
Implementation of https://github.com/vikejs/vike/issues/2093#issuecomment-2615231923

Fix #2093

### TODO
- [ ] remove the logic of [commit1](https://github.com/vikejs/vike/commit/c1cd2d978b9b811c159551927d0f843d7709066e) and [commit2](https://github.com/cr7pt0gr4ph7/vike/commit/87669c5c05584e77dc783b2aa9104b3e0f47e5bf) (introduced to fix #2034) because, with `ssrEmitAssets=true`, the `dist/server/assets` files went deleted