### PR TITLE
perf: switch from `fast-glob` to `tinyglobby`

### DIFF
--- a/docs/pages/filesystem-routing/+Page.mdx
+++ b/docs/pages/filesystem-routing/+Page.mdx
@@ -56,10 +56,10 @@ Vike crawls:
 - Skips soft-symlinked (`$ ln -s`) directories (if you use Git).
   > If you want to also crawl these then set `VIKE_CRAWL="{git:false}"`.
 
-By default Vike uses Git (if your repository uses Git) to crawl your files. If you set `VIKE_CRAWL="{git:false}"` then Vike uses [`fast-glob`](https://github.com/mrmlnc/fast-glob) instead.
+By default Vike uses Git (if your repository uses Git) to crawl your files. If you set `VIKE_CRAWL="{git:false}"` then Vike uses [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) instead.
 
 ```bash
-# Use fast-glob instead of Git to crawl files
+# Use tinyglobby instead of Git to crawl files
 $ VIKE_CRAWL="{git:false}" npm run dev
 ```
 

--- a/docs/pages/nextjs/+Page.mdx
+++ b/docs/pages/nextjs/+Page.mdx
@@ -132,7 +132,7 @@ With Vike, you have full control over your server and over your deployment strat
 
 ## Minimal and self-contained (no deps)
 
-[All dependencies](https://github.com/vikejs/vike/blob/3d042da/vike/package.json#L15-L26) are either shared with Vite (e.g. [`fast-glob`](https://github.com/mrmlnc/fast-glob)) or fully owned (e.g. we own [`@brillout/json-serializer`](https://github.com/brillout/json-serializer)). Adding Vike to your Vite app doesn't add any frivolous dependency.
+[All dependencies](https://github.com/vikejs/vike/blob/3d042da/vike/package.json#L15-L26) are either shared with Vite (e.g. [`tinyglobby`](docs/pages/nextjs/+Page.mdx:)) or fully owned (e.g. we own [`@brillout/json-serializer`](https://github.com/brillout/json-serializer)). Adding Vike to your Vite app doesn't add any frivolous dependency.
 
 We believe Vike hits the sweet spot of being a full-fledged frontend tool while avoiding unnecessary bells and whistles.
 

--- a/docs/pages/nextjs/+Page.mdx
+++ b/docs/pages/nextjs/+Page.mdx
@@ -132,7 +132,7 @@ With Vike, you have full control over your server and over your deployment strat
 
 ## Minimal and self-contained (no deps)
 
-[All dependencies](https://github.com/vikejs/vike/blob/3d042da/vike/package.json#L15-L26) are either shared with Vite (e.g. [`tinyglobby`](docs/pages/nextjs/+Page.mdx:)) or fully owned (e.g. we own [`@brillout/json-serializer`](https://github.com/brillout/json-serializer)). Adding Vike to your Vite app doesn't add any frivolous dependency.
+[All dependencies](https://github.com/vikejs/vike/blob/3d042da/vike/package.json#L15-L26) are either shared with Vite (e.g. [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby)) or fully owned (e.g. we own [`@brillout/json-serializer`](https://github.com/brillout/json-serializer)). Adding Vike to your Vite app doesn't add any frivolous dependency.
 
 We believe Vike hits the sweet spot of being a full-fledged frontend tool while avoiding unnecessary bells and whistles.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ importers:
     dependencies:
       '@brillout/docpress':
         specifier: ^0.11.2
-        version: 0.11.2(@algolia/client-search@4.24.0)(@types/react@19.0.8)(@vitejs/plugin-react-swc@3.7.2(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2)))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(search-insights@2.17.3)(typescript@5.7.3)(vike@vike)(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2))
+        version: 0.11.2(@algolia/client-search@4.24.0)(@types/react@19.0.8)(@vitejs/plugin-react-swc@3.7.2(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(search-insights@2.17.3)(typescript@5.7.3)(vike@vike)(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2))
       '@types/react':
         specifier: ^19.0.2
         version: 19.0.8
@@ -1801,9 +1801,6 @@ importers:
       esbuild:
         specifier: ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0
         version: 0.24.2
-      fast-glob:
-        specifier: ^3.0.0
-        version: 3.3.3
       json5:
         specifier: ^2.0.0
         version: 2.2.3
@@ -1813,6 +1810,9 @@ importers:
       source-map-support:
         specifier: ^0.5.0
         version: 0.5.21
+      tinyglobby:
+        specifier: ^0.2.10
+        version: 0.2.10
       vite:
         specifier: '>=5.1.0'
         version: 6.1.0(@types/node@20.17.17)(terser@5.38.1)(tsx@4.19.2)
@@ -2080,7 +2080,7 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
       typescript: '>=5.0.0'
-      vike: link:/home/rom/code/vike/vike/
+      vike: link:/home/bmccann/src/tmp/vike/vike/
       vite: '>=5.2.0'
     peerDependenciesMeta:
       '@vitejs/plugin-react-swc':
@@ -5126,6 +5126,14 @@ packages:
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
 
+  fdir@6.4.3:
+    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -6977,6 +6985,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyglobby@0.2.10:
+    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7228,7 +7240,7 @@ packages:
   vike-node@0.3.5:
     resolution: {integrity: sha512-W+xmy2lCVa9dQOmnFx8qVgznh822QYYT2VVD/f2/65XlSi59Ab20/3wr56zMNthxz3QO3g85yUpSUt0ZJTvXxA==}
     peerDependencies:
-      vike: link:/home/rom/code/vike/vike/
+      vike: link:/home/bmccann/src/tmp/vike/vike/
       vite: '>=5.0.10'
     peerDependenciesMeta:
       vite:
@@ -7239,12 +7251,12 @@ packages:
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
-      vike: link:/home/rom/code/vike/vike/
+      vike: link:/home/bmccann/src/tmp/vike/vike/
 
   vike-vue@0.8.6:
     resolution: {integrity: sha512-DT2PsxqfvMdkyuR3zdHPBcwrKjqpN7mIYeSIZ0WZsN+cEsY467nznyoZltq5vMQiQcEeQtQI0WrZTyBWKA7S5A==}
     peerDependencies:
-      vike: link:/home/rom/code/vike/vike/
+      vike: link:/home/bmccann/src/tmp/vike/vike/
       vue: '>=3.0.0'
 
   vite-node@3.0.5:
@@ -7266,7 +7278,7 @@ packages:
     resolution: {integrity: sha512-tNLg5fuMCF6nVfMlttstKt54VQ7KhqHh7/xahZdjGsbP8Z5ANCwy2WlIdrgkrwB752HMPyJnBXGSdg/O3UT3gg==}
     peerDependencies:
       '@vite-plugin-vercel/vike': 9.0.3
-      vike: link:/home/rom/code/vike/vike/
+      vike: link:/home/bmccann/src/tmp/vike/vike/
       vite: ^4.4 || ^5.0.2 || ^6
     peerDependenciesMeta:
       '@vite-plugin-vercel/vike':
@@ -7901,14 +7913,14 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@brillout/docpress@0.11.2(@algolia/client-search@4.24.0)(@types/react@19.0.8)(@vitejs/plugin-react-swc@3.7.2(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2)))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(search-insights@2.17.3)(typescript@5.7.3)(vike@vike)(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2))':
+  '@brillout/docpress@0.11.2(@algolia/client-search@4.24.0)(@types/react@19.0.8)(@vitejs/plugin-react-swc@3.7.2(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(search-insights@2.17.3)(typescript@5.7.3)(vike@vike)(vite@6.1.0(@types/node@22.13.1)(terser@5.38.1)(tsx@4.19.2))':
     dependencies:
       '@brillout/picocolors': 1.0.15
       '@docsearch/css': 3.8.3
       '@docsearch/react': 3.6.1(@algolia/client-search@4.24.0)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)
       '@mdx-js/mdx': 3.0.1
       '@mdx-js/react': 3.0.1(@types/react@19.0.8)(react@19.0.0)
-      '@mdx-js/rollup': 3.0.1(acorn@8.14.0)(rollup@4.34.4)
+      '@mdx-js/rollup': 3.0.1(rollup@4.34.4)
       '@shikijs/transformers': 1.2.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -8686,7 +8698,7 @@ snapshots:
       '@types/react': 19.0.8
       react: 19.0.0
 
-  '@mdx-js/rollup@3.0.1(acorn@8.14.0)(rollup@4.34.4)':
+  '@mdx-js/rollup@3.0.1(rollup@4.34.4)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       '@rollup/pluginutils': 5.1.4(rollup@4.34.4)
@@ -9800,17 +9812,17 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.97.1)
@@ -11026,6 +11038,10 @@ snapshots:
   fastq@1.19.0:
     dependencies:
       reusify: 1.0.4
+
+  fdir@6.4.3(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   fetch-blob@3.2.0:
     dependencies:
@@ -13226,7 +13242,7 @@ snapshots:
       react: 18.3.1
       react-streaming: 0.3.47(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  terser-webpack-plugin@5.3.10(webpack@5.97.1(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.10(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -13253,6 +13269,11 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.10:
+    dependencies:
+      fdir: 6.4.3(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinypool@1.0.2: {}
 
@@ -13829,9 +13850,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.97.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -13875,7 +13896,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.97.1(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.10(webpack@5.97.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/vike/node/plugin/plugins/importUserCode/v1-design/getVikeConfig/crawlPlusFiles.ts
+++ b/vike/node/plugin/plugins/importUserCode/v1-design/getVikeConfig/crawlPlusFiles.ts
@@ -62,7 +62,7 @@ async function crawlPlusFiles(
     (filesGitNothingFound || debug.isActivated) && (await tinyglobby(userRootDir, outDirRelativeFromUserRootDir))
   let files = !filesGitNothingFound
     ? filesGit
-    : // Fallback to fast-glob for users that dynamically generate plus files. (Assuming that no plus file is found because of the user's .gitignore list.)
+    : // Fallback to tinyglobby for users that dynamically generate plus files. (Assuming that no plus file is found because of the user's .gitignore list.)
       filesGlob
   assert(files)
   if (debug.isActivated) assert(deepEqual(filesGlob, filesGit), "Git and glob results aren't matching.")
@@ -72,7 +72,7 @@ async function crawlPlusFiles(
 
   // Normalize
   const plusFiles = files.map((filePath) => {
-    // Both `$ git-ls files` and fast-glob return posix paths
+    // Both `$ git-ls files` and tinyglobby return posix paths
     assertPosixPath(filePath)
     assert(!filePath.startsWith(userRootDir))
     const filePathAbsoluteUserRootDir = path.posix.join('/', filePath)

--- a/vike/node/plugin/shared/findPageFiles.ts
+++ b/vike/node/plugin/shared/findPageFiles.ts
@@ -18,7 +18,7 @@ async function findPageFiles(config: ResolvedConfig, fileTypes: FileType[], isDe
   pageFiles = pageFiles.map((p) => '/' + toPosixPath(p))
   const time = new Date().getTime() - timeBase
   if (isDev) {
-    // We only warn in dev, because while building it's expected to take a long time as globbing is competing for resources with other tasks
+    // We only warn in dev, because while building it's expected to take a long time as tinyglobby is competing for resources with other tasks
     assertWarning(
       time < 1.5 * 1000,
       `Finding your page files ${pc.cyan(

--- a/vike/node/plugin/shared/findPageFiles.ts
+++ b/vike/node/plugin/shared/findPageFiles.ts
@@ -1,6 +1,6 @@
 export { findPageFiles }
 
-import glob from 'fast-glob'
+import { glob } from 'tinyglobby'
 import type { ResolvedConfig } from 'vite'
 import { assertWarning, toPosixPath, scriptFileExtensions } from '../utils.js'
 import type { FileType } from '../../../shared/getPageFiles/fileTypes.js'
@@ -13,12 +13,12 @@ async function findPageFiles(config: ResolvedConfig, fileTypes: FileType[], isDe
   const timeBase = new Date().getTime()
   let pageFiles = await glob(
     fileTypes.map((fileType) => `**/*${fileType}.${scriptFileExtensions}`),
-    { ignore: ['**/node_modules/**', `${outDirRoot}/**`], cwd, dot: false }
+    { ignore: ['**/node_modules/**', `${outDirRoot}/**`], cwd, dot: false, expandDirectories: false }
   )
   pageFiles = pageFiles.map((p) => '/' + toPosixPath(p))
   const time = new Date().getTime() - timeBase
   if (isDev) {
-    // We only warn in dev, because while building it's expected to take a long time as fast-glob is competing for resources with other tasks
+    // We only warn in dev, because while building it's expected to take a long time as globbing is competing for resources with other tasks
     assertWarning(
       time < 1.5 * 1000,
       `Finding your page files ${pc.cyan(

--- a/vike/package.json
+++ b/vike/package.json
@@ -137,10 +137,10 @@
     "cac": "^6.0.0",
     "es-module-lexer": "^1.0.0",
     "esbuild": "^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",
-    "fast-glob": "^3.0.0",
     "json5": "^2.0.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.5.0",
+    "tinyglobby": "^0.2.10",
     "vite": ">=5.1.0"
   },
   "peerDependencies": {

--- a/vike/utils/findFile.ts
+++ b/vike/utils/findFile.ts
@@ -7,7 +7,7 @@ import { assertPosixPath } from './path.js'
 
 type Filename = 'package.json' | 'vike.config.js' | 'vike.config.ts'
 
-// We need to be able to crawl the filesystem, regardless of Vike's `$ git ls-files` command call, because we need to fallback if the user didn't setup Git (e.g. we cannot remove the glob fallback).
+// We need to be able to crawl the filesystem, regardless of Vike's `$ git ls-files` command call, because we need to fallback if the user didn't setup Git (e.g. we cannot remove the tinyglobby fallback).
 function findFile(arg: Filename | Filename[], cwd: string): null | string {
   assertPosixPath(cwd)
   const filenames = isArray(arg) ? arg : [arg]

--- a/vike/utils/findFile.ts
+++ b/vike/utils/findFile.ts
@@ -7,7 +7,7 @@ import { assertPosixPath } from './path.js'
 
 type Filename = 'package.json' | 'vike.config.js' | 'vike.config.ts'
 
-// We need to be able to crawl the filesystem, regardless of Vike's `$ git ls-files` command call, because we need to fallback if the user didn't setup Git (e.g. we cannot remove the fast-glob fallback).
+// We need to be able to crawl the filesystem, regardless of Vike's `$ git ls-files` command call, because we need to fallback if the user didn't setup Git (e.g. we cannot remove the glob fallback).
 function findFile(arg: Filename | Filename[], cwd: string): null | string {
   assertPosixPath(cwd)
   const filenames = isArray(arg) ? arg : [arg]


### PR DESCRIPTION
The docs say:

>## Minimal and self-contained (no deps)
>
>[All dependencies](https://github.com/vikejs/vike/blob/3d042da/vike/package.json#L15-L26) are either shared with Vite (e.g. [`fast-glob`](docs/pages/nextjs/+Page.mdx:))

But actually Vite switched to tinyglobby. There's also a PR out to switch vitest to tinyglobby. I thought it'd be good to stay aligned here

`fast-glob` has 17 dependencies vs just 2 for `tinyglobby`