### PR TITLE
chore: only run discord webhook step if webhook url defined

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -14,7 +14,7 @@ jobs:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
     steps:
       - name: Push the notification using Discord webhook
-        # Ideally this would be combined with the prior if, but the env isnt accessible at that level
+        # Skip pull requests. (This condition cannot be moved to the `if:` above because the secret isn't available there.)
         if: env.DISCORD_WEBHOOK != ''
         env:
           # 🟢 has poor compatibility: https://www.unicompat.com/1F7E2


### PR DESCRIPTION
Disables the step to run the discord curl call if the webhook URL is undefined