### PR TITLE
chore(deps): bump react-streaming to 0.4.19 and vike-react to 0.6.24

### DIFF
--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.2.6",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vite": "^6.3.2"
   },
   "type": "module"

--- a/examples/cloudflare-workers-react-full/package.json
+++ b/examples/cloudflare-workers-react-full/package.json
@@ -12,7 +12,7 @@
     "node-fetch": "^2.6.9",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-streaming": "^0.4.17",
+    "react-streaming": "^0.4.19",
     "vike": "0.4.259",
     "vite": "^7.0.6",
     "wrangler": "^4.56.0"

--- a/examples/react-full/package.json
+++ b/examples/react-full/package.json
@@ -17,7 +17,7 @@
     "node-fetch": "^3.3.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-streaming": "^0.4.17",
+    "react-streaming": "^0.4.19",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
     "vite": "^7.2.6"

--- a/examples/react-streaming/package.json
+++ b/examples/react-streaming/package.json
@@ -14,7 +14,7 @@
     "express": "^5.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-streaming": "^0.4.17",
+    "react-streaming": "^0.4.19",
     "sirv": "^3.0.2",
     "vike": "0.4.259",
     "vite": "^7.2.6"

--- a/packages/vike/package.json
+++ b/packages/vike/package.json
@@ -266,7 +266,7 @@
     "@types/picomatch": "^4.0.2",
     "@types/semver": "^7.7.1",
     "@types/source-map-support": "^0.5.10",
-    "react-streaming": "^0.4.17",
+    "react-streaming": "^0.4.19",
     "rimraf": "^6.1.3",
     "rolldown": "1.0.0-rc.17",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vite:
         specifier: ^6.3.2
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -270,8 +270,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       react-streaming:
-        specifier: ^0.4.17
-        version: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.4.19
+        version: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vike:
         specifier: 0.4.259
         version: link:../../packages/vike
@@ -459,8 +459,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       react-streaming:
-        specifier: ^0.4.17
-        version: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.4.19
+        version: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -510,8 +510,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       react-streaming:
-        specifier: ^0.4.17
-        version: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.4.19
+        version: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -577,7 +577,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       telefunc:
         specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -907,8 +907,8 @@ importers:
         specifier: ^0.5.10
         version: 0.5.10
       react-streaming:
-        specifier: ^0.4.17
-        version: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.4.19
+        version: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1054,8 +1054,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       react-streaming:
-        specifier: ^0.4.17
-        version: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.4.19
+        version: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vike:
         specifier: 0.4.259
         version: link:../../packages/vike
@@ -1228,8 +1228,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       react-streaming:
-        specifier: ^0.4.17
-        version: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.4.19
+        version: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1283,7 +1283,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       telefunc:
         specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1367,13 +1367,13 @@ importers:
         version: 19.2.6(react@19.2.6)
       telefunc:
         specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       vike:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.25.5
@@ -1413,13 +1413,13 @@ importers:
         version: 19.2.6(react@19.2.6)
       telefunc:
         specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6))
+        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6))
       vike:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.31.1
@@ -1563,8 +1563,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vite:
         specifier: ^6.3.2
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1587,8 +1587,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vite:
         specifier: ^6.3.2
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1644,8 +1644,8 @@ importers:
         specifier: ^0.1.26
         version: 0.1.26(z4qai3pfulggahdiot246p567y)
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
     devDependencies:
       '@photonjs/cloudflare':
         specifier: ^0.1.13
@@ -1687,8 +1687,8 @@ importers:
         specifier: ^0.1.26
         version: 0.1.26(z4qai3pfulggahdiot246p567y)
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
     devDependencies:
       '@photonjs/runtime':
         specifier: ^0.1.16
@@ -1754,8 +1754,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vite:
         specifier: ^7.0.6
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1858,10 +1858,10 @@ importers:
         version: 19.2.6(react@19.2.6)
       telefunc:
         specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1900,8 +1900,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1946,8 +1946,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       react-streaming:
-        specifier: ^0.4.17
-        version: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.4.19
+        version: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1955,8 +1955,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vite:
         specifier: ^7.1.2
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1991,11 +1991,11 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vike-react-redux:
         specifier: 0.1.3
-        version: 0.1.3(react-redux@9.2.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)(vike-react@0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike)
+        version: 0.1.3(react-redux@9.2.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)(vike-react@0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike)
       vite:
         specifier: ^6.2.5
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -2027,11 +2027,11 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vike-react-zustand:
         specifier: ^0.1.10
-        version: 0.1.10(react-dom@19.2.6(react@19.2.6))(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vike-react@0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike)(zustand@5.0.9(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)(use-sync-external-store@1.5.0(react@19.2.6)))
+        version: 0.1.10(react-dom@19.2.6(react@19.2.6))(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vike-react@0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike)(zustand@5.0.9(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)(use-sync-external-store@1.5.0(react@19.2.6)))
       vite:
         specifier: ^7.2.2
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -2060,8 +2060,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vike-server:
         specifier: ^1.0.25
         version: 1.0.25(@hattip/core@0.0.49)(@types/express@5.0.6)(fastify@5.7.4)(srvx@0.11.16)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -2201,8 +2201,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vite:
         specifier: ^7.0.6
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -2225,8 +2225,8 @@ importers:
         specifier: 0.4.259
         version: link:../../packages/vike
       vike-react:
-        specifier: ^0.6.23
-        version: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+        specifier: ^0.6.24
+        version: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       vite:
         specifier: ^6.3.2
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -7382,8 +7382,8 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-streaming@0.4.17:
-    resolution: {integrity: sha512-FgY2BSqqgpLv0Gw5wrX3kPZttBW50vSHFZCirFbgz8AT6lZHFjhOqlhP+x7zdzAv57aD9gclAYCnTafobOJEJw==}
+  react-streaming@0.4.19:
+    resolution: {integrity: sha512-7ahdcGA5hGruNsLw6rOihWtfiKYb2NvmAYo0OaVnqiHoX5QfVNL1vgY5HkRJb5pc2Veeju6tmvaYGQ+jhrwwTA==}
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
@@ -8212,8 +8212,8 @@ packages:
       vike-react: '>=0.4.13'
       zustand: '>=5.0.0'
 
-  vike-react@0.6.23:
-    resolution: {integrity: sha512-biove5kNaqcflyTbkjpCR+ebHZOzEEmsgp8WTDadbaQRouoKz2ackjnZmwpuH0tfroMgwS63wZ92q5NfZ4cksA==}
+  vike-react@0.6.24:
+    resolution: {integrity: sha512-IoZ1Owlhc1muhHDdqOvqjchT8gcMmWvYWPdatU/aSY7qr/PPhp63+Bj0SPZgl5F3k3YWEZVmbGwsiPP8r3wy9A==}
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
@@ -14450,10 +14450,10 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@brillout/import': 0.2.6
-      '@brillout/json-serializer': 0.5.23
+      '@brillout/json-serializer': 0.5.25
       '@brillout/picocolors': 1.0.31
       isbot-fast: 1.2.0
       react: 19.2.6
@@ -15147,7 +15147,7 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
+  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.23
@@ -15161,10 +15161,10 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       react: 19.2.6
-      react-streaming: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-streaming: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
 
-  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
+  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.23
@@ -15178,10 +15178,10 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       react: 19.2.6
-      react-streaming: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-streaming: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
 
-  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6)):
+  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.23
@@ -15195,7 +15195,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       react: 19.2.6
-      react-streaming: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-streaming: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6)
 
   terser-webpack-plugin@5.3.10(esbuild@0.27.3)(webpack@5.97.1):
@@ -15541,32 +15541,32 @@ snapshots:
       - srvx
       - supports-color
 
-  vike-react-redux@0.1.3(react-redux@9.2.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)(vike-react@0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike):
+  vike-react-redux@0.1.3(react-redux@9.2.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)(vike-react@0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike):
     dependencies:
       react: 19.2.6
       react-redux: 9.2.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
       vike: link:packages/vike
-      vike-react: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+      vike-react: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
 
-  vike-react-zustand@0.1.10(react-dom@19.2.6(react@19.2.6))(react-streaming@0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vike-react@0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike)(zustand@5.0.9(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)(use-sync-external-store@1.5.0(react@19.2.6))):
+  vike-react-zustand@0.1.10(react-dom@19.2.6(react@19.2.6))(react-streaming@0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vike-react@0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike))(vike@packages+vike)(zustand@5.0.9(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)(use-sync-external-store@1.5.0(react@19.2.6))):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
       '@brillout/json-serializer': 0.5.25
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-streaming: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-streaming: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vike: link:packages/vike
-      vike-react: 0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
+      vike-react: 0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
       zustand: 5.0.9(@types/react@19.2.15)(immer@10.2.0)(react@19.2.6)(use-sync-external-store@1.5.0(react@19.2.6))
     transitivePeerDependencies:
       - supports-color
 
-  vike-react@0.6.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike):
+  vike-react@0.6.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-streaming: 0.4.17(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-streaming: 0.4.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vike: link:packages/vike
 
   vike-server@1.0.25(@hattip/core@0.0.49)(@types/express@5.0.6)(fastify@5.7.4)(srvx@0.11.16)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):

--- a/test-deprecated-design/cloudflare-workers-react-full/package.json
+++ b/test-deprecated-design/cloudflare-workers-react-full/package.json
@@ -12,7 +12,7 @@
     "node-fetch": "^2.6.9",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-streaming": "^0.4.17",
+    "react-streaming": "^0.4.19",
     "vike": "0.4.259",
     "vite": "^6.3.2",
     "wrangler": "^4.56.0"

--- a/test-deprecated-design/react-streaming/package.json
+++ b/test-deprecated-design/react-streaming/package.json
@@ -13,7 +13,7 @@
     "express": "^5.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-streaming": "^0.4.17",
+    "react-streaming": "^0.4.19",
     "sirv": "^3.0.2",
     "vike": "0.4.259",
     "vite": "^6.3.2"

--- a/test/@cloudflare_vite-plugin/package.json
+++ b/test/@cloudflare_vite-plugin/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.6",
     "telefunc": "^0.2.20",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23"
+    "vike-react": "^0.6.24"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.25.5",

--- a/test/@cloudflare_vite-plugin_ud/package.json
+++ b/test/@cloudflare_vite-plugin_ud/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.6",
     "telefunc": "^0.2.20",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23"
+    "vike-react": "^0.6.24"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.31.1",

--- a/test/environment-api/package.json
+++ b/test/environment-api/package.json
@@ -10,7 +10,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vite": "^6.3.2"
   },
   "type": "module"

--- a/test/fileEnv/package.json
+++ b/test/fileEnv/package.json
@@ -9,7 +9,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vite": "^6.3.2"
   },
   "type": "module"

--- a/test/photon-cloudflare/package.json
+++ b/test/photon-cloudflare/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^19.2.6",
     "vike": "0.4.259",
     "vike-photon": "^0.1.26",
-    "vike-react": "^0.6.23"
+    "vike-react": "^0.6.24"
   },
   "devDependencies": {
     "@photonjs/cloudflare": "^0.1.13",

--- a/test/photon-vercel/package.json
+++ b/test/photon-vercel/package.json
@@ -9,7 +9,7 @@
     "react-dom": "^19.2.6",
     "vike": "0.4.259",
     "vike-photon": "^0.1.26",
-    "vike-react": "^0.6.23"
+    "vike-react": "^0.6.24"
   },
   "devDependencies": {
     "@photonjs/runtime": "^0.1.16",

--- a/test/playground/package.json
+++ b/test/playground/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^19.2.6",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vite": "^7.0.6"
   },
   "type": "module"

--- a/test/universal-deploy/package.json
+++ b/test/universal-deploy/package.json
@@ -13,7 +13,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "telefunc": "^0.2.20",
-    "vike-react": "^0.6.23"
+    "vike-react": "^0.6.24"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/test/vavite/package.json
+++ b/test/vavite/package.json
@@ -11,7 +11,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23"
+    "vike-react": "^0.6.24"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/test/vike-react-redux/package.json
+++ b/test/vike-react-redux/package.json
@@ -15,7 +15,7 @@
     "react-redux": "^9.2.0",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vike-react-redux": "0.1.3",
     "vite": "^6.2.5"
   },

--- a/test/vike-react-zustand/package.json
+++ b/test/vike-react-zustand/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.6",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vike-react-zustand": "^0.1.10",
     "vite": "^7.2.2",
     "zustand": "^5.0.9"

--- a/test/vike-react/package.json
+++ b/test/vike-react/package.json
@@ -11,10 +11,10 @@
     "node-fetch": "^3.3.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-streaming": "^0.4.17",
+    "react-streaming": "^0.4.19",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vite": "^7.1.2"
   },
   "type": "module"

--- a/test/vike-server/package.json
+++ b/test/vike-server/package.json
@@ -11,7 +11,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vike-server": "^1.0.25",
     "vite": "^7.1.9"
   },

--- a/test/vite-plugin-vercel/package.json
+++ b/test/vite-plugin-vercel/package.json
@@ -19,7 +19,7 @@
     "react": "^19.2.6",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vite": "^7.0.6"
   },
   "dependencies": {

--- a/test/vitest/package.json
+++ b/test/vitest/package.json
@@ -5,7 +5,7 @@
     "react-dom": "^19.2.6",
     "typescript": "^5.9.3",
     "vike": "0.4.259",
-    "vike-react": "^0.6.23",
+    "vike-react": "^0.6.24",
     "vite": "^6.3.2"
   },
   "type": "module"


### PR DESCRIPTION
Bumps both dependencies to their latest versions in a single PR:

- **react-streaming** `0.4.17` → `0.4.19` ([changelog](https://github.com/brillout/react-streaming/blob/main/CHANGELOG.md))
  - fix race conditions when closing and destroying streams ([#56](https://github.com/brillout/react-streaming/issues/56))
  - update `@brillout/json-serializer` to 0.5.23 ([#57](https://github.com/brillout/react-streaming/issues/57))
- **vike-react** `0.6.23` → `0.6.24` ([compare](https://github.com/vikejs/vike-react/compare/vike-react@0.6.23...vike-react@0.6.24))
  - `react-streaming@^0.4.19`
  - use `@brillout/json-serializer` instead of `devalue`

These two bumps are coupled (`vike-react@0.6.24` requires `react-streaming@^0.4.19`), so they are combined here.

Supersedes #3320 and #3321 — both can be closed once this is merged.

The lockfile was regenerated with `pnpm install` and validated with `pnpm install --frozen-lockfile` (passes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRdmf5Y5UDkJGegxzpYZ7U)_