### PR TITLE
fix: ensure proper replacement of __VIKE__IS_NON_RUNNABLE_DEV

### DIFF
--- a/packages/vike/node/vite/plugins/pluginNonRunnableDev.ts
+++ b/packages/vike/node/vite/plugins/pluginNonRunnableDev.ts
@@ -46,13 +46,14 @@ function pluginNonRunnableDev(): Plugin {
     },
     transform(code, id) {
       if (!config._isDev) return
-      if (id !== distFileIsNonRunnableDev && id !== distFileGlobalContext) return
+      const idWithoutHash = id.split('?')[0]!;
+      if (idWithoutHash !== distFileIsNonRunnableDev && idWithoutHash !== distFileGlobalContext) return
       if (isRunnableDevEnvironment(this.environment)) return
       const { magicString, getMagicStringResult } = getMagicString(code, id)
-      if (id === distFileIsNonRunnableDev) {
+      if (idWithoutHash === distFileIsNonRunnableDev) {
         magicString.replaceAll('__VIKE__IS_NON_RUNNABLE_DEV', JSON.stringify(true))
       }
-      if (id === distFileGlobalContext) {
+      if (idWithoutHash === distFileGlobalContext) {
         magicString.replaceAll('__VIKE__DYNAMIC_IMPORT', 'import')
       }
       return getMagicStringResult()


### PR DESCRIPTION
While working on Photon + Cloudflare + Vike, I noticed that Cloudflare can append hash IDs to certain files, which sometimes prevents them from matching in `vike:pluginNonRunnableDev` hook.

```js
{
  id: '/home/magne/workspace/vike-server/node_modules/.pnpm/vike@0.4.238_react-streaming@0.4.3_react-dom@19.1.1_react@19.1.1__react@19.1.1__vite@7._26f16f1ae2bc3a83a214ce6877b50b7a/node_modules/vike/dist/esm/utils/isNonRunnableDev.js?v=e9453e59',
  distFileIsNonRunnableDev: '/home/magne/workspace/vike-server/node_modules/.pnpm/vike@0.4.238_react-streaming@0.4.3_react-dom@19.1.1_react@19.1.1__react@19.1.1__vite@7._26f16f1ae2bc3a83a214ce6877b50b7a/node_modules/vike/dist/esm/utils/isNonRunnableDev.js'
}
```