### PR TITLE
fix: do not force exit when using universal-deploy

### DIFF
--- a/packages/vike/src/node/prerender/runPrerenderEntry.ts
+++ b/packages/vike/src/node/prerender/runPrerenderEntry.ts
@@ -32,7 +32,10 @@ async function runPrerenderFromCLIPrerenderCommand(): Promise<void> {
   runPrerender_forceExit()
   assert(false)
 }
-async function runPrerenderFromAutoRun(viteConfig: InlineConfig | undefined): Promise<{ forceExit: boolean }> {
+async function runPrerenderFromAutoRun(
+  viteConfig: InlineConfig | undefined,
+  isServerConfig: boolean,
+): Promise<{ forceExit: boolean }> {
   try {
     await runPrerender({ viteConfig }, 'auto-run')
   } catch (err) {
@@ -40,7 +43,7 @@ async function runPrerenderFromAutoRun(viteConfig: InlineConfig | undefined): Pr
     logErrorServer(err, null)
     process.exit(1)
   }
-  const forceExit = isVikeCli() || isViteCli()
+  const forceExit = !isServerConfig && (isVikeCli() || isViteCli())
   return { forceExit }
 }
 

--- a/packages/vike/src/node/vite/plugins/build/pluginBuildApp.ts
+++ b/packages/vike/src/node/vite/plugins/build/pluginBuildApp.ts
@@ -17,6 +17,7 @@ import { isViteServerSide_onlySsrEnv } from '../../shared/isViteServerSide.js'
 import { runPrerenderFromAutoRun } from '../../../prerender/runPrerenderEntry.js'
 import { getManifestFilePathRelative } from '../../shared/getManifestFilePathRelative.js'
 import { logErrorServer } from '../../../../server/runtime/logErrorServer.js'
+import { getServerConfig } from '../pluginUniversalDeploy/getServerConfig.js'
 import '../../assertEnvVite.js'
 
 const globalObject = getGlobalObject('build/pluginBuildApp.ts', {
@@ -138,7 +139,8 @@ async function triggerPrerendering(config: ResolvedConfig, viteEnv: Environment,
   if (!(await isPrerenderAutoRunEnabled(vikeConfig))) return
 
   const configInline = getFullBuildInlineConfig(config)
-  const res = await runPrerenderFromAutoRun(configInline)
+  const isServerConfig = !!getServerConfig(vikeConfig)
+  const res = await runPrerenderFromAutoRun(configInline, isServerConfig)
   globalObject.forceExit = res.forceExit
   assert(wasPrerenderRun())
 }


### PR DESCRIPTION
Fixes #3292
UD can build other Vite environments. When a `server` is configured, we know that we are following UD's build path, so we disabled force exit.