### PR TITLE
Fix a docs link to the vue-minimal example

### DIFF
--- a/docs/pages/new/+Page.mdx
+++ b/docs/pages/new/+Page.mdx
@@ -55,7 +55,7 @@ See also:
 - [GitHub > `vikejs/vike` > `boilerplates/`](https://github.com/vikejs/vike/tree/main/boilerplates)
 - [GitHub > `vikejs/vike` > `examples/react-minimal`](https://github.com/vikejs/vike/tree/main/examples/react-minimal)
 - [GitHub > `vikejs/vike` > `examples/react-full`](https://github.com/vikejs/vike/tree/main/examples/react-full)
-- [GitHub > `vikejs/vike` > `examples/vue-minimal`](https://github.com/vikejs/vike/tree/main/examples/react-minimal)
+- [GitHub > `vikejs/vike` > `examples/vue-minimal`](https://github.com/vikejs/vike/tree/main/examples/vue-minimal)
 - [GitHub > `vikejs/vike` > `examples/vue-full`](https://github.com/vikejs/vike/tree/main/examples/vue-full)
 
 


### PR DESCRIPTION
Example project link for vue-minimal is leading to react-minimal.