### PR TITLE
Bug: throw redirect in onBeforeRenderClient breaks back button

### DIFF
--- a/test/playground/pages/redirect/+Page.tsx
+++ b/test/playground/pages/redirect/+Page.tsx
@@ -1,0 +1,3 @@
+export function Page(){
+
+}

--- a/test/playground/pages/redirect/+onBeforeRenderClient.ts
+++ b/test/playground/pages/redirect/+onBeforeRenderClient.ts
@@ -1,0 +1,8 @@
+export { onBeforeRenderClient }
+
+import type { PageContextClient } from 'vike/types'
+import { redirect } from 'vike/abort'
+
+async function onBeforeRenderClient(pageContext: PageContextClient) {
+  throw redirect("/about")
+}

--- a/test/playground/pages/redirect/e2e-test.ts
+++ b/test/playground/pages/redirect/e2e-test.ts
@@ -1,0 +1,19 @@
+export { testRedirect }
+
+import { test, page, getServerUrl } from '@brillout/test-e2e'
+import { expectUrl } from '../../../utils'
+
+function testRedirect() {
+  test('redirects to /about and works with back button', async () => {
+    await page.goto(getServerUrl() + '/')
+    await expectUrl('/')
+
+    await page.click('a[href="/redirect"]')
+    await expectUrl('/about')
+
+    await page.goBack()
+    await expectUrl('/')
+  })
+
+  return
+}

--- a/test/playground/testRun.ts
+++ b/test/playground/testRun.ts
@@ -27,6 +27,7 @@ import { testHistoryPushState } from './pages/pushState/e2e-test'
 import { testStarWars } from './pages/star-wars/e2e-test'
 import { testDefaultAndClearSuffixes } from './pages/config-meta/default-clear/e2e-test'
 import { isCI, skip } from '@brillout/test-e2e'
+import { testRedirect } from './pages/redirect/e2e-test'
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url))
 
@@ -57,4 +58,5 @@ function testRun(cmd: 'npm run dev' | 'npm run preview' | 'npm run preview:build
   testDefaultAndClearSuffixes()
   testHistoryPushState()
   testStarWars()
+  testRedirect()
 }


### PR DESCRIPTION
I noticed that `throw redirect()` in `onBeforeRenderClient` breaks back button behavior. It works fine in `onBeforeRender` / `data`. I believe this may be because the browser has changed URL already by the time `onBeforeRenderClient` is called.

Opened this PR with demonstrative failing spec.

Is this intentional? Could not find clear guidance in docs on where `throw redirect()` is allowed