### PR TITLE
fix: fix pre-render force exit assert (fix #2475)

### DIFF
--- a/vike/node/api/build.ts
+++ b/vike/node/api/build.ts
@@ -34,8 +34,10 @@ async function build(options: APIOptions = {}): Promise<{}> {
     //    > We purposely don't start the pre-rendering in this `build()` function but in a Rollup hook instead.
     //    > Rationale: https://github.com/vikejs/vike/issues/2123
     await buildVite(viteConfigFromUserEnhanced)
+
     // After pre-rendering, when using the Vike CLI, the process is forcefully exited at the end of the buildVite() call above.
-    if (isVikeCli() && wasPrerenderRun()) assert(false)
+    const prerenderTrigger = wasPrerenderRun()
+    if (isVikeCli() && prerenderTrigger && prerenderTrigger !== 'prerender()') assert(false)
   }
 
   return {

--- a/vike/node/prerender/context.ts
+++ b/vike/node/prerender/context.ts
@@ -6,7 +6,11 @@ export { setWasPrerenderRun }
 import type { VikeConfigInternal } from '../vite/shared/resolveVikeConfigInternal.js'
 import { getGlobalObject } from '../../utils/getGlobalObject.js'
 import { resolvePrerenderConfigGlobal } from './resolvePrerenderConfig.js'
-const globalObject = getGlobalObject<{ isDisabled?: true; wasPrerenderRun?: true }>('prerender/context.ts', {})
+import type { PrerenderTrigger } from './runPrerender.js'
+const globalObject = getGlobalObject<{ isDisabled?: true; wasPrerenderRun?: PrerenderTrigger }>(
+  'prerender/context.ts',
+  {}
+)
 
 function isPrerenderAutoRunEnabled(vikeConfig: VikeConfigInternal) {
   const prerenderConfigGlobal = resolvePrerenderConfigGlobal(vikeConfig)
@@ -23,9 +27,9 @@ function temp_disablePrerenderAutoRun() {
   globalObject.isDisabled = true
 }
 
-function wasPrerenderRun(): boolean {
-  return !!globalObject.wasPrerenderRun
+function wasPrerenderRun() {
+  return globalObject.wasPrerenderRun
 }
-function setWasPrerenderRun(): void {
-  globalObject.wasPrerenderRun = true
+function setWasPrerenderRun(trigger: PrerenderTrigger): void {
+  globalObject.wasPrerenderRun = trigger
 }

--- a/vike/node/prerender/runPrerender.ts
+++ b/vike/node/prerender/runPrerender.ts
@@ -1,6 +1,7 @@
 export { runPrerender }
 export type { PrerenderOptions }
 export type { PrerenderContextPublic }
+export type { PrerenderTrigger }
 
 // Failed attempt to run this file (i.e. pre-rendering) in a separate process: https://github.com/vikejs/vike/commit/48feda87012115b32a5c9701da354cb8c138dfd2
 // - The issue is that prerenderContext needs to be serialized for being able to pass it from the child process to the parent process.
@@ -138,8 +139,9 @@ type PrerenderOptions = APIOptions & {
   base?: string
 }
 
-async function runPrerender(options: PrerenderOptions = {}, trigger: '$ vike prerender' | 'prerender()' | 'auto-run') {
-  setWasPrerenderRun()
+type PrerenderTrigger = '$ vike prerender' | 'prerender()' | 'auto-run'
+async function runPrerender(options: PrerenderOptions = {}, trigger: PrerenderTrigger) {
+  setWasPrerenderRun(trigger)
   checkOutdatedOptions(options)
   onSetupPrerender()
   setGlobalContext_isPrerendering()


### PR DESCRIPTION
Failed attempt to run pre-rendering in a separate process: https://github.com/vikejs/vike/commit/48feda87012115b32a5c9701da354cb8c138dfd2.

- The issue is that prerenderContext needs to be serialized for being able to pass it from the child process to the parent process.
- The prerenderContext is used by vike-vercel
