### PR TITLE
fix: include canonical link in prerendered redirect

### DIFF
--- a/packages/vike/node/prerender/runPrerender.ts
+++ b/packages/vike/node/prerender/runPrerender.ts
@@ -1174,7 +1174,8 @@ async function prerenderRedirects(
 }
 function getRedirectHtml(urlTarget: string) {
   const urlTargetSafe = escapeHtml(urlTarget)
-  // To test it: /test/playground => http://localhost:3000/download
+  // - Test: /test/playground => http://localhost:3000/download
+  // - Adding `<link rel="canonical">` for SEO, see https://github.com/vikejs/vike/pull/2711
   const htmlString = `<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/packages/vike/node/prerender/runPrerender.ts
+++ b/packages/vike/node/prerender/runPrerender.ts
@@ -1180,6 +1180,7 @@ function getRedirectHtml(urlTarget: string) {
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="refresh" content="0;url=${urlTargetSafe}">
+  <link rel="canonical" href="${urlTargetSafe}" />
   <title>Redirect ${urlTargetSafe}</title>
   <style>body{opacity:0}</style>
   <noscript>

--- a/test/playground/pages/e2e-test.ts
+++ b/test/playground/pages/e2e-test.ts
@@ -87,6 +87,7 @@ async function testRedirect(source: string, target: string, isDev: boolean) {
   } else {
     const html = await resp.text()
     expect(html).toContain(`<meta http-equiv="refresh" content="0;url=${target}">`)
+    expect(html).toContain(`<link rel="canonical" href="${target}" />`)
     expect(isDev).toBe(false)
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to how HTML redirects are handled in the prerendering logic, for better SEO

* Added a `<link rel="canonical" href="..."/>` tag to the HTML generated for redirects in `getRedirectHtml`, which helps search engines recognize the canonical destination of the redirect.

* Updated the end-to-end test in `e2e-test.ts` to verify the presence of the canonical link in redirect HTML, ensuring the new behavior is covered by tests.

## Prior Art

Other site generators / frameworks add the canonical link. See:

- https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/alias.html
- https://github.com/jekyll/jekyll-redirect-from/blob/master/lib/jekyll-redirect-from/redirect.html