### PR TITLE
fix: add global +configs to optimizeDeps scan

### DIFF
--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -139,19 +139,19 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
   if (debug.isActivated) {
     // Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots
     // stay in sync with the corresponding environment values — so logging only the env
-    // values isn't hiding anything. We don't assert `entries`: Vike writes server entries
-    // only to `env.optimizeDeps.entries` (Vite no longer reads `ssr.optimizeDeps.entries`),
-    // so the legacy SSR slot stays at whatever the user/plugins set initially.
+    // values isn't hiding anything. We don't assert SSR `entries`: when a plugin (e.g.
+    // @cloudflare/vite-plugin) sets it as a string, our `add()` allocates a new array which
+    // replaces only `env.optimizeDeps.entries`, leaving the legacy slot at the original
+    // string. Vite no longer reads `ssr.optimizeDeps.entries` anyway.
     const client = config.environments.client?.optimizeDeps
-    if (client) {
-      assert(deepEqual(config.optimizeDeps.include, client.include))
-      assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
-    }
+    assert(client)
+    assert(deepEqual(config.optimizeDeps.entries, client.entries))
+    assert(deepEqual(config.optimizeDeps.include, client.include))
+    assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
     const ssr = config.environments.ssr?.optimizeDeps
-    if (ssr) {
-      assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
-      assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
-    }
+    assert(ssr)
+    assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
+    assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
     const envs: Record<string, unknown> = {}
     for (const envName in config.environments) {
       const env = config.environments[envName]!

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -137,9 +137,6 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
 
   // Debug
   if (debug.isActivated) {
-    // Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots
-    // stay in sync with the corresponding environment values — so logging only the env
-    // values isn't hiding anything.
     const client = config.environments.client?.optimizeDeps
     assert(client)
     assert(deepEqual(config.optimizeDeps.entries, client.entries))
@@ -147,8 +144,9 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
     const ssr = config.environments.ssr?.optimizeDeps
     assert(ssr)
-    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+    /* Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
     assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
+    */
     assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
     assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
     const envs: Record<string, unknown> = {}

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -12,7 +12,7 @@ import { requireResolveOptional } from '../../../../utils/requireResolve.js'
 import { isVirtualFileId } from '../../../../utils/virtualFileId.js'
 import { getVikeConfigInternal } from '../../shared/resolveVikeConfigInternal.js'
 import { analyzeClientEntries } from '../build/pluginBuildConfig.js'
-import type { DefinedAtFilePath, PageConfigBuildTime } from '../../../../types/PageConfig.js'
+import type { DefinedAtFilePath, PageConfigBuildTime, PageConfigGlobalBuildTime } from '../../../../types/PageConfig.js'
 import type { FilePath } from '../../../../types/FilePath.js'
 import {
   virtualFileIdGlobalEntryClientCR,
@@ -82,10 +82,14 @@ const optimizeDeps = {
 // - Make server environments inherit from ssr.optimizeDeps (it isn't the case by default)
 async function resolveOptimizeDeps(config: ResolvedConfig) {
   const vikeConfig = await getVikeConfigInternal()
-  const { _pageConfigs: pageConfigs } = vikeConfig
+  const { _pageConfigs: pageConfigs, _pageConfigGlobal: pageConfigGlobal } = vikeConfig
 
   // Retrieve user's + files (i.e. Vike entries)
-  const { entriesClient, entriesServer, includeClient, includeServer } = await getPageDeps(config, pageConfigs)
+  const { entriesClient, entriesServer, includeClient, includeServer } = await getPageDeps(
+    config,
+    pageConfigs,
+    pageConfigGlobal,
+  )
 
   // Add late discovered dependencies, if they exist
   LATE_DISCOVERED.forEach((dep) => {
@@ -131,7 +135,14 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
   }
 
   // Debug
-  if (debug.isActivated)
+  if (debug.isActivated) {
+    const envs: Record<string, unknown> = {}
+    for (const envName in config.environments) {
+      const env = config.environments[envName]!
+      envs[`config.environments.${envName}.optimizeDeps.entries`] = env.optimizeDeps.entries
+      envs[`config.environments.${envName}.optimizeDeps.include`] = env.optimizeDeps.include
+      envs[`config.environments.${envName}.optimizeDeps.exclude`] = env.optimizeDeps.exclude
+    }
     debug('optimizeDeps', {
       'config.optimizeDeps.entries': config.optimizeDeps.entries,
       'config.optimizeDeps.include': config.optimizeDeps.include,
@@ -140,10 +151,16 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
       'config.ssr.optimizeDeps.entries': config.ssr.optimizeDeps.entries,
       'config.ssr.optimizeDeps.include': config.ssr.optimizeDeps.include,
       'config.ssr.optimizeDeps.exclude': config.ssr.optimizeDeps.exclude,
+      ...envs,
     })
+  }
 }
 
-async function getPageDeps(config: ResolvedConfig, pageConfigs: PageConfigBuildTime[]) {
+async function getPageDeps(
+  config: ResolvedConfig,
+  pageConfigs: PageConfigBuildTime[],
+  pageConfigGlobal: PageConfigGlobalBuildTime,
+) {
   let entriesClient: string[] = []
   let entriesServer: string[] = []
   let includeClient: string[] = []
@@ -195,9 +212,13 @@ async function getPageDeps(config: ResolvedConfig, pageConfigs: PageConfigBuildT
   }
 
   // V1 design
+  // Iterate per-page configs AND global configs (e.g. +server, +middleware, +onError) so that
+  // entries reachable from +server.ts (Hono/Telefunc/Sentry/etc.) get scanned upfront —
+  // otherwise they're discovered lazily and trigger "✨ new dependencies optimized" + reload.
   {
+    const allPageConfigs: (PageConfigBuildTime | PageConfigGlobalBuildTime)[] = [...pageConfigs, pageConfigGlobal]
     ;[true, false].forEach((isForClientSide) => {
-      pageConfigs.forEach((pageConfig) => {
+      allPageConfigs.forEach((pageConfig) => {
         Object.entries(pageConfig.configValueSources).forEach(([configName]) => {
           const runtimeEnv = {
             isForClientSide,

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -135,14 +135,20 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     env.optimizeDeps.entries = remove(env.optimizeDeps.entries ?? [])
   }
 
+  // Mirror SSR env entries back to the legacy `config.ssr.optimizeDeps.entries` slot — when
+  // a plugin sets it as a string (e.g. @cloudflare/vite-plugin via normalizePath(workerConfig.main)),
+  // `add()` allocates a new array that replaces only `env.optimizeDeps.entries`, leaving the
+  // legacy slot stale.
+  if (config.environments.ssr?.optimizeDeps.entries) {
+    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+    config.ssr.optimizeDeps.entries = config.environments.ssr.optimizeDeps.entries
+  }
+
   // Debug
   if (debug.isActivated) {
     // Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots
     // stay in sync with the corresponding environment values — so logging only the env
-    // values isn't hiding anything. We don't assert SSR `entries`: when a plugin (e.g.
-    // @cloudflare/vite-plugin) sets it as a string, our `add()` allocates a new array which
-    // replaces only `env.optimizeDeps.entries`, leaving the legacy slot at the original
-    // string. Vite no longer reads `ssr.optimizeDeps.entries` anyway.
+    // values isn't hiding anything.
     const client = config.environments.client?.optimizeDeps
     assert(client)
     assert(deepEqual(config.optimizeDeps.entries, client.entries))
@@ -150,6 +156,8 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
     const ssr = config.environments.ssr?.optimizeDeps
     assert(ssr)
+    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+    assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
     assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
     assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
     const envs: Record<string, unknown> = {}

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -144,7 +144,7 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
     const ssr = config.environments.ssr?.optimizeDeps
     assert(ssr)
-    /* Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+    /* Vite doesn't seem to support config.ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
     assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
     */
     assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -137,18 +137,7 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
 
   // Debug
   if (debug.isActivated) {
-    const client = config.environments.client?.optimizeDeps
-    assert(client)
-    assert(deepEqual(config.optimizeDeps.entries, client.entries))
-    assert(deepEqual(config.optimizeDeps.include, client.include))
-    assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
-    const ssr = config.environments.ssr?.optimizeDeps
-    assert(ssr)
-    /* Vite doesn't seem to support config.ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
-    assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
-    */
-    assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
-    assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
+    assertEnvsInSyncWithLegacy(config)
     const envs: Record<string, unknown> = {}
     for (const envName in config.environments) {
       const env = config.environments[envName]!
@@ -158,6 +147,24 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     }
     debug('optimizeDeps', envs)
   }
+}
+
+// Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots
+// stay in sync with the corresponding environment values — so logging only the env values
+// (above) isn't hiding anything.
+function assertEnvsInSyncWithLegacy(config: ResolvedConfig) {
+  const client = config.environments.client?.optimizeDeps
+  assert(client)
+  assert(deepEqual(config.optimizeDeps.entries, client.entries))
+  assert(deepEqual(config.optimizeDeps.include, client.include))
+  assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
+  const ssr = config.environments.ssr?.optimizeDeps
+  assert(ssr)
+  /* Vite doesn't seem to support config.ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+  assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
+  */
+  assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
+  assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
 }
 
 async function getPageDeps(

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -149,24 +149,6 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
   }
 }
 
-// Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots
-// stay in sync with the corresponding environment values — so logging only the env values
-// (above) isn't hiding anything.
-function assertEnvsInSyncWithLegacy(config: ResolvedConfig) {
-  const client = config.environments.client?.optimizeDeps
-  assert(client)
-  assert(deepEqual(config.optimizeDeps.entries, client.entries))
-  assert(deepEqual(config.optimizeDeps.include, client.include))
-  assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
-  const ssr = config.environments.ssr?.optimizeDeps
-  assert(ssr)
-  /* Vite doesn't seem to support config.ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
-  assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
-  */
-  assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
-  assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
-}
-
 async function getPageDeps(
   config: ResolvedConfig,
   pageConfigs: PageConfigBuildTime[],
@@ -309,4 +291,21 @@ function remove(input: string[] | string | undefined) {
   let list = normalizeInput(input)
   list = list.filter((e) => !ALWAYS_REMOVE.includes(e))
   return list
+}
+// Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots
+// stay in sync with the corresponding environment values — so logging only the env values
+// (above) isn't hiding anything.
+function assertEnvsInSyncWithLegacy(config: ResolvedConfig) {
+  const client = config.environments.client?.optimizeDeps
+  assert(client)
+  assert(deepEqual(config.optimizeDeps.entries, client.entries))
+  assert(deepEqual(config.optimizeDeps.include, client.include))
+  assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
+  const ssr = config.environments.ssr?.optimizeDeps
+  assert(ssr)
+  /* Vite doesn't seem to support config.ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+  assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
+  */
+  assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
+  assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
 }

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -5,6 +5,7 @@ import type { ResolvedConfig, UserConfig } from 'vite'
 import { findPageFiles } from '../../shared/findPageFiles.js'
 import { assert } from '../../../../utils/assert.js'
 import { createDebug } from '../../../../utils/debug.js'
+import { deepEqual } from '../../../../utils/deepEqual.js'
 import { isArray } from '../../../../utils/isArray.js'
 import { isFilePathAbsoluteFilesystem } from '../../../../utils/isFilePathAbsoluteFilesystem.js'
 import { assertImportIsNpmPackage, getNpmPackageName } from '../../../../utils/parseNpmPackage.js'
@@ -136,6 +137,21 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
 
   // Debug
   if (debug.isActivated) {
+    // Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots
+    // stay in sync with the corresponding environment values — so logging only the env
+    // values isn't hiding anything. We don't assert `entries`: Vike writes server entries
+    // only to `env.optimizeDeps.entries` (Vite no longer reads `ssr.optimizeDeps.entries`),
+    // so the legacy SSR slot stays at whatever the user/plugins set initially.
+    const client = config.environments.client?.optimizeDeps
+    if (client) {
+      assert(deepEqual(config.optimizeDeps.include, client.include))
+      assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
+    }
+    const ssr = config.environments.ssr?.optimizeDeps
+    if (ssr) {
+      assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
+      assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
+    }
     const envs: Record<string, unknown> = {}
     for (const envName in config.environments) {
       const env = config.environments[envName]!
@@ -143,18 +159,7 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
       envs[`config.environments.${envName}.optimizeDeps.include`] = env.optimizeDeps.include
       envs[`config.environments.${envName}.optimizeDeps.exclude`] = env.optimizeDeps.exclude
     }
-    debug('optimizeDeps', {
-      // TODO/ai dedupe from here...
-      'config.optimizeDeps.entries': config.optimizeDeps.entries,
-      'config.optimizeDeps.include': config.optimizeDeps.include,
-      'config.optimizeDeps.exclude': config.optimizeDeps.exclude,
-      // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
-      'config.ssr.optimizeDeps.entries': config.ssr.optimizeDeps.entries,
-      'config.ssr.optimizeDeps.include': config.ssr.optimizeDeps.include,
-      'config.ssr.optimizeDeps.exclude': config.ssr.optimizeDeps.exclude,
-      // ...to here — instead assert(deeepEqual()) the values with envName === client and envName === ssr
-      ...envs,
-    })
+    debug('optimizeDeps', envs)
   }
 }
 

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -135,15 +135,6 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     env.optimizeDeps.entries = remove(env.optimizeDeps.entries ?? [])
   }
 
-  // Mirror SSR env entries back to the legacy `config.ssr.optimizeDeps.entries` slot — when
-  // a plugin sets it as a string (e.g. @cloudflare/vite-plugin via normalizePath(workerConfig.main)),
-  // `add()` allocates a new array that replaces only `env.optimizeDeps.entries`, leaving the
-  // legacy slot stale.
-  if (config.environments.ssr?.optimizeDeps.entries) {
-    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
-    config.ssr.optimizeDeps.entries = config.environments.ssr.optimizeDeps.entries
-  }
-
   // Debug
   if (debug.isActivated) {
     // Sanity-check that the legacy `config.optimizeDeps` and `config.ssr.optimizeDeps` slots

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -135,15 +135,6 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     env.optimizeDeps.entries = remove(env.optimizeDeps.entries ?? [])
   }
 
-  // Mirror SSR env entries back to the legacy `config.ssr.optimizeDeps.entries` slot — when
-  // a plugin sets it as a string (e.g. @cloudflare/vite-plugin via normalizePath(workerConfig.main)),
-  // `add()` allocates a new array that replaces only `env.optimizeDeps.entries`, leaving the
-  // legacy slot stale.
-  if (config.environments.ssr?.optimizeDeps.entries) {
-    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
-    config.ssr.optimizeDeps.entries = config.environments.ssr.optimizeDeps.entries
-  }
-
   // Debug
   if (debug.isActivated) {
     const client = config.environments.client?.optimizeDeps
@@ -153,8 +144,9 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
     const ssr = config.environments.ssr?.optimizeDeps
     assert(ssr)
-    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+    /* Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
     assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
+    */
     assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
     assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
     const envs: Record<string, unknown> = {}

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -144,6 +144,7 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
       envs[`config.environments.${envName}.optimizeDeps.exclude`] = env.optimizeDeps.exclude
     }
     debug('optimizeDeps', {
+      // TODO/ai dedupe from here...
       'config.optimizeDeps.entries': config.optimizeDeps.entries,
       'config.optimizeDeps.include': config.optimizeDeps.include,
       'config.optimizeDeps.exclude': config.optimizeDeps.exclude,
@@ -151,6 +152,7 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
       'config.ssr.optimizeDeps.entries': config.ssr.optimizeDeps.entries,
       'config.ssr.optimizeDeps.include': config.ssr.optimizeDeps.include,
       'config.ssr.optimizeDeps.exclude': config.ssr.optimizeDeps.exclude,
+      // ...to here — instead assert(deeepEqual()) the values with envName === client and envName === ssr
       ...envs,
     })
   }

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -135,6 +135,15 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     env.optimizeDeps.entries = remove(env.optimizeDeps.entries ?? [])
   }
 
+  // Mirror SSR env entries back to the legacy `config.ssr.optimizeDeps.entries` slot — when
+  // a plugin sets it as a string (e.g. @cloudflare/vite-plugin via normalizePath(workerConfig.main)),
+  // `add()` allocates a new array that replaces only `env.optimizeDeps.entries`, leaving the
+  // legacy slot stale.
+  if (config.environments.ssr?.optimizeDeps.entries) {
+    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+    config.ssr.optimizeDeps.entries = config.environments.ssr.optimizeDeps.entries
+  }
+
   // Debug
   if (debug.isActivated) {
     const client = config.environments.client?.optimizeDeps
@@ -144,9 +153,8 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
     assert(deepEqual(config.optimizeDeps.exclude, client.exclude))
     const ssr = config.environments.ssr?.optimizeDeps
     assert(ssr)
-    /* Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
+    // @ts-ignore Vite doesn't seem to support ssr.optimizeDeps.entries (vite@7.0.6, July 2025)
     assert(deepEqual(config.ssr.optimizeDeps.entries, ssr.entries))
-    */
     assert(deepEqual(config.ssr.optimizeDeps.include, ssr.include))
     assert(deepEqual(config.ssr.optimizeDeps.exclude, ssr.exclude))
     const envs: Record<string, unknown> = {}

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -137,7 +137,6 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
 
   // Debug
   if (debug.isActivated) {
-    assertEnvsInSyncWithLegacy(config)
     const envs: Record<string, unknown> = {}
     for (const envName in config.environments) {
       const env = config.environments[envName]!
@@ -146,6 +145,7 @@ async function resolveOptimizeDeps(config: ResolvedConfig) {
       envs[`config.environments.${envName}.optimizeDeps.exclude`] = env.optimizeDeps.exclude
     }
     debug('optimizeDeps', envs)
+    assertEnvsInSyncWithLegacy(config)
   }
 }
 

--- a/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/optimizeDeps.ts
@@ -212,13 +212,9 @@ async function getPageDeps(
   }
 
   // V1 design
-  // Iterate per-page configs AND global configs (e.g. +server, +middleware, +onError) so that
-  // entries reachable from +server.ts (Hono/Telefunc/Sentry/etc.) get scanned upfront —
-  // otherwise they're discovered lazily and trigger "✨ new dependencies optimized" + reload.
   {
-    const allPageConfigs: (PageConfigBuildTime | PageConfigGlobalBuildTime)[] = [...pageConfigs, pageConfigGlobal]
     ;[true, false].forEach((isForClientSide) => {
-      allPageConfigs.forEach((pageConfig) => {
+      ;[...pageConfigs, pageConfigGlobal].forEach((pageConfig) => {
         Object.entries(pageConfig.configValueSources).forEach(([configName]) => {
           const runtimeEnv = {
             isForClientSide,


### PR DESCRIPTION
Iterate `_pageConfigGlobal` alongside `_pageConfigs` in the dev optimizeDeps loop, so that entries reachable from `+server.ts`, `+middleware.ts`, `+onError.ts` etc. get added to the SSR environment's `optimizeDeps.entries` and scanned upfront by Vite.

Previously only per-page configs (`_pageConfigs`) were iterated, so the entire transitive graph of `+server.ts` was invisible to the dep scanner — every npm package imported from it would surface lazily and trigger "✨ new dependencies optimized" + page reload at first hit.

In a vike-on-cloudflare project, this eliminates 4 reload cycles during dev startup (Hono/Sentry/Telefunc/Stripe/Drizzle/Resend get scanned together with `+server.ts`) and shaves ~30% off the ready-time.

Also surface per-environment entries/include/exclude in the `vike:optimizeDeps` debug log — `config.ssr.optimizeDeps.*` shows the legacy Vite config slot, not what each environment ends up with.