### PR TITLE
Update EdgeOne Pages link to new URL

### DIFF
--- a/docs/pages/edgeone-pages/+Page.mdx
+++ b/docs/pages/edgeone-pages/+Page.mdx
@@ -1,7 +1,7 @@
 import { StaticHostDocIntro, StaticHostDocOutro, StaticHostDocStrategies } from '../../components/static-host'
 import { Link } from '@brillout/docpress'
 
-[EdgeOne Pages](https://edgeone.ai/products/pages) is a deployment platform developed by [Tencent](https://en.wikipedia.org/wiki/Tencent). It supports server capabilities such as <Link href="/ssr">SSR</Link> and <Link href="/stream">HTML streaming</Link>.
+[EdgeOne Pages](https://pages.edgeone.ai/) is a deployment platform developed by [Tencent](https://en.wikipedia.org/wiki/Tencent). It supports server capabilities such as <Link href="/ssr">SSR</Link> and <Link href="/stream">HTML streaming</Link>.
 
 See also: [EdgeOne Pages > Vike](https://pages.edgeone.ai/document/framework-vike).
 


### PR DESCRIPTION
Browsing the page again, this link https://pages.edgeone.ai/ is more suitable as an introductory page for EdgeOne Pages. Please approve and merge it again.