### PR TITLE
fix: write transpiled config files to node_modules temp dir

### DIFF
--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/pointerImports.spec.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/pointerImports.spec.ts
@@ -5,24 +5,58 @@ function t(code: string) {
   return transformPointerImports(code, '/fake-file.js', 'all', true)
 }
 
+function tWithMap(code: string, pointerImports: Record<string, boolean>) {
+  return transformPointerImports(code, '/fake-file.js', pointerImports, true)
+}
+
 describe('transformPointerImports()', () => {
   it('basics', () => {
     expect(t('bla')).toMatchInlineSnapshot(`null`)
     expect(t("import { something } from './bla.js'")).toMatchInlineSnapshot(
-      `"const something = '​import:./bla.js:something';
-"`,
+      `"const something = '​import:./bla.js:something';"`,
     )
-    expect(t("import def from './bla.js'")).toMatchInlineSnapshot(`"const def = '​import:./bla.js:default';
-"`)
+    expect(t("import def from './bla.js'")).toMatchInlineSnapshot(`"const def = '​import:./bla.js:default';"`)
   })
   it('removes unused imports', () => {
     expect(t("import './style.css'")).toMatchInlineSnapshot(`""`)
     expect(t("import './script.js'")).toMatchInlineSnapshot(`""`)
   })
   it('import as', () => {
-    expect(t("import { bla as blu } from './bla.js'")).toMatchInlineSnapshot(`"const blu = '​import:./bla.js:bla';
-"`)
-    expect(t("import * as blo from './bla.js'")).toMatchInlineSnapshot(`"const blo = '​import:./bla.js:*';
-"`)
+    expect(t("import { bla as blu } from './bla.js'")).toMatchInlineSnapshot(`"const blu = '​import:./bla.js:bla';"`)
+    expect(t("import * as blo from './bla.js'")).toMatchInlineSnapshot(`"const blo = '​import:./bla.js:*';"`)
+  })
+  it('does not add lines when transforming pointer imports', () => {
+    const code = [
+      "import { createRequire } from 'node:module'",
+      "import { something } from './bla.js'",
+      "throw new Error('probe')",
+    ].join('\n')
+
+    const codeMod = tWithMap(code, {
+      'node:module': false,
+      './bla.js': true,
+    })
+
+    expect(codeMod).toBeTruthy()
+    expect(codeMod!.split('\n')).toHaveLength(code.split('\n').length)
+  })
+  it('preserves non-pointer imports', () => {
+    expect(
+      tWithMap(
+        [
+          "import { createRequire } from 'node:module'",
+          "import { something } from './bla.js'",
+          'export { createRequire }',
+        ].join('\n'),
+        {
+          'node:module': false,
+          './bla.js': true,
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "const something = '​import:./bla.js:something';import { createRequire } from 'node:module'
+
+      export { createRequire }"
+    `)
   })
 })

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/pointerImports.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/pointerImports.ts
@@ -44,7 +44,8 @@ function transformPointerImports(
   const spliceOperations: SpliceOperation[] = []
   // Collect all const declarations to prepend at the top, so that they are
   // available before any code runs (import declarations are hoisted but const
-  // is not, so we must place them at the top to avoid TDZ errors).
+  // is not, so we must place them at the top to avoid TDZ errors). We don't add
+  // a newline because this runs after esbuild generated the source map.
   const constDeclarations: string[] = []
 
   // Performance trick
@@ -130,7 +131,7 @@ function transformPointerImports(
   if (constDeclarations.length === 0 && spliceOperations.length === 0) return null
   const codeWithImportsRemoved = spliceMany(code, spliceOperations)
   if (constDeclarations.length === 0) return codeWithImportsRemoved
-  return constDeclarations.join('') + '\n' + codeWithImportsRemoved
+  return constDeclarations.join('') + codeWithImportsRemoved
 }
 function getImports(code: string): ImportDeclaration[] {
   const result = parseSync(code, {

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/transpileAndExecuteFile.spec.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/transpileAndExecuteFile.spec.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { transpileAndExecuteFile } from './transpileAndExecuteFile.js'
+import type { FilePathResolved } from '../../../../types/FilePath.js'
+import type { EsbuildCache } from './transpileAndExecuteFile.js'
+
+const tmpDirs: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  tmpDirs.forEach((tmpDir) => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+  tmpDirs.length = 0
+})
+
+describe('transpileAndExecuteFile()', () => {
+  it('sets source map metadata for runtime errors in the main config file', async () => {
+    const userRootDir = createTmpDir()
+    fs.mkdirSync(path.posix.join(userRootDir, 'node_modules'))
+    const configFilePath = path.posix.join(userRootDir, '+config.ts')
+    fs.writeFileSync(configFilePath, "throw new Error('probe')\n")
+
+    let vikeTempFilePath: string | undefined
+    const writeFileSyncOriginal = fs.writeFileSync
+    const writeFileSync = vi.spyOn(fs, 'writeFileSync')
+    writeFileSync.mockImplementation((file, data, options) => {
+      const filePath = String(file)
+      if (filePath.includes('/node_modules/.vike-temp/+config.ts.build-')) {
+        vikeTempFilePath = filePath
+      }
+      return writeFileSyncOriginal.call(fs, file, data, options)
+    })
+
+    let err: unknown
+    try {
+      await transpileAndExecuteFile(
+        getFilePathResolved(configFilePath, userRootDir),
+        userRootDir,
+        false,
+        getEsbuildCache(),
+      )
+    } catch (err_) {
+      err = err_
+    }
+
+    expect(err).toBeInstanceOf(Error)
+    expect(vikeTempFilePath).toBeDefined()
+    const sourceMap = getInlineSourceMap(writeFileSync.mock.calls, vikeTempFilePath!)
+    expect(sourceMap.sources).toContain(configFilePath)
+    expect(sourceMap.sourceRoot).toBeUndefined()
+  })
+  it('executes transpiled config files from node_modules/.vike-temp with original file-scope values', async () => {
+    const userRootDir = createTmpDir()
+    fs.mkdirSync(path.posix.join(userRootDir, 'node_modules'))
+    const configFilePath = path.posix.join(userRootDir, '+config.ts')
+    fs.writeFileSync(
+      configFilePath,
+      [
+        'export const values = {',
+        '  importMetaUrl: import.meta.url,',
+        '  importMetaDirname: import.meta.dirname,',
+        '  importMetaFilename: import.meta.filename,',
+        '  importMetaMain: import.meta.main,',
+        "  importMetaResolve: import.meta.resolve('./config-data.txt'),",
+        '  dirname: __dirname,',
+        '  filename: __filename,',
+        '}',
+      ].join('\n'),
+    )
+
+    const writtenFiles: string[] = []
+    const writeFileSyncOriginal = fs.writeFileSync
+    const writeFileSync = vi.spyOn(fs, 'writeFileSync')
+    writeFileSync.mockImplementation((file, data, options) => {
+      writtenFiles.push(String(file))
+      return writeFileSyncOriginal.call(fs, file, data, options)
+    })
+
+    const { fileExports } = await transpileAndExecuteFile(
+      getFilePathResolved(configFilePath, userRootDir),
+      userRootDir,
+      false,
+      getEsbuildCache(),
+    )
+
+    expect(writtenFiles.some((file) => file.includes('/node_modules/.vike-temp/+config.ts.build-'))).toBe(true)
+    expect(fileExports.values).toEqual({
+      importMetaUrl: `file://${configFilePath}`,
+      importMetaDirname: userRootDir,
+      importMetaFilename: configFilePath,
+      importMetaMain: false,
+      importMetaResolve: `file://${userRootDir}/config-data.txt`,
+      dirname: userRootDir,
+      filename: configFilePath,
+    })
+  })
+  it('sets source map metadata for runtime errors in bundled relative modules', async () => {
+    const userRootDir = createTmpDir()
+    fs.mkdirSync(path.posix.join(userRootDir, 'node_modules'))
+    const configFilePath = path.posix.join(userRootDir, '+config.ts')
+    const importedFilePath = path.posix.join(userRootDir, 'config-stack-trace-probe.ts')
+    fs.writeFileSync(configFilePath, "import './config-stack-trace-probe'\n")
+    fs.writeFileSync(importedFilePath, "throw new Error('probe')\n")
+
+    let vikeTempFilePath: string | undefined
+    const writeFileSyncOriginal = fs.writeFileSync
+    const writeFileSync = vi.spyOn(fs, 'writeFileSync')
+    writeFileSync.mockImplementation((file, data, options) => {
+      const filePath = String(file)
+      if (filePath.includes('/node_modules/.vike-temp/+config.ts.build-')) {
+        vikeTempFilePath = filePath
+      }
+      return writeFileSyncOriginal.call(fs, file, data, options)
+    })
+
+    let err: unknown
+    try {
+      await transpileAndExecuteFile(
+        getFilePathResolved(configFilePath, userRootDir),
+        userRootDir,
+        false,
+        getEsbuildCache(),
+      )
+    } catch (err_) {
+      err = err_
+    }
+
+    expect(err).toBeInstanceOf(Error)
+
+    expect(vikeTempFilePath).toBeDefined()
+    const sourceMap = getInlineSourceMap(writeFileSync.mock.calls, vikeTempFilePath!)
+    expect(sourceMap.sources).toContain(importedFilePath)
+    expect(sourceMap.sources).toContain(configFilePath)
+    expect(sourceMap.sourceRoot).toBeUndefined()
+  })
+  it('falls back to the next-to-source artifact path when node_modules/.vike-temp cannot be written', async () => {
+    const userRootDir = createTmpDir()
+    fs.mkdirSync(path.posix.join(userRootDir, 'node_modules'))
+    const configFilePath = path.posix.join(userRootDir, '+config.ts')
+    fs.writeFileSync(configFilePath, 'export const value = 42\n')
+
+    const writtenFiles: string[] = []
+    const writeFileSyncOriginal = fs.writeFileSync
+    const writeFileSync = vi.spyOn(fs, 'writeFileSync')
+    writeFileSync.mockImplementation((file, data, options) => {
+      const filePath = String(file)
+      if (filePath.includes('/node_modules/.vike-temp/')) {
+        const err = new Error('read-only node_modules') as NodeJS.ErrnoException
+        err.code = 'EROFS'
+        throw err
+      }
+      writtenFiles.push(filePath)
+      return writeFileSyncOriginal.call(fs, file, data, options)
+    })
+
+    const { fileExports } = await transpileAndExecuteFile(
+      getFilePathResolved(configFilePath, userRootDir),
+      userRootDir,
+      false,
+      getEsbuildCache(),
+    )
+
+    expect(fileExports.value).toBe(42)
+    expect(writtenFiles.some((file) => file.includes('/node_modules/.vike-temp/'))).toBe(false)
+    expect(writtenFiles.some((file) => file.includes('/+config.ts.build-'))).toBe(true)
+  })
+})
+
+function createTmpDir(): string {
+  const tmpDir = fs.mkdtempSync(path.posix.join(os.tmpdir(), 'vike-transpile-test-'))
+  tmpDirs.push(tmpDir)
+  return tmpDir
+}
+
+function getFilePathResolved(filePathAbsoluteFilesystem: string, userRootDir: string): FilePathResolved {
+  const filePathAbsoluteUserRootDir = filePathAbsoluteFilesystem.slice(userRootDir.length)
+  return {
+    filePathAbsoluteFilesystem,
+    filePathToShowToUserResolved: filePathAbsoluteUserRootDir,
+    fileName: path.posix.basename(filePathAbsoluteFilesystem),
+    filePathAbsoluteUserRootDir,
+    importPathAbsolute: null,
+    filePathToShowToUser: filePathAbsoluteUserRootDir,
+    filePathAbsoluteVite: filePathAbsoluteUserRootDir,
+  }
+}
+
+function getEsbuildCache(): EsbuildCache {
+  return {
+    transpileCache: {},
+    vikeConfigDependencies: new Set(),
+  }
+}
+
+function getInlineSourceMap(
+  writeFileSyncCalls: unknown[][],
+  filePath: string,
+): { sourceRoot?: string; sources: string[] } {
+  const writeFileSyncCall = writeFileSyncCalls.find(([file]) => file === filePath)
+  expect(writeFileSyncCall).toBeDefined()
+  const code = writeFileSyncCall![1]
+  expect(typeof code).toBe('string')
+  const match = (code as string).match(/\/\/# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)\s*$/)
+  expect(match).toBeTruthy()
+  return JSON.parse(Buffer.from(match![1]!, 'base64').toString('utf-8'))
+}

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/transpileAndExecuteFile.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/transpileAndExecuteFile.ts
@@ -8,6 +8,7 @@ import {
   build,
   type BuildResult,
   type BuildOptions,
+  type Loader,
   formatMessages,
   type Message,
   version,
@@ -17,6 +18,7 @@ import {
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import pc from '@brillout/picocolors'
 import { import_ } from '@brillout/import'
 import { assert, assertWarning } from '../../../../utils/assert.js'
@@ -43,6 +45,8 @@ const debug = createDebug('vike:pointer-imports')
 const debugEsbuildResolve = createDebug('vike:esbuild-resolve')
 const debugConfig = createDebug('vike:config')
 if (debugEsbuildResolve.isActivated) debugEsbuildResolve('esbuild version', version)
+const sourceMapCommentPrefix = '//# source' + 'MappingURL=data:application/json;base64,'
+const inlineSourceMapRE = new RegExp(`${escapeRegExp(sourceMapCommentPrefix)}([A-Za-z0-9+/=]+)\\s*$`)
 
 type FileExports = { fileExports: Record<string, unknown> }
 
@@ -149,10 +153,15 @@ async function transpileWithEsbuild(
 ) {
   const entryFilePath = filePath.filePathAbsoluteFilesystem
   const entryFileDir = path.posix.dirname(entryFilePath)
+  const dirnameVarName = '__vike_injected_original_dirname'
+  const filenameVarName = '__vike_injected_original_filename'
+  const importMetaUrlVarName = '__vike_injected_original_import_meta_url'
+  const importMetaResolveVarName = '__vike_injected_original_import_meta_resolve'
   const options: BuildOptions = {
     platform: 'node',
     entryPoints: [entryFilePath],
     sourcemap: 'inline',
+    sourceRoot: `${entryFileDir}/`,
     write: false,
     target: ['node14.18', 'node16'],
     outfile: path.posix.join(
@@ -164,6 +173,25 @@ async function transpileWithEsbuild(
     logLevel: 'silent',
     format: 'esm',
     absWorkingDir: userRootDir,
+    define: {
+      __dirname: dirnameVarName,
+      __filename: filenameVarName,
+      'import.meta.url': importMetaUrlVarName,
+      'import.meta.dirname': dirnameVarName,
+      'import.meta.filename': filenameVarName,
+      'import.meta.main': 'false',
+      'import.meta.resolve': importMetaResolveVarName,
+    },
+    banner: {
+      js:
+        'import { createRequire as __vike_createRequire } from "node:module";' +
+        'import { pathToFileURL as __vike_pathToFileURL } from "node:url";' +
+        'const __vike_import_meta_resolve = (specifier, importer) => {' +
+        'if (/^(?:\\.{1,2}\\/|\\/|file:)/.test(specifier)) return new URL(specifier, importer).href;' +
+        'const resolved = __vike_createRequire(importer).resolve(specifier);' +
+        'return resolved.startsWith("node:") ? resolved : __vike_pathToFileURL(resolved).href;' +
+        '};',
+    },
     // Disable tree-shaking to avoid dead-code elimination, so that unused imports aren't removed.
     // Esbuild still sometimes removes unused imports because of TypeScript: https://github.com/evanw/esbuild/issues/3034
     treeShaking: false,
@@ -173,7 +201,29 @@ async function transpileWithEsbuild(
   }
 
   const pointerImports: Record<string, boolean> = {}
+  pointerImports['node:module'] = false
+  pointerImports['node:url'] = false
   options.plugins = [
+    {
+      name: 'vike:inject-file-scope-variables',
+      setup(build) {
+        build.onLoad({ filter: /\.[cm]?[jt]sx?$/ }, async (args) => {
+          const id = toPosixPath(args.path)
+          const code = fs.readFileSync(id, 'utf-8')
+          esbuildCache.vikeConfigDependencies.add(id)
+          const injectValues =
+            `const ${dirnameVarName} = ${JSON.stringify(path.posix.dirname(id))};` +
+            `const ${filenameVarName} = ${JSON.stringify(id)};` +
+            `const ${importMetaUrlVarName} = ${JSON.stringify(pathToFileURL(id).href)};` +
+            `const ${importMetaResolveVarName} = (specifier, importer = ${importMetaUrlVarName}) => ` +
+            `__vike_import_meta_resolve(specifier, importer);`
+          return {
+            contents: injectFileScopeVariables(code, injectValues),
+            loader: getEsbuildLoader(id),
+          }
+        })
+      },
+    },
     // Determine whether an import should be:
     //  - A pointer import
     //  - Externalized
@@ -348,12 +398,104 @@ async function transpileWithEsbuild(
     esbuildCache.vikeConfigDependencies.add(filePathAbsoluteFilesystem)
   })
 
-  const code = result.outputFiles![0]!.text
+  const code = normalizeInlineSourceMapSources(result.outputFiles![0]!.text, entryFileDir)
   assert(typeof code === 'string')
   return { code, pointerImports }
 }
 
+function normalizeInlineSourceMapSources(code: string, sourceDir: string): string {
+  const match = code.match(inlineSourceMapRE)
+  if (!match) return code
+
+  const sourceMapBase64 = match[1]!
+  const sourceMap = JSON.parse(Buffer.from(sourceMapBase64, 'base64').toString('utf-8')) as {
+    sourceRoot?: string
+    sources?: string[]
+  }
+  if (!Array.isArray(sourceMap.sources)) return code
+
+  // The generated artifact is imported from node_modules/.vike-temp, so relative
+  // sources need to be made independent from the artifact's runtime location.
+  sourceMap.sources = sourceMap.sources.map((source) =>
+    normalizeSourceMapSource(source, sourceMap.sourceRoot, sourceDir),
+  )
+  delete sourceMap.sourceRoot
+
+  const sourceMapNormalizedBase64 = Buffer.from(JSON.stringify(sourceMap), 'utf-8').toString('base64')
+  return code.replace(inlineSourceMapRE, `${sourceMapCommentPrefix}${sourceMapNormalizedBase64}`)
+}
+
+function normalizeSourceMapSource(source: string, sourceRoot: string | undefined, sourceDir: string): string {
+  if (source.startsWith('file://')) return fileURLToPath(source)
+  if (path.posix.isAbsolute(source)) return source
+  if (sourceRoot) {
+    if (sourceRoot.startsWith('file://')) return fileURLToPath(new URL(source, sourceRoot))
+    return path.posix.join(sourceRoot, source)
+  }
+  return path.posix.join(sourceDir, source)
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function injectFileScopeVariables(code: string, injectValues: string): string {
+  // Keep the original line numbers stable for source maps. The first line's
+  // columns can be offset by the injected prefix.
+  if (!code.startsWith('#!')) {
+    return injectValues + code
+  }
+  let firstLineEndIndex = code.indexOf('\n')
+  if (firstLineEndIndex < 0) firstLineEndIndex = code.length
+  return code.slice(0, firstLineEndIndex + 1) + injectValues + code.slice(firstLineEndIndex + 1)
+}
+
+function getEsbuildLoader(filePath: string): Loader {
+  const fileExtension = path.posix.extname(filePath)
+  if (fileExtension === '.ts' || fileExtension === '.mts' || fileExtension === '.cts') return 'ts'
+  if (fileExtension === '.tsx') return 'tsx'
+  if (fileExtension === '.jsx') return 'jsx'
+  return 'js'
+}
+
 async function executeTranspiledFile(filePath: FilePathResolved, code: string) {
+  const { filePathAbsoluteFilesystem } = filePath
+
+  const vikeTempDir = findNearestNodeModules(path.posix.dirname(filePathAbsoluteFilesystem))
+  if (!vikeTempDir) {
+    return await executeTranspiledFileNextToSource(filePath, code)
+  }
+
+  const fileHash = crypto
+    .createHash('sha256')
+    .update(`${filePathAbsoluteFilesystem}\0${code}`)
+    .digest('hex')
+    .slice(0, 12)
+  const fileName = `${path.posix.basename(filePathAbsoluteFilesystem)}.build-${fileHash}.mjs`
+
+  const filePathTmp = path.posix.join(vikeTempDir, '.vike-temp', fileName)
+  try {
+    fs.mkdirSync(path.posix.dirname(filePathTmp), { recursive: true })
+    fs.writeFileSync(filePathTmp, code)
+  } catch (err) {
+    if (!isWriteFailure(err)) throw err
+    return await executeTranspiledFileNextToSource(filePath, code)
+  }
+  const clean = () => {
+    try {
+      fs.unlinkSync(filePathTmp)
+    } catch {}
+  }
+  let fileExports: Record<string, unknown> = {}
+  try {
+    fileExports = await executeFile(filePathTmp, filePath)
+  } finally {
+    clean()
+  }
+  return fileExports
+}
+
+async function executeTranspiledFileNextToSource(filePath: FilePathResolved, code: string) {
   const { filePathAbsoluteFilesystem } = filePath
   // Alternative to using a temporary file: https://github.com/vitejs/vite/pull/13269
   //  - But seems to break source maps, so I don't think it's worth it
@@ -376,6 +518,44 @@ async function executeTranspiledFile(filePath: FilePathResolved, code: string) {
     clean()
   }
   return fileExports
+}
+
+function findNearestNodeModules(basedir: string): string | null {
+  assertPosixPath(basedir)
+  while (basedir) {
+    const nodeModulesDir = path.posix.join(basedir, 'node_modules')
+    if (tryStatSync(nodeModulesDir)?.isDirectory()) {
+      return nodeModulesDir
+    }
+
+    const nextBasedir = path.posix.dirname(basedir)
+    if (nextBasedir === basedir) break
+    basedir = nextBasedir
+  }
+
+  return null
+}
+
+function tryStatSync(file: string): fs.Stats | undefined {
+  try {
+    // The "throwIfNoEntry" is a performance optimization for cases where the file does not exist
+    return fs.statSync(file, { throwIfNoEntry: false })
+  } catch {
+    // Ignore errors
+  }
+}
+
+function isWriteFailure(err: unknown): boolean {
+  if (!isObject(err)) return false
+  const code = err.code
+  return (
+    code === 'EACCES' ||
+    code === 'EPERM' ||
+    code === 'EROFS' ||
+    code === 'ENOENT' ||
+    code === 'ENOTDIR' ||
+    code === 'EISDIR'
+  )
 }
 
 async function executeFile(filePathToExecuteAbsoluteFilesystem: string, filePathSourceFile: FilePathResolved) {


### PR DESCRIPTION
## Summary

This PR changes how Vike executes transpiled config files:

- write generated config artifacts under `<nearest-node_modules>/.vike-temp/` instead of the application source tree when possible;
- fall back to the existing next-to-source artifact path when `.vike-temp` cannot be used;
- preserve original-source semantics for `import.meta.*`, `__dirname`, and `__filename`;
- keep inline source maps anchored to the original config source files;
- add unit coverage for the config temp-file execution path and for the pointer-import regression caused by injected banner imports.

## Motivation

When Vike runs under Bun `--hot`, writing transient transpiled config artifacts inside the source tree can trigger Bun's hot reload watcher while the Vike/Vite config graph is still being linked.

The failure has been observed on cold starts with an empty Vite cache:

```txt
[vike] Failed to execute .../node_modules/vike-react/dist/config.js because:
TypeError: Requested module is not instantiated yet.
    at link (native)
    at linkAndEvaluateModule (native)
    at requestImportModule (native)
    at processTicksAndRejections (native)
```

After this failure, Vike can continue with an invalid config state and frontend pages render as 500.

The reliable mitigation is to keep the generated config artifact outside watched application source directories:

```txt
<nearest-node_modules>/.vike-temp/+config.ts.build-<hash>.mjs
```

The nearest `node_modules` directory is selected by walking upward from the source config file directory. This keeps bare import resolution aligned with the project/package dependency tree while avoiding source-tree watcher events for transient generated files.

## Implementation

Generated config artifacts are written to:

```txt
<nearest-node_modules>/.vike-temp/<source-basename>.build-<hash>.mjs
```

The hash includes both the source file path and generated code:

```txt
hash(filePathAbsoluteFilesystem + "\0" + code)
```

This avoids collisions between distinct config files that transpile to identical code.

If no suitable `node_modules` directory exists, or if `.vike-temp` cannot be created or written, Vike uses the existing next-to-source generated artifact path. Expected filesystem failures such as permission errors, read-only directories, and missing path components are treated as fallback conditions.

The generated file remains short-lived: Vike writes it, imports it, and removes it in `finally`.

## Original File Semantics

Moving the generated `.mjs` artifact changes the physical runtime location of the imported file. Config code can depend on file-scoped values such as:

```js
import.meta.url
import.meta.dirname
import.meta.filename
import.meta.main
import.meta.resolve
__dirname
__filename
```

This PR preserves the original config source file as the semantic location for these values.

The implementation injects per-file constants for the original source directory, filename, and file URL, then rewrites supported file-scoped expressions before bundling. `import.meta.resolve(specifier)` resolves against the original importer URL. Because the rewrite is parser/transform based, formatted expressions such as:

```js
import.meta
  .resolve('./config-data.txt')
```

are handled as well.

Example:

```js
import { readFileSync } from 'node:fs'

const data = readFileSync(new URL('./config-data.txt', import.meta.url), 'utf8')
```

With this PR, `./config-data.txt` resolves relative to the original `+config.ts`, even though the generated artifact is imported from `.vike-temp`.

## Source Maps

The bundled config artifact includes an inline source map whose `sources` point to the original config files. Vike asks esbuild to anchor the source map to the original config directory, then normalizes the final inline source map so `sources` are filesystem-absolute. This makes source-map metadata independent from the generated artifact location under `.vike-temp`, while remaining compatible with Vike's existing `source-map-support` stack handling.

File-scoped values are injected through esbuild's `onLoad()` hook before the final bundle is generated, so the final inline source map is produced by the same esbuild build that emits the config artifact.

Pointer imports are transformed after bundling. The transform preserves the generated line count by avoiding an extra prepended line, so the inline source map continues to describe the code that Vike imports from `.vike-temp`.

One source-map limitation remains for column precision on the first line of code in each transformed module. The injected file-scoped variables are prepended without adding a newline, so line numbers remain stable, while the first line's columns are offset by the injected prefix. Stack traces still point to the original source file and line, including relative modules bundled into the config artifact.

## Vite Alignment

This PR follows Vite's bundled config loader because Vite faced the same class of problems and resolved them through several focused iterations. The implementation mirrors the relevant Vite changes and uses the same resolution strategy where it applies to Vike, so config temp-file execution, source-map metadata, file-scoped values, and filesystem fallback behavior are handled as reliably as possible.

- Vite docs: bundled temporary config files are written under `node_modules/.vite-temp`.
  https://vite.dev/config/#debugging-the-config-file-on-vs-code

- vitejs/vite#18509, `fix(config): write temporary vite config to node_modules`

  Moves bundled config artifacts to `node_modules/.vite-temp` and discusses compatibility concerns around relative references, dependency resolution, workspace packages, and `import.meta.*` shims.

- vitejs/vite#18833, `fix(config): make stacktrace path correct when sourcemap is enabled`

  Keeps stack traces/source-map paths aligned with the original config source path even when the generated artifact is imported from `.vite-temp`.

- vitejs/vite#20573, commit `c583927bee657f15f63fdf80468fbe6a74eacdec`, `fix(config): make debugger work with bundle loader`

  Covers the same source-map/debugger problem for Vite's esbuild config bundle loader. Vike uses the same principle of anchoring source maps to the original config directory while keeping the format compatible with Vike's runtime stack handling.

- vitejs/vite#18844, `fix: no permission to create vite config file`

  Handles permission and read-only filesystem cases for config temp-file creation. This PR applies the same robustness principle by falling back when `.vike-temp` cannot be used.

- vitejs/vite#8442, commit `51e9195fe9`, `better config __dirname support`

  Introduces injected variables such as `__vite_injected_original_import_meta_url` so bundled config code observes the original file URL.

- vitejs/vite#15888, commit `3efb1a11a0`

  Extends config shimming to `import.meta.dirname` and `import.meta.filename`.

- vitejs/vite#20516, commit `5d3e3c2ae`

  Covers `import.meta.main` in bundled config code.

- vitejs/vite#20962, commit `f86789a6e`

  Covers `import.meta.resolve` in bundled config code.

- vitejs/vite#21312

  Fixes detection of `import.meta.resolve` when the expression is formatted across multiple lines.

## Testing

Added unit coverage for:

- `transformPointerImports()` preserving non-pointer banner imports such as `node:module` while still transforming pointer imports in the same file;
- `transformPointerImports()` transforming pointer imports without adding generated lines after esbuild has emitted the source map;
- `transpileAndExecuteFile()` writing the generated config artifact under `node_modules/.vike-temp`;
- `transpileAndExecuteFile()` falling back to the next-to-source artifact path when `node_modules/.vike-temp` cannot be written;
- preserving original-source values for `import.meta.url`, `import.meta.dirname`, `import.meta.filename`, `import.meta.main`, `import.meta.resolve`, `__dirname`, and `__filename` when the generated artifact is imported from `.vike-temp`.
- inline source maps for runtime errors thrown directly by `+config.ts` pointing to the original config file;
- inline source maps for runtime errors thrown by a relative module bundled into `+config.ts` pointing to the original relative module.

Runtime stack mapping was also checked outside Vitest, with `source-map-support` active, for both a direct throw in `+config.ts` and a throw in a bundled relative module.

The runtime check confirmed that stack traces point to the original source file and line. Column precision on the first line of transformed modules is not guaranteed because file-scoped variables are injected before that first line without adding a newline.

The full unit test suite passes, and the package build succeeds.

A manual dev-server check with `examples/react-full` reaches Vike/Vite ready state successfully.

I am also using this patch successfully in a project currently under development. The server side, built with Elysia, updates quickly through Bun's `--hot` reload, while the Vike side keeps working with Vite HMR as expected.
