### PR TITLE
docs(extensions): add Rudder under Frameworks

### DIFF
--- a/docs/pages/extensions/+Page.mdx
+++ b/docs/pages/extensions/+Page.mdx
@@ -90,4 +90,4 @@ Adapters for integrating a <Link href="/server">server framework</Link>:
 ## Frameworks
 
 - [`vike-vue-content`](https://github.com/EralChen/vike-vue-content#readme) - Content rendering framework built on Vike + Vue for docs sites with content-driven routing and zero-boilerplate setup.
-- [RudderJS](https://github.com/rudderjs/rudder#readme) - Laravel-inspired, framework-agnostic Node.js meta-framework built on Vike + Vite - DI container, Eloquent-style ORM, Rudder CLI, middleware, queues, and auth.
+- [Rudder](https://github.com/rudderjs/rudder#readme) - Laravel-inspired, framework-agnostic Node.js meta-framework built on Vike + Vite - DI container, Eloquent-style ORM, Rudder CLI, middleware, queues, and auth.

--- a/docs/pages/extensions/+Page.mdx
+++ b/docs/pages/extensions/+Page.mdx
@@ -90,3 +90,4 @@ Adapters for integrating a <Link href="/server">server framework</Link>:
 ## Frameworks
 
 - [`vike-vue-content`](https://github.com/EralChen/vike-vue-content#readme) - Content rendering framework built on Vike + Vue for docs sites with content-driven routing and zero-boilerplate setup.
+- [RudderJS](https://github.com/rudderjs/rudder#readme) - Laravel-inspired, framework-agnostic Node.js meta-framework built on Vike + Vite - DI container, Eloquent-style ORM, Rudder CLI, middleware, queues, and auth.


### PR DESCRIPTION
Adds RudderJS to the new Frameworks section, as suggested by @brillout in #3351.

RudderJS is a Laravel-inspired, framework-agnostic Node.js meta-framework built on Vike + Vite (DI container, Eloquent-style ORM, CLI, middleware, queues, auth). Repo: https://github.com/rudderjs/rudder

Placed as a Frameworks entry matching the existing format. Happy to adjust the wording or link target if preferred.