### PR TITLE
perf: skip old-design glob imports for V1-design projects

### DIFF
--- a/packages/vike/src/node/vite/plugins/pluginVirtualFiles/generateVirtualFileGlobalEntryWithOldDesign.ts
+++ b/packages/vike/src/node/vite/plugins/pluginVirtualFiles/generateVirtualFileGlobalEntryWithOldDesign.ts
@@ -17,7 +17,7 @@ import { version as viteVersion } from 'vite'
 import { type FileType, fileTypes } from '../../../../shared-server-client/getPageFiles/fileTypes.js'
 import path from 'node:path'
 import { generateVirtualFileGlobalEntry } from './generateVirtualFileGlobalEntry.js'
-import { getVikeConfigInternal } from '../../shared/resolveVikeConfigInternal.js'
+import { getVikeConfigInternal, isV1Design } from '../../shared/resolveVikeConfigInternal.js'
 import { getOutDirs } from '../../shared/getOutDirs.js'
 import { isViteServerSide_extraSafe } from '../../shared/isViteServerSide.js'
 import { resolveIncludeAssetsImportedByServer } from '../../../../server/runtime/renderPageServer/getPageAssets/retrievePageAssetsProd.js'
@@ -128,6 +128,11 @@ export const neverLoaded = {};
 ${await generateVirtualFileGlobalEntry(isForClientSide, isDev, id, isClientRouting)}
 
 `
+
+  // Projects using the V1 design (+config.ts) have no .page.client/.page.server/.page.route files,
+  // so the glob calls below would expand to empty objects. Skip them entirely to keep the
+  // global-entry virtual module lean for the common case.
+  if (isV1Design()) return fileContent
 
   const vikeConfig = await getVikeConfigInternal()
 


### PR DESCRIPTION
## What

`generateVirtualFileGlobalEntryWithOldDesign()` always emits up to 7 `import.meta.glob()` calls — covering `.page`, `.page.client`, `.page.server`, `.page.route` × (import + exportNames + extractAssets) — into the `global-entry` virtual module, regardless of design.

In a **V1-design** project (using `+config.ts` files) there are no `.page.*` files, so every one of those globs expands to an empty object. Zero benefit, but Vite still scans the project tree (glob root is `/`) for each pattern.

## Change

Check `isV1Design()` before the glob block and return early when the project uses only the new design. The empty-object exports (`pageFilesLazy`, `pageFilesEager`, etc.) are still emitted above the early return, so the module's public shape is unchanged.

Old-design and mixed-design projects are unaffected (`isV1Design()` is `false` for them).

## Context

Split out from #3336 (the import-deduplication change) so the two perf improvements can be reviewed and merged independently.

https://claude.ai/code/session_0194Javu51nwH7cthohuX9X5

---
_Generated by [Claude Code](https://claude.ai/code/session_0194Javu51nwH7cthohuX9X5)_