### PR TITLE
perf: pre-shape pageContext for V8 hidden-class stability

### DIFF
--- a/packages/vike/src/shared-server-client/createPageContextShared.ts
+++ b/packages/vike/src/shared-server-client/createPageContextShared.ts
@@ -41,10 +41,100 @@ function createPageContextShared<T extends Record<string, unknown>>(
 }
 
 function createPageContextObject() {
+  // V8 hidden-class stability optimization — pre-declare commonly assigned pageContext fields
+  // as `undefined` so V8 sees one stable shape across the request lifecycle.
+  //
+  // Background: pageContext is mutated by ~35 objectAssign() calls across the SSR pipeline,
+  // adding fields in different orders depending on which conditional branches fire. Without
+  // this pre-declaration, V8 creates many different hidden classes for what is logically the
+  // same object — making property reads at hot call sites megamorphic and 1.5–2× slower than
+  // they would be with a stable shape (microbenchmarked).
+  //
+  // The fields listed here are the well-known plain-data fields populated by the server-side
+  // SSR path. Adding more does not change semantics for fields that are only used as
+  // overwrite-on-assign data — only fields that get written later are affected; undeclared
+  // fields will still cause one-shot shape transitions on first write.
+  //
+  // IMPORTANT: Four categories of fields must NOT be pre-declared:
+  //
+  //   1. Lazy-compute memoization markers checked via `'X' in pageContext` — currently
+  //      `_pageAssets` (loadPageConfigsLazyServerSide.ts) and `_pageId` (getPageContextPublicShared.ts).
+  //      Pre-declaring as `undefined` makes the `in` check spuriously true and short-circuits
+  //      the compute path.
+  //
+  //   2. Fields in the built-in `passToClient` list (serializeContext.ts:28) that may stay
+  //      undefined after the SSR path — currently `data`, `abortReason`, `abortStatusCode`.
+  //      The client-side serializer (propKeys.ts:getPropVal) uses `key in obj` to gate
+  //      serialization, so pre-declaring them causes spurious `"!undefined"` markers to land
+  //      in the inlined `vike_pageContext` JSON.
+  //
+  //   3. Fields in the error-path passToClient list (serializeContext.ts:42), notably
+  //      `pageProps` (also commonly added to user `passToClient`) and `is404` — same risk
+  //      as (2), plus `is404` carries a `hasProp(pageContext, 'is404', 'boolean')` assertion
+  //      that pre-declaration as `undefined` would silently break.
+  //
+  //   4. Fields that get explicitly assigned and then merged-back via the `objectAssign(target,
+  //      forked_source, true)` pattern — currently `pageId`. In the abort path
+  //      (renderPageServer.ts:668), `objectAssign(pageContext, pageContextErrorPageInit, true)`
+  //      copies own property descriptors from a fork of the begin-state pageContext. If the
+  //      fork carries `pageId: undefined` (because of pre-declaration), that overwrites the
+  //      `pageId = errorPageId` set on the line above, causing the assertPageContext check in
+  //      serializeContext to fail. `routeParams` is unaffected because the same call site
+  //      explicitly assigns it to `{}` before the merge.
+  //
+  // NOTE: URL-computed accessor properties (`urlPathname`, `url`, `urlParsed`) are intentionally
+  // omitted — they are installed via `Object.defineProperty` with getters by
+  // `getPageContextUrlComputed()`, and pre-declaring them as data properties would cost an extra
+  // shape transition when they get replaced with accessor descriptors.
+  //
+  // The cast preserves the original narrow return type — the additional `undefined` fields are
+  // a runtime-only shape hint, not part of the API contract. Downstream code uses objectAssign()
+  // to add fields with their concrete types (via the `asserts obj is Obj & ObjAddendum` signature).
   const pageContext = {
     _isOriginalObject: true as const,
     isPageContext: true as const,
-  }
+    isClientSide: undefined,
+    isPrerendering: undefined,
+    _requestId: undefined,
+    urlOriginal: undefined,
+    headersOriginal: undefined,
+    headers: undefined,
+    _reqWeb: undefined,
+    _reqDev: undefined,
+    _globalContext: undefined,
+    _pageFilesAll: undefined,
+    _baseServer: undefined,
+    _baseAssets: undefined,
+    _pageContextInit: undefined,
+    _urlHandler: undefined,
+    isClientSideNavigation: undefined,
+    // pageId intentionally NOT pre-declared — gets clobbered back to undefined by the
+    // `objectAssign(pageContext, pageContextErrorPageInit, true)` merge in the abort path
+    // (renderPageServer.ts:668), breaking assertPageContext.
+    routeParams: undefined,
+    // is404 intentionally NOT pre-declared — error-path passToClient + hasProp assertion.
+    _pageConfig: undefined,
+    exportsAll: undefined,
+    exports: undefined,
+    from: undefined,
+    Page: undefined,
+    _isHtmlOnly: undefined,
+    _passToClient: undefined,
+    __getPageAssets: undefined,
+    // _pageAssets intentionally NOT pre-declared — lazy-compute marker
+    // (`'_pageAssets' in pageContext` in loadPageConfigsLazyServerSide.ts).
+    headersResponse: undefined,
+    // data intentionally NOT pre-declared — built-in passToClient.
+    _renderHook: undefined,
+    _pageContextPromise: undefined,
+    // pageProps intentionally NOT pre-declared — error-path passToClient + common user passToClient target.
+    _cspNonce: undefined,
+    pageContextsAborted: undefined,
+    _isStream: undefined,
+    errorWhileRendering: undefined,
+    // abortReason / abortStatusCode intentionally NOT pre-declared — built-in passToClient.
+    httpResponse: undefined,
+  } as { _isOriginalObject: true; isPageContext: true }
   changeEnumerable(pageContext, '_isOriginalObject', false)
   return pageContext
 }


### PR DESCRIPTION
## Summary

Pre-declare the common plain-data `pageContext` fields as `undefined` in `createPageContextObject()` so V8 sees one stable hidden class across the request lifecycle. Currently `pageContext` is mutated by ~35 `objectAssign` calls across the SSR pipeline in different orders depending on which conditional branches fire — producing many V8 hidden classes for what is logically one object.

## Microbench

5M iterations, 60-property pageContext (57 plain data + 3 getters matching `getPageContextUrlComputed()`), identical read function:

| Variant | ns/read | Notes |
|---|---:|---|
| Empty + `defineProperties` (current behavior) | 1.48 | baseline |
| **Pre-shape + `defineProperties` (this patch)** | **0.90** | **1.64× faster** |
| Pre-shape + `Object.assign` (sanity) | 0.92 | confirms pre-shape benefit, not the mutation method |
| Pre-shape + direct assignment (ceiling) | 0.71 | fastest possible |

Reading properties from incrementally-built objects becomes increasingly slow across iterations as V8's optimization tier system observes more shapes and de-opts inline caches. Pre-shaped stays stable across iterations.

## Honest caveat — no end-to-end RPS impact at tested scales

I tested this end-to-end against a meta-framework consumer's minimal scaffold at c=10 and c=100, 5×30s iterations each. **The patch did not measurably move sustained RPS** in either case — the system had ~28% idle CPU at all tested concurrency, so property-read CPU isn't the binding constraint at this workload.

The microbench result is real; the end-to-end gain is workload-dependent. The patch should help at higher CPU saturation (very large apps, very high concurrency on small hardware) where V8 hidden-class churn would otherwise dominate. At the scales most apps run, the benefit is invisible.

I'm sending this as a quick-win patch per our Discord conversation — happy to drop it if you'd rather not carry a patch whose end-to-end win isn't yet demonstrated.

## Narrowed scope after CI feedback

The first push (`fd59c4b`) included all 37 well-known plain-data fields. CI surfaced real semantic breakage — the "zero semantic change" framing was wrong. I audited the codebase and identified four categories of fields that must NOT be pre-declared:

1. **Lazy-compute memoization markers** checked via `'X' in pageContext` — `_pageAssets` (`loadPageConfigsLazyServerSide.ts:105`) and `_pageId` (`getPageContextPublicShared.ts:23`). Pre-declaring as `undefined` makes the `in` check spuriously true and short-circuits the compute path.

2. **Built-in `passToClient` fields** that may stay undefined after SSR — `data`, `abortReason`, `abortStatusCode` (`serializeContext.ts:28`). The serializer's `getPropVal` (`propKeys.ts:9`) uses `key in obj` to gate inclusion, so pre-declaring causes `"!undefined"` markers to land in the inlined `vike_pageContext` JSON.

3. **Error-path `passToClient` fields** — `pageProps` (also a common user `passToClient` target) and `is404` (`serializeContext.ts:42`). Same risk as (2), plus `is404` carries a `hasProp('is404', 'boolean')` assertion that pre-declaration silently breaks.

4. **Fields explicitly assigned and then merged-back via `objectAssign(target, forked_source, true)`** — `pageId`. In the abort path (`renderPageServer.ts:668`), `objectAssign(pageContext, pageContextErrorPageInit, true)` copies own property descriptors from a fork of the begin-state pageContext. With pre-declaration, the fork carries `pageId: undefined`, which clobbers the `pageId = errorPageId` set on the line above, breaking `assertPageContext`. `routeParams` is unaffected because the same call site explicitly assigns it to `{}` before the merge.

Each excluded field carries a comment at its position in the field list explaining the category. The remaining ~30 fields are safe overwrite-on-assign data fields.

## Safety

- ✅ 180/180 unit tests pass (`pnpm test:units`)
- ✅ 12/12 vitest E2E tests pass (`pnpm vitest run --project e2e`)
- ✅ `pnpm test:types` passes
- ✅ `pnpm format:check` passes
- ✅ Selected browser-based e2e suites verified locally: `examples/auth`, `examples/react-minimal`, `examples/vue-minimal`, `examples/i18n`, `examples/render-modes`, `examples/file-structure-domain-driven`, `examples/custom-preload`, `examples/base-url-server`, `test/abort`, `test/env`, `test/plusMiddlewares`, `test/hook-override`, `packages/create-vike-core/boilerplate-{react,react-ts,vue,vue-ts}`
- ✅ The cast preserves the narrow return type — downstream typing via `objectAssign`'s `asserts obj is Obj & ObjAddendum` is unaffected
- ✅ URL accessor properties (`urlPathname`/`url`/`urlParsed`) are intentionally NOT pre-declared, so their later installation via getters via `getPageContextUrlComputed()` doesn't cost an extra descriptor-type transition

## Implementation notes

Adding more fields would not change semantics for safe (overwrite-on-assign) fields — only fields that get written later are affected; undeclared fields will still cause one-shot shape transitions on first write. The four-category exclusion list above documents the audit so a future contributor adding a new field knows what to check before adding it.