### PR TITLE
fix: load +config.server with pointer import

### DIFF
--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/metaBuiltIn.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/metaBuiltIn.ts
@@ -353,7 +353,7 @@ const metaBuiltIn: ConfigDefinitionsBuiltIn = {
     global: true,
   },
   server: {
-    env: { server: true },
+    env: { server: true, config: true },
     global: true,
   },
   cli: {


### PR DESCRIPTION
Fix #3341

### Changes
- [x] resolve `+config.server` with pointer import
- [ ] load server app from `+config.server` instead of the default one