### PR TITLE
fix: fix catch of infinite redirections (fix #2262)

### DIFF
--- a/vike/node/runtime/renderPage.ts
+++ b/vike/node/runtime/renderPage.ts
@@ -24,7 +24,6 @@ import {
   prependBase,
   removeUrlOrigin,
   setUrlOrigin,
-  createUrlFromComponents,
   isUri,
   type UrlPublic,
   getUrlPretty
@@ -529,7 +528,7 @@ async function normalizeUrl(
     httpRequestId,
     'info'
   )
-  const httpResponse = createHttpResponseRedirect({ url: urlNormalized, statusCode: 301 }, pageContextInit.urlOriginal)
+  const httpResponse = createHttpResponseRedirect({ url: urlNormalized, statusCode: 301 }, pageContextInit)
   const pageContextHttpResponse = createPageContext(pageContextInit)
   objectAssign(pageContextHttpResponse, { httpResponse })
   return pageContextHttpResponse
@@ -576,7 +575,7 @@ async function getPermanentRedirect(
     httpRequestId,
     'info'
   )
-  const httpResponse = createHttpResponseRedirect({ url: urlTarget, statusCode: 301 }, urlWithoutBase)
+  const httpResponse = createHttpResponseRedirect({ url: urlTarget, statusCode: 301 }, pageContextInit)
   const pageContextHttpResponse = createPageContext(pageContextInit)
   objectAssign(pageContextHttpResponse, { httpResponse })
   return pageContextHttpResponse
@@ -588,6 +587,7 @@ function normalize(url: string) {
 async function handleAbortError(
   errAbort: ErrorAbort,
   pageContextsFromRewrite: PageContextFromRewrite[],
+  // The original `pageContextInit` object passed to `renderPage(pageContextInit)`
   pageContextInit: { urlOriginal: string },
   // handleAbortError() creates a new pageContext object and we don't merge pageContextNominalPageInit to it: we only use some pageContextNominalPageInit information.
   pageContextNominalPageInit: {
@@ -644,20 +644,7 @@ async function handleAbortError(
   if (pageContextAbort._urlRedirect) {
     const pageContextReturn = createPageContext(pageContextInit)
     objectAssign(pageContextReturn, pageContextAbort)
-    const httpResponse = createHttpResponseRedirect(
-      pageContextAbort._urlRedirect,
-      (() => {
-        const { pathname, searchOriginal } = pageContextNominalPageInit.urlParsed
-        const urlLogical = createUrlFromComponents(
-          null,
-          pathname,
-          searchOriginal,
-          // The server-side doesn't have access to the hash
-          null
-        )
-        return urlLogical
-      })()
-    )
+    const httpResponse = createHttpResponseRedirect(pageContextAbort._urlRedirect, pageContextInit)
     objectAssign(pageContextReturn, { httpResponse })
     return { pageContextReturn }
   }

--- a/vike/node/runtime/renderPage/createHttpResponse.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse.ts
@@ -142,8 +142,11 @@ async function createHttpResponsePageContextJson(pageContextSerialized: string) 
   return httpResponse
 }
 
-function createHttpResponseRedirect({ url, statusCode }: UrlRedirect, urlOriginal: string): HttpResponse {
-  assertNoInfiniteHttpRedirect(url, urlOriginal)
+function createHttpResponseRedirect(
+  { url, statusCode }: UrlRedirect,
+  pageContextInit: { urlOriginal: string }
+): HttpResponse {
+  assertNoInfiniteHttpRedirect(url, pageContextInit)
   assert(url)
   assert(statusCode)
   assert(300 <= statusCode && statusCode <= 399)

--- a/vike/node/runtime/renderPage/createHttpResponse.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse.ts
@@ -142,12 +142,8 @@ async function createHttpResponsePageContextJson(pageContextSerialized: string) 
   return httpResponse
 }
 
-function createHttpResponseRedirect(
-  { url, statusCode }: UrlRedirect,
-  // The URL we assume the redirect to be logically based on
-  urlLogical: string
-): HttpResponse {
-  assertNoInfiniteHttpRedirect(url, urlLogical)
+function createHttpResponseRedirect({ url, statusCode }: UrlRedirect, urlOriginal: string): HttpResponse {
+  assertNoInfiniteHttpRedirect(url, urlOriginal)
   assert(url)
   assert(statusCode)
   assert(300 <= statusCode && statusCode <= 399)

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.spec.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.spec.ts
@@ -2,20 +2,23 @@ import { expect, describe, it, assert } from 'vitest'
 import { stripAnsi } from '../../utils.js'
 import { assertNoInfiniteHttpRedirect } from './assertNoInfiniteHttpRedirect.js'
 
+const call = (urlRedirectTarget: string, urlOriginal: string) =>
+  assertNoInfiniteHttpRedirect(urlRedirectTarget, { urlOriginal })
+
 describe('assertNoInfiniteHttpRedirect()', () => {
   it('works', () => {
     expectErr(
       () => {
-        assertNoInfiniteHttpRedirect('/a', '/a')
+        call('/a', '/a')
       },
       (msg) => {
         expect(msg).toMatchInlineSnapshot('"[vike][Wrong Usage] Infinite loop of HTTP URL redirects: /a -> /a"')
       }
     )
-    assertNoInfiniteHttpRedirect('/a', '/b')
+    call('/a', '/b')
     expectErr(
       () => {
-        assertNoInfiniteHttpRedirect('/a', '/a')
+        call('/a', '/a')
       },
       (msg) => {
         expect(msg).toMatchInlineSnapshot('"[vike][Wrong Usage] Infinite loop of HTTP URL redirects: /a -> /a"')
@@ -23,18 +26,18 @@ describe('assertNoInfiniteHttpRedirect()', () => {
     )
     expectErr(
       () => {
-        assertNoInfiniteHttpRedirect('/b', '/a')
+        call('/b', '/a')
       },
       (msg) => {
         expect(msg).toMatchInlineSnapshot('"[vike][Wrong Usage] Infinite loop of HTTP URL redirects: /a -> /b -> /a"')
       }
     )
-    assertNoInfiniteHttpRedirect('/a', '/c')
-    assertNoInfiniteHttpRedirect('/b', '/c')
-    assertNoInfiniteHttpRedirect('/c', '/d')
+    call('/a', '/c')
+    call('/b', '/c')
+    call('/c', '/d')
     expectErr(
       () => {
-        assertNoInfiniteHttpRedirect('/d', '/b')
+        call('/d', '/b')
       },
       (msg) => {
         expect(msg).toMatchInlineSnapshot(
@@ -42,11 +45,11 @@ describe('assertNoInfiniteHttpRedirect()', () => {
         )
       }
     )
-    assertNoInfiniteHttpRedirect('/a', '/e')
-    assertNoInfiniteHttpRedirect('/e', '/c')
+    call('/a', '/e')
+    call('/e', '/c')
     expectErr(
       () => {
-        assertNoInfiniteHttpRedirect('/d', '/a')
+        call('/d', '/a')
       },
       (msg) => {
         expect(msg).toMatchInlineSnapshot(

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
@@ -8,10 +8,12 @@ const globalObject = getGlobalObject<{ redirectGraph: Graph }>('createHttpRespon
   redirectGraph: {}
 })
 
+// It's too strict, see https://github.com/vikejs/vike/issues/1270#issuecomment-1820608999
+// - Let's create a new setting `+doNotCatchInfiniteRedirect` if someone complains.
 function assertNoInfiniteHttpRedirect(urlRedirectTarget: string, urlLogical: string) {
   if (!urlRedirectTarget.startsWith('/')) {
-    // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (in itself).
-    //  - There isn't a reliable way to check whether the redirect points to an external origin or the same origin. For same origins, we assume/hope the user to pass the URL without origin.
+    // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (at least not in itself).
+    //  - There isn't a reliable way to check whether the redirect points to an external origin or the same origin; we hope/assume the user sets the URL without origin.
     //    ```js
     //    // For same-origin, the user usually/hopefully passes a URL without origin
     //    renderPage({ urlOriginal: '/some/pathname' })

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
@@ -10,7 +10,13 @@ const globalObject = getGlobalObject<{ redirectGraph: Graph }>('createHttpRespon
 
 // It's too strict, see https://github.com/vikejs/vike/issues/1270#issuecomment-1820608999
 // - Let's create a new setting `+doNotCatchInfiniteRedirect` if someone complains.
-function assertNoInfiniteHttpRedirect(urlRedirectTarget: string, urlLogical: string) {
+function assertNoInfiniteHttpRedirect(
+  // The exact URL that the user will be redirected to.
+  // - It includes the Base URL as well as the locale (i18n) base.
+  urlRedirectTarget: string,
+  // Rationale for cechking against `urlOriginal`: https://github.com/vikejs/vike/pull/2264#issuecomment-2713890263
+  urlOriginal: string
+) {
   if (!urlRedirectTarget.startsWith('/')) {
     // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (at least not in itself).
     //  - There isn't a reliable way to check whether the redirect points to an external origin or the same origin; we hope/assume the user sets the URL without origin.
@@ -20,10 +26,10 @@ function assertNoInfiniteHttpRedirect(urlRedirectTarget: string, urlLogical: str
     //    ```
     return
   }
-  assert(urlLogical.startsWith('/'))
+  assert(urlOriginal.startsWith('/'))
   const graph = copy(globalObject.redirectGraph)
   graph[urlRedirectTarget] ??= new Set()
-  graph[urlRedirectTarget]!.add(urlLogical)
+  graph[urlRedirectTarget]!.add(urlOriginal)
   validate(graph)
   globalObject.redirectGraph = graph
 }

--- a/vike/utils/parseUrl-extras.ts
+++ b/vike/utils/parseUrl-extras.ts
@@ -101,6 +101,7 @@ function modifyUrlPathname(url: string, modifier: (urlPathname: string) => strin
 function removeUrlOrigin(url: string): { urlModified: string; origin: string | null } {
   const { origin, pathnameOriginal, searchOriginal, hashOriginal } = parseUrl(url, '/')
   const urlModified = createUrlFromComponents(null, pathnameOriginal, searchOriginal, hashOriginal)
+  assert(urlModified.startsWith('/'))
   return { urlModified, origin }
 }
 function setUrlOrigin(url: string, origin: string | null): false | string {


### PR DESCRIPTION
Fixes:
- #2262

History of `assertNoInfiniteHttpRedirect()`:
 - https://github.com/vikejs/vike/issues/1270
 - https://github.com/vikejs/vike/issues/1103
 - https://github.com/vikejs/vike/commit/522bd0fa3190e31aa4f59e781f7661d1a9569b12

I wonder why I used `urlLogical` instead of `urlOriginal`.

>   // The URL we assume the redirect to be logically based on
>   urlLogical: string

Isn't it overthinking it? Can't we just simply observe the URL redirection chain for loops, regardless of the semantics behind the URL redirections? This PR makes `assertNoInfiniteHttpRedirect()` use `urlOriginal` instead of `urlLogical`, let's see if a user complains.