### PR TITLE
[failed attempt] make infinite redirection loop detection reliable (closes #2262)

### DIFF
--- a/vike/node/runtime/renderPage/createHttpResponse.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse.ts
@@ -146,12 +146,11 @@ function createHttpResponseRedirect(
   { url, statusCode }: UrlRedirect,
   pageContextInit: { urlOriginal: string }
 ): HttpResponse {
-  const cookieInfiniteRedirectionDetector = assertNoInfiniteHttpRedirect(url, pageContextInit)
+  assertNoInfiniteHttpRedirect(url, pageContextInit)
   assert(url)
   assert(statusCode)
   assert(300 <= statusCode && statusCode <= 399)
   const headers: ResponseHeaders = [['Location', url]]
-  if (cookieInfiniteRedirectionDetector) headers.push(cookieInfiniteRedirectionDetector)
   return createHttpResponse(
     statusCode,
     'text/html;charset=utf-8',

--- a/vike/node/runtime/renderPage/createHttpResponse.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse.ts
@@ -146,11 +146,12 @@ function createHttpResponseRedirect(
   { url, statusCode }: UrlRedirect,
   pageContextInit: { urlOriginal: string }
 ): HttpResponse {
-  assertNoInfiniteHttpRedirect(url, pageContextInit)
+  const cookieInfiniteRedirectionDetector = assertNoInfiniteHttpRedirect(url, pageContextInit)
   assert(url)
   assert(statusCode)
   assert(300 <= statusCode && statusCode <= 399)
   const headers: ResponseHeaders = [['Location', url]]
+  if (cookieInfiniteRedirectionDetector) headers.push(cookieInfiniteRedirectionDetector)
   return createHttpResponse(
     statusCode,
     'text/html;charset=utf-8',

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.spec.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.spec.ts
@@ -6,6 +6,11 @@ const call = (urlRedirectTarget: string, urlOriginal: string) =>
   assertNoInfiniteHttpRedirect(urlRedirectTarget, { urlOriginal })
 
 describe('assertNoInfiniteHttpRedirect()', () => {
+  it('temporariy disabled', () => {
+    expect(call('/a', '/a')).toBe('DISABLED')
+  })
+  if (true as boolean) return
+
   it('works', () => {
     expectErr(
       () => {

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
@@ -18,7 +18,7 @@ function assertNoInfiniteHttpRedirect(
   }
 ) {
   // TO-DO/eventually: use cookie as described at https://github.com/vikejs/vike/pull/2273
-  if (true as boolean) return // Disabled until we make it reliable.
+  if (true as boolean) return 'DISABLED' // Disabled until we make it reliable.
 
   if (!urlRedirectTarget.startsWith('/')) {
     // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (at least not in itself).

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
@@ -8,8 +8,6 @@ const globalObject = getGlobalObject<{ redirectGraph: Graph }>('createHttpRespon
   redirectGraph: {}
 })
 
-// It's too strict, see https://github.com/vikejs/vike/issues/1270#issuecomment-1820608999
-// - Let's create a new setting `+doNotCatchInfiniteRedirect` if someone complains.
 function assertNoInfiniteHttpRedirect(
   // The exact URL that the user will be redirected to.
   // - It includes the Base URL as well as the locale (i18n) base.
@@ -19,6 +17,9 @@ function assertNoInfiniteHttpRedirect(
     urlOriginal: string
   }
 ) {
+  // TO-DO/eventually: use cookie as described at https://github.com/vikejs/vike/pull/2273
+  if (true as boolean) return; // Disabled until we make it reliable.
+
   if (!urlRedirectTarget.startsWith('/')) {
     // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (at least not in itself).
     //  - There isn't a reliable way to check whether the redirect points to an external origin or the same origin; we hope/assume the user sets the URL without origin.

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
@@ -18,7 +18,7 @@ function assertNoInfiniteHttpRedirect(
   }
 ) {
   // TO-DO/eventually: use cookie as described at https://github.com/vikejs/vike/pull/2273
-  if (true as boolean) return; // Disabled until we make it reliable.
+  if (true as boolean) return // Disabled until we make it reliable.
 
   if (!urlRedirectTarget.startsWith('/')) {
     // We assume that urlRedirectTarget points to an origin that is external (not the same origin), and we can therefore assume that the app doesn't define an infinite loop (at least not in itself).

--- a/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
+++ b/vike/node/runtime/renderPage/createHttpResponse/assertNoInfiniteHttpRedirect.ts
@@ -1,5 +1,6 @@
 export { assertNoInfiniteHttpRedirect }
 
+import { getRandomId } from '../../../plugin/utils.js'
 import { assert, assertUsage, getGlobalObject, removeUrlOrigin } from '../../utils.js'
 import pc from '@brillout/picocolors'
 
@@ -33,8 +34,16 @@ function assertNoInfiniteHttpRedirect(
   const graph = copy(globalObject.redirectGraph)
   graph[urlRedirectTarget] ??= new Set()
   graph[urlRedirectTarget]!.add(urlOriginalNormalized)
-  validate(graph)
+  const redirectionLoop = validate(graph)
   globalObject.redirectGraph = graph
+  if (redirectionLoop) {
+    // assertUsage(false, `Infinite loop of HTTP URL redirects: ${redirectionLoop.map(pc.cyan).join(' -> ')}`)
+    const cookieInfiniteRedirectionDetector: [string, string] = [
+      'Set-Cookie',
+      `redirection-loop-client-id=${getRandomId()}`
+    ]
+    return cookieInfiniteRedirectionDetector
+  }
 }
 
 function copy(G: Graph): Graph {
@@ -43,12 +52,12 @@ function copy(G: Graph): Graph {
 
 // Adapted from: https://stackoverflow.com/questions/60904464/detect-cycle-in-directed-graph/60907076#60907076
 function validate(G: Graph) {
-  Object.keys(G).forEach((n) => check(G, n, []))
+  return Object.keys(G).find((n) => check(G, n, []))
 }
 function check(G: Graph, n: string, path: string[]) {
   if (path.includes(n)) {
     const cycle = path.slice(path.indexOf(n)).concat(n)
-    assertUsage(false, `Infinite loop of HTTP URL redirects: ${cycle.map(pc.cyan).join(' -> ')}`)
+    return cycle
   }
   G[n]?.forEach((node) => check(G, node, [...path, n]))
 }


### PR DESCRIPTION
Failed attempt to fix https://github.com/vikejs/vike/issues/1270#issuecomment-1820608999.

A solution would be to set a cookie that tracks infinite loops, but it's far from trivial to implement, thus postponing.

Removing the infinite redirection loop detection in the meantime.

See also:
 - https://github.com/vikejs/vike/pull/2264
 - Browser already have a built-in detection: ERR_TOO_MANY_REDIRECTS https://www.semrush.com/blog/too-many-redirects/