### PR TITLE
Update docs for change of vike-server/serve() options

### DIFF
--- a/docs/pages/vike-server/+Page.mdx
+++ b/docs/pages/vike-server/+Page.mdx
@@ -210,7 +210,7 @@ serve(app, {
   },
 
   // Called once the server is created
-  onServer(server) {
+  onCreate(server) {
     // `server` type depends on your runtime:
     //   Node.js:  Server ('node:http') by default. It's an HTTPS or HTTP2 server
     //             if the `createServer` option was provided (see below).


### PR DESCRIPTION
Reflects the fix from vike-server [v1.0.10](https://github.com/vikejs/vike-server/compare/v1.0.9...v1.0.10) (fix: rename onServer hook to onCreate #95)