### PR TITLE
fix: pipeable web stream

### DIFF
--- a/vike/node/runtime/html/stream.ts
+++ b/vike/node/runtime/html/stream.ts
@@ -220,6 +220,14 @@ function getStreamReadableWeb(htmlRender: HtmlRender): null | StreamReadableWeb 
   if (isStreamReadableWeb(htmlRender)) {
     return htmlRender
   }
+  if (isStreamPipeWeb(htmlRender)) {
+    const streamPipeWeb = getStreamPipeWeb(htmlRender)
+    assert(streamPipeWeb)
+
+    const { readable, writable } = new TransformStream();
+    streamPipeWeb(writable)
+    return readable
+  }
   return null
 }
 

--- a/vike/node/runtime/html/stream.ts
+++ b/vike/node/runtime/html/stream.ts
@@ -224,7 +224,7 @@ function getStreamReadableWeb(htmlRender: HtmlRender): null | StreamReadableWeb 
     const streamPipeWeb = getStreamPipeWeb(htmlRender)
     assert(streamPipeWeb)
 
-    const { readable, writable } = new TransformStream();
+    const { readable, writable } = new TransformStream()
     streamPipeWeb(writable)
     return readable
   }


### PR DESCRIPTION
Fixes errors like this one:
```
Error: [vike][Wrong Usage] pageContext.httpResponse.getReadableWebStream() can't be used because the onRenderHtml() hook defined by vike-solid/__internal/integration/onRenderHtml provides a Web Stream Pipe. Make sure the onRenderHtml() defined by vike-solid/__internal/integration/onRenderHtml hook provides a Readable Web Stream instead. See https://vike.dev/streaming for more information.
```