### PR TITLE
docs(extensions): add vike-vue-content under Vue section

### DIFF
--- a/docs/pages/extensions/+Page.mdx
+++ b/docs/pages/extensions/+Page.mdx
@@ -85,3 +85,8 @@ Adapters for integrating a <Link href="/server">server framework</Link>:
 - [`@vikejs/fastify`](https://github.com/vikejs/servers/tree/main/packages/fastify#readme)
 
 <Contribution>[Contributions welcome](https://github.com/vikejs/vike/issues/1715) to create extensions.</Contribution>
+
+
+## Frameworks
+
+- [`vike-vue-content`](https://github.com/EralChen/vike-vue-content#readme) - Content rendering framework built on Vike + Vue for docs sites with content-driven routing and zero-boilerplate setup.


### PR DESCRIPTION
Adds vike-vue-content to the Extensions page.

Note: for now, I placed it under the Vue section. Happy to move it to a dedicated Frameworks section if preferred.