### PR TITLE
fix: do not close web stream prematurly

### DIFF
--- a/vike/node/runtime/html/renderHtml.ts
+++ b/vike/node/runtime/html/renderHtml.ts
@@ -134,7 +134,12 @@ async function renderHtmlStream(
       return injectAtStreamAfterFirstChunk()
     }
   }
+  let resume = () => {}
+  if (isStreamFromReactStreamingPackage(streamOriginal)) {
+    resume = streamOriginal.doNotClose()
+  }
   const streamWrapper = await processStream(streamOriginal, processStreamOptions)
+  resume()
   return streamWrapper
 }
 


### PR DESCRIPTION
@brillout Vike wasn't using `doNotClose`, which is what caused [this issue](https://github.com/vikejs/vike-server/issues/119).
I tested the fix with Hono, Express and Fastify, they seem to always work as intended now.

Prior to this fix, calls to `injectToStream` would potentially be dropped.