### PR TITLE
fix: add safe  operations to decodeURI.

### DIFF
--- a/vike/node/runtime/renderPage.ts
+++ b/vike/node/runtime/renderPage.ts
@@ -362,7 +362,10 @@ function logHttpResponse(urlOriginalPretty: string, httpRequestId: number, pageC
   logRuntimeInfo?.(msg, httpRequestId, isNominal ? 'info' : 'error')
 }
 function prettyUrl(url: string) {
-  return pc.bold(decodeURI(url))
+  try {
+    return pc.bold(decodeURI(url))
+  } catch {}
+  return pc.bold(url)
 }
 
 function getPageContextHttpResponseError(

--- a/vike/node/runtime/renderPage.ts
+++ b/vike/node/runtime/renderPage.ts
@@ -363,8 +363,10 @@ function logHttpResponse(urlOriginalPretty: string, httpRequestId: number, pageC
 }
 function prettyUrl(url: string) {
   try {
-    return pc.bold(decodeURI(url))
-  } catch {}
+    url = decodeURI(url)
+  } catch {
+    // https://github.com/vikejs/vike/pull/2367#issuecomment-2800967564
+  }
   return pc.bold(url)
 }
 


### PR DESCRIPTION
when window.location.pathname = 'E5%A7%8B/%22%7D%22%7D' , it will get error:
``` ts
URIError: URI malformed
    at decodeURI (<anonymous>)
    at prettyUrl (file:///Users/xxxx/=xxxx/node_modules/.pnpm/vike@0.4.224_react-streaming@0.3.48_react-dom@19.0.0_react@19.0.0__react@19.0.0__vite@6.2.1_@_hf5uinn3urlsbelld7h44mswdi/node_modules/vike/dist/esm/node/runtime/renderPage.js:242:20)
    at getRequestInfoMessage (file:///Users/xxxx/yyyy/node_modules/.pnpm/vike@0.4.224_react-streaming@0.3.48_react-dom@19.0.0_react@19.0.0__react@19.0.0__vite@6.2.1_@_hf5uinn3urlsbelld7h44mswdi/node_modules/vike/dist/esm/node/runtime/renderPage.js:200:29)
    at logHttpRequest (file:///Users/xxxx/yyyy/node_modules/.pnpm/vike@0.4.224_react-streaming@0.3.48_react-dom@19.0.0_react@19.0.0__react@19.0.0__vite@6.2.1_@_hf5uinn3urlsbelld7h44mswdi/node_modules/vike/dist/esm/node/runtime/renderPage.js:197:22)
    at renderPage (file:///Users/xxxx/yyyy/node_modules/.pnpm/vike@0.4.224_react-streaming@0.3.48_react-dom@19.0.0_react@19.0.0__react@19.0.0__vite@6.2.1_@_hf5uinn3urlsbelld7h44mswdi/node_modules/vike/dist/esm/node/runtime/renderPage.js:35:5)
    at Object.<anonymous> (file:///Users/xxxx/yyyyr/vike-handler.ts:1:392)
    at Object.universalHandlerExpress (file:///Users/xxxx/yyyy/node_modules/.pnpm/@universal-middleware+express@0.4.8/node_modules/@universal-middleware/express/dist/index.js:285:53)
    at Layer.handle [as handle_request] (/Users/xxxx/yyyynode_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/xxxx/yyyy/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/route.js:149:13)
    at next (/Users/xxxx/yyyy/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/route.js:145:7)
```
This PR is aimed at adding safe operations to decodeURI.