### PR TITLE
fix: don't force the esbuild CSS minifier on Vite 8+ (fix #3326)

### DIFF
--- a/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
+++ b/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
@@ -11,16 +11,15 @@ import path from 'node:path'
 import { existsSync } from 'node:fs'
 import type { ViteManifest, ViteManifestEntry } from '../../../../types/ViteManifest.js'
 import { assert, assertWarning } from '../../../../utils/assert.js'
-import { isVersionMatch } from '../../../../utils/assertVersion.js'
 import { getGlobalObject } from '../../../../utils/getGlobalObject.js'
 import { isEqualStringList } from '../../../../utils/isEqualStringList.js'
 import { isObject } from '../../../../utils/isObject.js'
 import { pLimit } from '../../../../utils/pLimit.js'
 import { unique } from '../../../../utils/unique.js'
 import { parseVirtualFileId } from '../../../../shared-server-node/virtualFileId.js'
-import type { Environment, ResolvedConfig, Rollup } from 'vite'
-import { version as viteVersion } from 'vite'
+import type { Environment, ResolvedConfig, Rollup, UserConfig } from 'vite'
 import { getAssetsDir } from '../../shared/getAssetsDir.js'
+import { isVite8OrAbove } from '../../shared/isVite8OrAbove.js'
 import pc from '@brillout/picocolors'
 import { isV1Design } from '../../shared/resolveVikeConfigInternal.js'
 import { getOutDirs } from '../../shared/getOutDirs.js'
@@ -363,7 +362,7 @@ async function writeManifestFile(manifest: ViteManifest, manifestFilePath: strin
   await fs.writeFile(manifestFilePath, manifestFileContent, 'utf-8')
 }
 
-async function handleAssetsManifest_getBuildConfig() {
+async function handleAssetsManifest_getBuildConfig(config: UserConfig) {
   const isFixEnabled = handleAssetsManifest_isFixEnabled()
   return {
     // https://github.com/vikejs/vike/issues/1339
@@ -374,15 +373,12 @@ async function handleAssetsManifest_getBuildConfig() {
     // default), so forcing `'esbuild'` breaks setups that don't install esbuild such as Yarn PnP. Using `true`
     // lets Vite use its bundled default minifier while still forcing minification.
     // https://github.com/vikejs/vike/issues/3326
-    cssMinify: isFixEnabled ? (isVite8OrAbove() ? true : 'esbuild') : undefined,
+    cssMinify: isFixEnabled ? (isVite8OrAbove(config) ? true : 'esbuild') : undefined,
     manifest: true,
     /* Already set by vike:build:pluginBuildApp
     copyPublicDir: !isViteServerSide_viteEnvOptional(config),
     */
   } as const
-}
-function isVite8OrAbove() {
-  return isVersionMatch(viteVersion, ['8.0.0'])
 }
 
 async function handleAssetsManifest(

--- a/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
+++ b/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
@@ -370,8 +370,8 @@ async function handleAssetsManifest_getBuildConfig(config: UserConfig) {
     // Required if `ssrEmitAssets: true`, see https://github.com/vitejs/vite/pull/11430#issuecomment-1454800934
     // We must force CSS minification (the SSR build doesn't minify CSS by default) but we mustn't force the
     // `'esbuild'` minifier: as of Vite 8 esbuild is an optional peer dependency (Lightning CSS is the new
-    // default), so forcing `'esbuild'` breaks setups that don't install esbuild such as Yarn PnP. Using `true`
-    // lets Vite use its bundled default minifier while still forcing minification.
+    // default), so forcing `'esbuild'` breaks setups that don't install esbuild. Using `true` lets Vite use
+    // its bundled default minifier while still forcing minification.
     // https://github.com/vikejs/vike/issues/3326
     cssMinify: isFixEnabled ? (isVite8OrAbove(config) ? true : 'esbuild') : undefined,
     manifest: true,

--- a/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
+++ b/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
@@ -368,11 +368,6 @@ async function handleAssetsManifest_getBuildConfig(config: UserConfig) {
     // https://github.com/vikejs/vike/issues/1339
     ssrEmitAssets: isFixEnabled ? true : undefined,
     // Required if `ssrEmitAssets: true`, see https://github.com/vitejs/vite/pull/11430#issuecomment-1454800934
-    // We must force CSS minification (the SSR build doesn't minify CSS by default) but we mustn't force the
-    // `'esbuild'` minifier: as of Vite 8 esbuild is an optional peer dependency (Lightning CSS is the new
-    // default), so forcing `'esbuild'` breaks setups that don't install esbuild. Using `true` lets Vite use
-    // its bundled default minifier while still forcing minification.
-    // https://github.com/vikejs/vike/issues/3326
     cssMinify: isFixEnabled ? (isVite8OrAbove(config) ? true : 'esbuild') : undefined,
     manifest: true,
     /* Already set by vike:build:pluginBuildApp

--- a/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
+++ b/packages/vike/src/node/vite/plugins/build/handleAssetsManifest.ts
@@ -11,6 +11,7 @@ import path from 'node:path'
 import { existsSync } from 'node:fs'
 import type { ViteManifest, ViteManifestEntry } from '../../../../types/ViteManifest.js'
 import { assert, assertWarning } from '../../../../utils/assert.js'
+import { isVersionMatch } from '../../../../utils/assertVersion.js'
 import { getGlobalObject } from '../../../../utils/getGlobalObject.js'
 import { isEqualStringList } from '../../../../utils/isEqualStringList.js'
 import { isObject } from '../../../../utils/isObject.js'
@@ -18,6 +19,7 @@ import { pLimit } from '../../../../utils/pLimit.js'
 import { unique } from '../../../../utils/unique.js'
 import { parseVirtualFileId } from '../../../../shared-server-node/virtualFileId.js'
 import type { Environment, ResolvedConfig, Rollup } from 'vite'
+import { version as viteVersion } from 'vite'
 import { getAssetsDir } from '../../shared/getAssetsDir.js'
 import pc from '@brillout/picocolors'
 import { isV1Design } from '../../shared/resolveVikeConfigInternal.js'
@@ -367,12 +369,20 @@ async function handleAssetsManifest_getBuildConfig() {
     // https://github.com/vikejs/vike/issues/1339
     ssrEmitAssets: isFixEnabled ? true : undefined,
     // Required if `ssrEmitAssets: true`, see https://github.com/vitejs/vite/pull/11430#issuecomment-1454800934
-    cssMinify: isFixEnabled ? 'esbuild' : undefined,
+    // We must force CSS minification (the SSR build doesn't minify CSS by default) but we mustn't force the
+    // `'esbuild'` minifier: as of Vite 8 esbuild is an optional peer dependency (Lightning CSS is the new
+    // default), so forcing `'esbuild'` breaks setups that don't install esbuild such as Yarn PnP. Using `true`
+    // lets Vite use its bundled default minifier while still forcing minification.
+    // https://github.com/vikejs/vike/issues/3326
+    cssMinify: isFixEnabled ? (isVite8OrAbove() ? true : 'esbuild') : undefined,
     manifest: true,
     /* Already set by vike:build:pluginBuildApp
     copyPublicDir: !isViteServerSide_viteEnvOptional(config),
     */
   } as const
+}
+function isVite8OrAbove() {
+  return isVersionMatch(viteVersion, ['8.0.0'])
 }
 
 async function handleAssetsManifest(

--- a/packages/vike/src/node/vite/plugins/build/pluginBuildConfig.ts
+++ b/packages/vike/src/node/vite/plugins/build/pluginBuildConfig.ts
@@ -51,9 +51,9 @@ function pluginBuildConfig(): Plugin[] {
       },
       config: {
         order: 'post',
-        async handler() {
+        async handler(config) {
           onSetupBuild()
-          const build = await handleAssetsManifest_getBuildConfig()
+          const build = await handleAssetsManifest_getBuildConfig(config)
           return { build }
         },
       },

--- a/packages/vike/src/node/vite/plugins/build/pluginDistFileNames.ts
+++ b/packages/vike/src/node/vite/plugins/build/pluginDistFileNames.ts
@@ -15,7 +15,7 @@ import type { OutputOptions as RolldownOutputOptions } from 'rolldown'
 import { getAssetsDir } from '../../shared/getAssetsDir.js'
 import { assertModuleId, getFilePathToShowToUserModule } from '../../shared/getFilePath.js'
 import '../../assertEnvVite.js'
-import { isVersionMatch } from '../../../../utils/assertVersion.js'
+import { isVite8OrAbove } from '../../shared/isVite8OrAbove.js'
 type PreRenderedChunk = Rollup.PreRenderedChunk
 type PreRenderedAsset = Rollup.PreRenderedAsset
 
@@ -337,12 +337,6 @@ function getCssChunkName(id: string, config: ResolvedConfig): string | undefined
     const hash = getIdHash(id)
     return `${name}-${hash}`
   }
-}
-
-function isVite8OrAbove(config: ResolvedConfig) {
-  const viteVersion = config._viteVersionResolved
-  assert(viteVersion)
-  return isVersionMatch(viteVersion, ['8.0.0'])
 }
 
 function getRollupOutputs(config: ResolvedConfig): Rollup.OutputOptions[] {

--- a/packages/vike/src/node/vite/plugins/build/pluginModuleBanner.ts
+++ b/packages/vike/src/node/vite/plugins/build/pluginModuleBanner.ts
@@ -2,9 +2,9 @@ export { pluginModuleBanner }
 
 import type { ResolvedConfig, Plugin } from 'vite'
 import { assert } from '../../../../utils/assert.js'
-import { isVersionMatch } from '../../../../utils/assertVersion.js'
 import { removeVirtualFileIdPrefix } from '../../../../utils/virtualFileId.js'
 import { getMagicString } from '../../shared/getMagicString.js'
+import { isVite8OrAbove } from '../../shared/isVite8OrAbove.js'
 import '../../assertEnvVite.js'
 
 // Misusing legal comments so that esbuild doesn't remove them.
@@ -70,7 +70,5 @@ function checkIsEnabled(config: ResolvedConfig) {
 // - https://github.com/vitejs/vite/issues/21228#issuecomment-3627899741
 // - TO-DO/eventually: remove this file once Vike requires Vite 8 or above
 function hasNativeModuleRegions(config: ResolvedConfig) {
-  const viteVersion = config._viteVersionResolved
-  assert(viteVersion)
-  return isVersionMatch(viteVersion, ['8.0.0'])
+  return isVite8OrAbove(config)
 }

--- a/packages/vike/src/node/vite/shared/isVite8OrAbove.ts
+++ b/packages/vike/src/node/vite/shared/isVite8OrAbove.ts
@@ -1,0 +1,11 @@
+export { isVite8OrAbove }
+
+import type { ResolvedConfig, UserConfig } from 'vite'
+import { assert } from '../../../utils/assert.js'
+import { isVersionMatch } from '../../../utils/assertVersion.js'
+
+function isVite8OrAbove(config: UserConfig | ResolvedConfig): boolean {
+  const viteVersion = config._viteVersionResolved
+  assert(viteVersion)
+  return isVersionMatch(viteVersion, ['8.0.0'])
+}

--- a/packages/vike/src/node/vite/shared/isVite8OrAbove.ts
+++ b/packages/vike/src/node/vite/shared/isVite8OrAbove.ts
@@ -3,6 +3,7 @@ export { isVite8OrAbove }
 import type { ResolvedConfig, UserConfig } from 'vite'
 import { assert } from '../../../utils/assert.js'
 import { isVersionMatch } from '../../../utils/assertVersion.js'
+import '../assertEnvVite.js'
 
 function isVite8OrAbove(config: UserConfig | ResolvedConfig): boolean {
   const viteVersion = config._viteVersionResolved


### PR DESCRIPTION
Closes #3326

## Problem

Vike forces `build.cssMinify` so that CSS is minified in the SSR build (required when `build.ssrEmitAssets: true`, see https://github.com/vitejs/vite/pull/11430#issuecomment-1454800934), but it hardcoded the `'esbuild'` minifier.

As of **Vite 8**, esbuild became an *optional peer dependency* and Lightning CSS is the new default CSS minifier. Forcing the literal `'esbuild'` hits Vite's `config.build.cssMinify === 'esbuild'` branch, which tries to load esbuild — and fails when it isn't installed (e.g. Yarn PnP):

```
[plugin vite:css-post]
Error: vite tried to access esbuild (a peer dependency) but it isn't provided by its ancestors
```

## Fix

```diff
-cssMinify: isFixEnabled ? 'esbuild' : undefined,
+cssMinify: isFixEnabled ? (isVite8OrAbove() ? true : 'esbuild') : undefined,
```

- **Vite ≥ 8** → `true`: forces minification while letting Vite use its **bundled** default minifier (Lightning CSS), so no esbuild is required.
- **Vite < 8** → `'esbuild'`: unchanged (esbuild is the bundled default there; Lightning CSS is opt-in).
- fix disabled → `undefined` (unchanged).

## Note

This swaps the two version branches relative to the formula in https://github.com/vikejs/vike/issues/3326#issuecomment-4667475493. Mapping Vite ≥ 8 to `'esbuild'` would re-trigger the reported error, since `=== 'esbuild'` is exactly the path that loads esbuild; `true` is the safe value on Vite 8 because that's where the default became Lightning CSS.

https://claude.ai/code/session_01HQnoXP8YgbyUpTgKWqwaRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQnoXP8YgbyUpTgKWqwaRn)_