### PR TITLE
Update title for Universal Deploy heading

### DIFF
--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -758,7 +758,7 @@ const headings = [
   },
   {
     level: 2,
-    title: 'Introducing Universal Deploy',
+    title: 'Introducing Universal Deploy `+server.js`',
     url: '/blog/universal-deploy',
   },
   {

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -758,7 +758,7 @@ const headings = [
   },
   {
     level: 2,
-    title: 'Introducing Universal Deploy `+server.js`',
+    title: 'Introducing Universal Deploy (`+server`)',
     url: '/blog/universal-deploy',
   },
   {


### PR DESCRIPTION
I was looking for the release blog for "+server.js" but couldn't find it. Then I noticed that it is called "Universal Deploy" good framing but I was serching for "+server.js" so I couldn't find it at first.

### What I changed

- Changed the headline in the navigation

Introducing Universal Deploy -> Introducing Universal Deploy `+server.js`