### PR TITLE
fix: duplicate URL verification on pre-rendering

### DIFF
--- a/packages/vike/src/node/prerender/runPrerender.ts
+++ b/packages/vike/src/node/prerender/runPrerender.ts
@@ -448,11 +448,11 @@ async function callOnBeforePrerenderStartHooks(
   // If duplicate URL is found an error will be issued
   const pageContextsByUrl: Record<string, PageContextPrerendered> = {}
   for (const pageContext of prerenderContext.pageContexts) {
+    assert(pageContext._providedByHook)
     const urlNormalized = normalizeUrl(pageContext.urlOriginal)
     const pageContextSameUrl = pageContextsByUrl[urlNormalized]
     if (pageContextSameUrl) {
       assert(pageContextSameUrl._providedByHook)
-      assert(pageContext._providedByHook)
       const { hookName, hookFilePath } = pageContext._providedByHook
       const providedTwice =
         hookFilePath === pageContextSameUrl._providedByHook.hookFilePath


### PR DESCRIPTION
When a single 'onBeforePrerenderStart' hook pass duplicated URL entries the part of the 'callOnBeforePrerenderStartHooks' that verify duplicated URL by iterating through the current 'pageContexts' array don't complain with an error.

After inspecting the content of the 'pageContexts', I noticed the array would still be empty when checking for existing URLs. The concurrent access to the 'pageContexts' and the context switching happening before this array is populated made this array appear empty for a number of page entries that tries to check its content.

Before this commit the URL generation, URL duplication check and pageContext generation was handled in a single Promise. With this commit the URL generation is handled in a separate set of Promises. Based on the result of the URL generation the duplicate URLs are checked synchronously. The 'pageContext' are then generated on another separate Promise which populates the 'pageContexts' array.

This allows to not check the content of the 'pageContexts' array while populating it.

I didn't find any place where I can add tests for the duplicate URL. Please let me know if I can add one somewhere.