### PR TITLE
Align right-side numbers in chip diagram

### DIFF
--- a/docs/pages/index/sections/features/chip/Chip.tsx
+++ b/docs/pages/index/sections/features/chip/Chip.tsx
@@ -235,6 +235,7 @@ export const Chip = () => {
                         width: '20px',
                         marginRight: '24px',
                         textTransform: 'uppercase',
+                        fontVariantNumeric: 'tabular-nums',
                         textAlign: 'end'
                       }}
                     >


### PR DESCRIPTION
Oops. I missed one of the styles in https://github.com/vikejs/vike/pull/2341