### PR TITLE
remove daisyui

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,6 @@
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^5.0.0",
-    "daisyui": "^5.5.14",
     "gsap": "^3.14.2",
     "lucide-react": "^0.563.0",
     "react": "^19.2.4",

--- a/docs/pages/index/tailwind.css
+++ b/docs/pages/index/tailwind.css
@@ -21,16 +21,48 @@
   --color-bg: oklch(0.9702 0 0);
   --color-white: #fdfdfd;
 
-  /* daisyUI specific */
-  --d-color-info: oklch(60% 0.126 221.723);
-  --d-color-success: oklch(62% 0.194 149.214);
-  --d-color-warning: oklch(80% 0.199 91.936);
-  --d-color-error: oklch(57% 0.245 27.325);
+  --theme-base-100: var(--color-grey-300);
+  --theme-base-200: var(--color-grey-400);
+  --theme-base-300: var(--color-bg);
+  --theme-base-content: var(--color-content);
 
-  /* define ui variant colors while re-using pregenerated daisy variants */
-  --d-color-primary: #13ad6a;
-  --d-color-secondary: #4198db;
-  --d-color-accent: #b5721b;
+  --theme-primary: #13ad6a;
+  --theme-primary-content: var(--color-bg);
+  --theme-secondary: #4198db;
+  --theme-secondary-content: var(--color-bg);
+  --theme-accent: #b5721b;
+  --theme-accent-content: var(--color-bg);
+  --theme-neutral: var(--color-content);
+  --theme-neutral-content: var(--color-bg);
+  --theme-info: oklch(60% 0.126 221.723);
+  --theme-info-content: var(--color-bg);
+  --theme-success: oklch(62% 0.194 149.214);
+  --theme-success-content: var(--color-bg);
+  --theme-warning: oklch(80% 0.199 91.936);
+  --theme-warning-content: var(--color-black);
+  --theme-error: oklch(57% 0.245 27.325);
+  --theme-error-content: var(--color-bg);
+
+  --color-base-100: var(--theme-base-100);
+  --color-base-200: var(--theme-base-200);
+  --color-base-300: var(--theme-base-300);
+  --color-base-content: var(--theme-base-content);
+  --color-primary: var(--theme-primary);
+  --color-primary-content: var(--theme-primary-content);
+  --color-secondary: var(--theme-secondary);
+  --color-secondary-content: var(--theme-secondary-content);
+  --color-accent: var(--theme-accent);
+  --color-accent-content: var(--theme-accent-content);
+  --color-neutral: var(--theme-neutral);
+  --color-neutral-content: var(--theme-neutral-content);
+  --color-info: var(--theme-info);
+  --color-info-content: var(--theme-info-content);
+  --color-success: var(--theme-success);
+  --color-success-content: var(--theme-success-content);
+  --color-warning: var(--theme-warning);
+  --color-warning-content: var(--theme-warning-content);
+  --color-error: var(--theme-error);
+  --color-error-content: var(--theme-error-content);
 
   /* colors for hooks */
   --color-onBeforeRenderClient: oklch(0.819 0.0686 339.84);
@@ -55,60 +87,36 @@
   --color-onRenderHtml-hex: #6fbe59;
   --color-onAfterRenderHtml: oklch(0.8549 0.1547 94.42);
   --color-onAfterRenderHtml-hex: #f0cd42;
-}
-
-@plugin "daisyui" {
-  root: '#tailwind-portal';
-  /* leave this here - seems playwright or other headless browsers are not able to support @property css attributes */
-  exclude: properties;
-  themes: vike --default;
-}
-
-@plugin "daisyui/theme" {
-  name: 'vike';
-  --color-base-100: var(--color-grey-300);
-  --color-base-200: var(--color-grey-400);
-  --color-base-300: var(--color-bg);
-  --color-base-content: var(--color-content);
-
-  /* flexibility - green */
-  --color-primary: var(--d-color-primary);
-  --color-primary-content: var(--color-bg);
-
-  /* stability - blue */
-  --color-secondary: var(--d-color-secondary);
-  --color-secondary-content: var(--color-bg);
-
-  /* dx - orange */
-  --color-accent: var(--d-color-accent);
-  --color-accent-content: var(--color-bg);
-
-  --color-neutral: var(--color-content);
-  --color-neutral-content: var(--color-bg);
-  --color-info: var(--d-color-info);
-  --color-info-content: var(--color-bg);
-  --color-success: var(--d-color-success);
-  --color-success-content: var(--color-bg);
-  --color-warning: var(--d-color-warning);
-  --color-warning-content: var(--color-black);
-  --color-error: var(--d-color-error);
-  --color-error-content: var(--color-bg);
-  /* .rounded-selector = 0.25rem */
   --radius-selector: 0.25rem;
-  /* .rounded-field = 0.5rem */
   --radius-field: 0.35rem;
-  /* .rounded-box = 1rem */
   --radius-box: 0.75rem;
-  /* 4px */
-  --size-selector: 0.25rem;
-  --size-field: 0.25rem;
-  --border: 1.5px;
-
-  --depth: 0;
-  --noise: 0;
 }
 
 @layer base {
+  #tailwind-portal[data-theme='vike'] {
+    --theme-base-100: var(--color-grey-300);
+    --theme-base-200: var(--color-grey-400);
+    --theme-base-300: var(--color-bg);
+    --theme-base-content: var(--color-content);
+    --theme-primary: #13ad6a;
+    --theme-primary-content: var(--color-bg);
+    --theme-secondary: #4198db;
+    --theme-secondary-content: var(--color-bg);
+    --theme-accent: #b5721b;
+    --theme-accent-content: var(--color-bg);
+    --theme-neutral: var(--color-content);
+    --theme-neutral-content: var(--color-bg);
+    --theme-info: oklch(60% 0.126 221.723);
+    --theme-info-content: var(--color-bg);
+    --theme-success: oklch(62% 0.194 149.214);
+    --theme-success-content: var(--color-bg);
+    --theme-warning: oklch(80% 0.199 91.936);
+    --theme-warning-content: var(--color-black);
+    --theme-error: oklch(57% 0.245 27.325);
+    --theme-error-content: var(--color-bg);
+    --theme-border-size: 1.5px;
+  }
+
   #tailwind-portal,
   #tailwind-portal *,
   #tailwind-portal ::before,
@@ -181,6 +189,166 @@
 
   #tailwind-portal :where(select) {
     @apply !text-sm !w-fit border border-grey;
+  }
+}
+
+@layer components {
+  /* Local DaisyUI compatibility subset used by the docs site. */
+  #tailwind-portal .rounded-field {
+    border-radius: var(--radius-field);
+  }
+
+  #tailwind-portal .rounded-box {
+    border-radius: var(--radius-box);
+  }
+
+  #tailwind-portal .join {
+    display: inline-flex;
+    align-items: stretch;
+  }
+
+  #tailwind-portal .join > .join-item {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  #tailwind-portal .join > .join-item:first-child:not(:last-child) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  #tailwind-portal .join > .join-item:last-child:not(:first-child) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  #tailwind-portal .join > .join-item:not(:first-child):not(:last-child) {
+    border-radius: 0;
+  }
+
+  #tailwind-portal .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 1.25rem;
+    padding-inline: 0.5rem;
+    border: 1px solid currentColor;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  #tailwind-portal .badge-xs {
+    min-height: 1rem;
+    padding-inline: 0.375rem;
+    font-size: 0.65rem;
+  }
+
+  #tailwind-portal .badge-grey {
+    background-color: var(--color-grey-300);
+    color: var(--color-grey);
+  }
+
+  #tailwind-portal .btn {
+    --btn-color: var(--theme-neutral);
+    --btn-content: var(--theme-neutral-content);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 2.75rem;
+    padding-inline: 1rem;
+    border: var(--theme-border-size) solid var(--btn-color);
+    border-radius: var(--radius-field);
+    background-color: var(--btn-color);
+    color: var(--btn-content);
+    font-weight: 600;
+    line-height: 1.2;
+    text-decoration: none;
+    white-space: nowrap;
+    transition:
+      color 150ms ease,
+      background-color 150ms ease,
+      border-color 150ms ease,
+      opacity 150ms ease;
+  }
+
+  #tailwind-portal .btn-neutral {
+    --btn-color: var(--theme-neutral);
+    --btn-content: var(--theme-neutral-content);
+  }
+
+  #tailwind-portal .btn-primary {
+    --btn-color: var(--theme-primary);
+    --btn-content: var(--theme-primary-content);
+  }
+
+  #tailwind-portal .btn-secondary {
+    --btn-color: var(--theme-secondary);
+    --btn-content: var(--theme-secondary-content);
+  }
+
+  #tailwind-portal .btn-accent {
+    --btn-color: var(--theme-accent);
+    --btn-content: var(--theme-accent-content);
+  }
+
+  #tailwind-portal .btn-outline {
+    background-color: transparent;
+    color: var(--btn-color);
+  }
+
+  #tailwind-portal .btn-outline:hover,
+  #tailwind-portal .btn-outline:focus-visible {
+    background-color: var(--btn-color);
+    color: var(--btn-content);
+  }
+
+  #tailwind-portal .btn-ghost {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--btn-color);
+  }
+
+  #tailwind-portal .btn-ghost:hover,
+  #tailwind-portal .btn-ghost:focus-visible {
+    background-color: color-mix(in oklab, var(--btn-color) 10%, transparent);
+  }
+
+  #tailwind-portal .btn-sm {
+    min-height: 2rem;
+    padding-inline: 0.75rem;
+    font-size: 0.875rem;
+  }
+
+  #tailwind-portal .btn-md {
+    min-height: 2.75rem;
+    padding-inline: 1rem;
+    font-size: 0.875rem;
+  }
+
+  #tailwind-portal .btn-lg {
+    min-height: 3.5rem;
+    padding-inline: 1.25rem;
+    font-size: 1rem;
+  }
+
+  @media (width >= 40rem) {
+    #tailwind-portal .sm\:btn-lg {
+      min-height: 3.5rem;
+      padding-inline: 1.25rem;
+      font-size: 1rem;
+    }
+  }
+
+  @media (width >= 48rem) {
+    #tailwind-portal .md\:btn-lg {
+      min-height: 3.5rem;
+      padding-inline: 1.25rem;
+      font-size: 1rem;
+    }
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.0
         version: 5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
-      daisyui:
-        specifier: ^5.5.14
-        version: 5.5.19
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
@@ -4931,6 +4928,9 @@ packages:
   '@vite-plugin-vercel/schemas@1.1.0':
     resolution: {integrity: sha512-Vl7r+Itu7oS2/Ypo0wyPOB87AHdoU4EsmDNkSjTeKc7wl9xxHafCMd2Uc9qLOcX0tlDtcwJkjvB4A//ObqL8/w==}
 
+  '@vite-plugin-vercel/schemas@1.1.1':
+    resolution: {integrity: sha512-Gkk5QUET2Rj6K0faYoYSh+R9D1XkqHJS/Eoh9emBYYimfKibtiFccVL37P4O6DBtosxoXXvxxgYT0ahVz3XF3g==}
+
   '@vitejs/plugin-react-swc@3.11.0':
     resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
     peerDependencies:
@@ -5703,9 +5703,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  daisyui@5.5.19:
-    resolution: {integrity: sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -9968,7 +9965,7 @@ snapshots:
       '@vercel/build-utils': 13.8.1
       '@vercel/nft': 1.3.2(rollup@4.43.0)
       '@vercel/routing-utils': 5.3.1
-      '@vite-plugin-vercel/schemas': 1.1.0
+      '@vite-plugin-vercel/schemas': 1.1.1
       convert-route: 0.1.2
       esbuild: 0.27.3
       fast-glob: 3.3.3
@@ -11063,6 +11060,10 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  '@vite-plugin-vercel/schemas@1.1.1':
+    dependencies:
+      zod: 4.4.3
+
   '@vitejs/plugin-react-swc@3.11.0(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.27
@@ -12082,8 +12083,6 @@ snapshots:
   csstype@2.6.21: {}
 
   csstype@3.2.3: {}
-
-  daisyui@5.5.19: {}
 
   data-uri-to-buffer@4.0.1: {}
 


### PR DESCRIPTION
## Problem

Remove the `daisyui` dependency from the docs app without changing the rendered website, behavior, or theming contract.

## Current state

- `docs/package.json` depends on `daisyui`.
- `docs/pages/index/tailwind.css` uses `@plugin "daisyui"` and `@plugin "daisyui/theme"` to:
  - scope DaisyUI to `#tailwind-portal`
  - define the custom `vike` theme
  - provide DaisyUI component/semantic classes such as `btn`, `badge`, `join`, `rounded-box`, `rounded-field`, `bg-base-*`, `text-base-content`, `text-primary`, `bg-primary`, and related color/radius tokens
- The landing page under `docs/pages/index/**` uses those DaisyUI classes across many components.
- `docs/pages/banner/Banner.tsx` also imports the same Tailwind stylesheet and keeps the same `#tailwind-portal` / `data-theme="vike"` contract.
- There is also docs content and navigation for `/daisyui` (`docs/pages/daisyui/+Page.mdx`, `docs/headings.ts`, links from other docs pages).

## Proposed approach

Create a local DaisyUI compatibility layer inside the docs app, then remove the package.

1. Replace DaisyUI plugin usage in `docs/pages/index/tailwind.css` with local theme variables and custom utilities/components that reproduce only the DaisyUI surface the docs site actually uses.
2. Preserve the existing `#tailwind-portal` and `data-theme="vike"` contract so page code does not need behavioral changes.
3. Audit all DaisyUI-derived classes used by the docs app and either:
   - keep the class names and implement them locally, or
   - rewrite call sites to pure Tailwind utilities when that is simpler and provably equivalent.
4. Remove `daisyui` from `docs/package.json`, then refresh the lockfile.
5. Build the docs site and compare for regressions, especially the landing page and banner surfaces.

## Suggested implementation shape

- **Preferred:** keep the existing class names (`btn`, `btn-primary`, `badge`, `join`, `rounded-box`, `bg-base-300`, etc.) and re-implement only the subset the docs actually uses. This minimizes React/MDX churn and reduces the risk of accidental UX changes.
- Recreate DaisyUI theme tokens as plain CSS custom properties under `#tailwind-portal[data-theme='vike']`.
- Recreate only the used component classes:
  - button variants and sizes
  - badge variants/sizes
  - join / join-item
  - radius helpers such as `rounded-box` and `rounded-field`
  - semantic color aliases (`bg-base-*`, `text-base-content`, `text-primary`, `bg-secondary`, etc.) if Tailwind no longer generates them once DaisyUI is removed

## Risks / considerations

- The package removal itself is easy; preserving identical visuals is the real work.
- Some current classes are DaisyUI semantic tokens rather than stock Tailwind utilities, so they will disappear unless recreated.
- The banner and landing page both depend on the same stylesheet contract, so they need to be checked together.
- Scope assumption: keep the `/daisyui` docs page and existing links unchanged as informational docs; only remove DaisyUI as an implementation dependency of the docs app.

## Todos

1. Inventory all DaisyUI-provided classes/tokens actually used by the docs app.
2. Design a local replacement stylesheet that preserves the `vike` theme and `#tailwind-portal` scoping.
3. Implement the compatibility layer and update any call sites that cannot be preserved safely as-is.
4. Remove the dependency and regenerate the lockfile.
5. Build and visually review the docs pages that currently depend on DaisyUI styling.
