### PR TITLE
fix: prepend base to prerender redirect target URLs (fix #3349)

### DIFF
--- a/packages/vike/src/node/prerender/runPrerender.ts
+++ b/packages/vike/src/node/prerender/runPrerender.ts
@@ -25,6 +25,7 @@ import { pLimit, PLimit } from '../../utils/pLimit.js'
 import { preservePropertyGetters } from '../../utils/preservePropertyGetters.js'
 import { assertPosixPath } from '../../utils/path.js'
 import { urlToFile } from '../../utils/urlToFile.js'
+import { prependBase } from '../../utils/parseUrl-extras.js'
 import { prerenderPage } from '../../server/runtime/renderPageServer/renderPageServerAfterRoute.js'
 import { createPageContextServer } from '../../server/runtime/renderPageServer/createPageContextServer.js'
 import pc from '@brillout/picocolors'
@@ -1170,7 +1171,8 @@ async function prerenderRedirects(
   const redirectsStatic = getStaticRedirectsForPrerender(redirects, showWarningUponDynamicRedirects)
   for (const [urlSource, urlTarget] of Object.entries(redirectsStatic)) {
     const urlOriginal = urlSource
-    const htmlString = getRedirectHtml(urlTarget)
+    const urlTargetWithBase = urlTarget.startsWith('/') ? prependBase(urlTarget, globalContext.baseServer) : urlTarget
+    const htmlString = getRedirectHtml(urlTargetWithBase)
     await onComplete({
       pageContext: { urlOriginal, pageId: null, is404: false, isRedirect: true },
       htmlString,


### PR DESCRIPTION
## Summary

When a Vite `base` is configured (e.g. `base: '/my-app/'`), the prerendered redirect HTML files contain redirect URLs **without** the base prefix, causing broken static redirects.

For example, with `redirects: { '/docs': '/docs/introduction' }` and `base: '/my-app/'`:

- **Before (broken):** `<meta http-equiv="refresh" content="0;url=/docs/introduction">`
- **After (fixed):** `<meta http-equiv="refresh" content="0;url=/my-app/docs/introduction">`

The server-side redirect handling in `renderPageServer.ts` correctly calls `prependBase()` on the target, but `prerenderRedirects()` in `runPrerender.ts` was missing this step.

## Fix

Prepend the base to internal redirect targets (`urlTarget.startsWith('/')`) in `prerenderRedirects()`, consistent with the server-side behavior. External redirect targets (e.g. `mailto:`, `https://`) are left unchanged.

Closes #3349

## Test plan

- [ ] Set a Vite `base` and define static redirects in config
- [ ] Run `vite build` with prerendering enabled
- [ ] Verify the generated redirect HTML includes the base in the redirect URL
- [ ] Verify external redirect targets (e.g. `https://...`) are not affected
- [ ] Verify redirects still work correctly when no base is configured (`base: '/'`)