### PR TITLE
DEVOPS-5836: Adds .claude/settings.local.json and mcp-vscode.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules/
 # https://github.com/vikejs/vike/pull/1997
 /.pnpm-store/
+.claude/settings.local.json
+mcp-vscode.json


### PR DESCRIPTION
## Summary
Adds `.claude/settings.local.json` and `mcp-vscode.json` to `.gitignore`.

`.claude/settings.local.json` is the user-specific local override file for Claude Code and should not be committed. We are intentionally not ignoring the entire `.claude/` directory as shared project config may exist there.

`mcp-vscode.json` is the VS Code MCP configuration file that should not be committed.

Fixes DEVOPS-5836