### PR TITLE
feat: `pageContext.runtime` (vike-server)

### DIFF
--- a/vike/node/runtime/universal-middleware.ts
+++ b/vike/node/runtime/universal-middleware.ts
@@ -5,7 +5,13 @@ export default async function universalVikeHandler(
   context: Record<string, unknown>,
   runtime: Record<string, unknown>
 ) {
-  const pageContextInit = { ...context, ...runtime, runtime, urlOriginal: request.url, headersOriginal: request.headers }
+  const pageContextInit = {
+    ...context,
+    ...runtime,
+    runtime,
+    urlOriginal: request.url,
+    headersOriginal: request.headers
+  }
   const pageContext = await renderPage(pageContextInit)
   const response = pageContext.httpResponse
   const readable = response.getReadableWebStream()

--- a/vike/node/runtime/universal-middleware.ts
+++ b/vike/node/runtime/universal-middleware.ts
@@ -5,7 +5,7 @@ export default async function universalVikeHandler(
   context: Record<string, unknown>,
   runtime: Record<string, unknown>
 ) {
-  const pageContextInit = { ...context, ...runtime, urlOriginal: request.url, headersOriginal: request.headers }
+  const pageContextInit = { ...context, runtime, urlOriginal: request.url, headersOriginal: request.headers }
   const pageContext = await renderPage(pageContextInit)
   const response = pageContext.httpResponse
   const readable = response.getReadableWebStream()

--- a/vike/node/runtime/universal-middleware.ts
+++ b/vike/node/runtime/universal-middleware.ts
@@ -5,7 +5,7 @@ export default async function universalVikeHandler(
   context: Record<string, unknown>,
   runtime: Record<string, unknown>
 ) {
-  const pageContextInit = { ...context, runtime, urlOriginal: request.url, headersOriginal: request.headers }
+  const pageContextInit = { ...context, ...runtime, runtime, urlOriginal: request.url, headersOriginal: request.headers }
   const pageContext = await renderPage(pageContextInit)
   const response = pageContext.httpResponse
   const readable = response.getReadableWebStream()


### PR DESCRIPTION
https://vike.dev/server#custom-pagecontext

>The runtime object is also available at pageContext.runtime. 