### PR TITLE
fix: dupe server assets logic

### DIFF
--- a/vike/node/plugin/plugins/buildConfig.ts
+++ b/vike/node/plugin/plugins/buildConfig.ts
@@ -68,8 +68,10 @@ function buildConfig(): Plugin[] {
           {
             isServerAssetsFixEnabled = fixServerAssets_isEnabled() && (await isV1Design(config))
             if (isServerAssetsFixEnabled) {
+              // https://github.com/vikejs/vike/issues/2093
+              // `ssrEmitAssets: true` not needed because it dupe the server assets
+              // if needed, the user can set `ssrEmitAssets: true` in vite.config.js
               // https://github.com/vikejs/vike/issues/1339
-              config.build.ssrEmitAssets = true
               // Required if `ssrEmitAssets: true`, see https://github.com/vitejs/vite/pull/11430#issuecomment-1454800934
               config.build.cssMinify = 'esbuild'
               fixServerAssets_assertCssTarget_populate(config)


### PR DESCRIPTION
Implementation of https://github.com/vikejs/vike/issues/2093#issuecomment-2615231923

Follow up of #2115

Fix https://github.com/vikejs/vike/issues/2093

### Changes
- disable `ssrEmitAssets` by default as Vite behavior
- add feature `ssrEmitAssets=true` (the user can set `ssrEmitAssets=true`) to bundle the server assets
  - in the previous logic, `ssrEmitAssets` is always enabled and the bundled server assets were removed at the end of build
- improve the _create-and-delete_ server assets generated by `ssrEmitAssets=true`
