### PR TITLE
fix: make Vike extension installation idempotent (fix #3354)

### DIFF
--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
@@ -396,17 +396,11 @@ async function resolveConfigDefinitions(
   > = {}
   await Promise.all(
     objectEntries(plusFilesByLocationId).map(async ([locationIdPage, plusFiles]) => {
-      // dedupeExtensions(): make Vike extension installation idempotent across config inheritance
-      // — a Vike extension inherited from an ancestor isn't applied again at a descendant. The list
-      // is sorted by inheritance order, so the most-specific occurrence is kept.
-      // https://github.com/vikejs/vike/issues/3354
-      const plusFilesRelevant: PlusFile[] = dedupeExtensions(
-        objectEntries(plusFilesByLocationId)
-          .filter(([locationId]) => isInherited(locationId, locationIdPage))
-          .map(([, plusFiles]) => plusFiles)
-          .flat()
-          .sort((plusFile1, plusFile2) => sortAfterInheritanceOrderPage(plusFile1, plusFile2, locationIdPage, null)),
-      )
+      const plusFilesRelevant: PlusFile[] = objectEntries(plusFilesByLocationId)
+        .filter(([locationId]) => isInherited(locationId, locationIdPage))
+        .map(([, plusFiles]) => plusFiles)
+        .flat()
+        .sort((plusFile1, plusFile2) => sortAfterInheritanceOrderPage(plusFile1, plusFile2, locationIdPage, null))
       const { configDefinitions, peerDependencyConfigNames } = collectConfigDefinitions(
         plusFilesRelevant,
         (configDef) => configDef.global !== true,
@@ -474,24 +468,12 @@ function getPageConfigsBuildTime(
     configDefinitions: configDefinitionsResolved.configDefinitionsGlobal,
     configValueSources: {},
   }
-  // dedupeExtensions(): a Vike extension contributes its global config at most once, even when
-  // installed at several locationIds. The list is sorted by global inheritance order, so the
-  // highest-precedence occurrence is kept. https://github.com/vikejs/vike/issues/3354
-  // We use all of `plusFilesByLocationId` (not just global locations) in order to allow non-global
-  // Vike extensions to create global configs, and to set the value of global configs such as
-  // `+vite` (enabling Vike extensions to add Vite plugins).
-  const plusFilesGlobal = dedupeExtensions(
-    Object.values(plusFilesByLocationId)
-      .flat()
-      .sort((plusFile1, plusFile2) =>
-        sortAfterInheritanceOrderGlobal(plusFile1, plusFile2, plusFilesByLocationId, null),
-      ),
-  )
   objectEntries(configDefinitionsResolved.configDefinitionsGlobal).forEach(([configName, configDef]) => {
     const sources = resolveConfigValueSources(
       configName,
       configDef,
-      plusFilesGlobal,
+      // We use `plusFilesByLocationId` in order to allow non-global Vike extensions to create global configs, and to set the value of global configs such as `+vite` (enabling Vike extensions to add Vite plugins).
+      Object.values(plusFilesByLocationId).flat(),
       userRootDir,
       true,
       plusFilesByLocationId,
@@ -922,9 +904,13 @@ function resolveConfigValueSources(
   isGlobal: boolean,
   plusFilesByLocationId: PlusFilesByLocationId,
 ): ConfigValueSource[] {
-  let sources: ConfigValueSource[] = plusFilesRelevant
-    .filter((plusFile) => isDefiningConfig(plusFile, configName))
-    .flatMap((plusFile) => getConfigValueSources(configName, plusFile, configDef, userRootDir))
+  // dedupeExtensions(): make Vike extension installation idempotent — a Vike extension contributes
+  // its config value at most once, however many times it's installed (reached over several
+  // `extends`, installed at different paths, or inherited across locationIds).
+  // https://github.com/vikejs/vike/issues/3354
+  let sources: ConfigValueSource[] = dedupeExtensions(
+    plusFilesRelevant.filter((plusFile) => isDefiningConfig(plusFile, configName)),
+  ).flatMap((plusFile) => getConfigValueSources(configName, plusFile, configDef, userRootDir))
 
   // Filter hydrid global-local configs
   if (!isCallable(configDef.global)) {

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
@@ -88,6 +88,7 @@ import {
 } from '../../../shared-server-client/page-configs/serialize/serializeConfigValues.js'
 import {
   getPlusFilesByLocationId,
+  dedupeExtensions,
   type PlusFile,
   type PlusFilesByLocationId,
 } from './resolveVikeConfigInternal/getPlusFilesByLocationId.js'
@@ -395,11 +396,17 @@ async function resolveConfigDefinitions(
   > = {}
   await Promise.all(
     objectEntries(plusFilesByLocationId).map(async ([locationIdPage, plusFiles]) => {
-      const plusFilesRelevant: PlusFile[] = objectEntries(plusFilesByLocationId)
-        .filter(([locationId]) => isInherited(locationId, locationIdPage))
-        .map(([, plusFiles]) => plusFiles)
-        .flat()
-        .sort((plusFile1, plusFile2) => sortAfterInheritanceOrderPage(plusFile1, plusFile2, locationIdPage, null))
+      // dedupeExtensions(): make Vike extension installation idempotent across config inheritance
+      // — a Vike extension inherited from an ancestor isn't applied again at a descendant. The list
+      // is sorted by inheritance order, so the most-specific occurrence is kept.
+      // https://github.com/vikejs/vike/issues/3354
+      const plusFilesRelevant: PlusFile[] = dedupeExtensions(
+        objectEntries(plusFilesByLocationId)
+          .filter(([locationId]) => isInherited(locationId, locationIdPage))
+          .map(([, plusFiles]) => plusFiles)
+          .flat()
+          .sort((plusFile1, plusFile2) => sortAfterInheritanceOrderPage(plusFile1, plusFile2, locationIdPage, null)),
+      )
       const { configDefinitions, peerDependencyConfigNames } = collectConfigDefinitions(
         plusFilesRelevant,
         (configDef) => configDef.global !== true,
@@ -467,12 +474,24 @@ function getPageConfigsBuildTime(
     configDefinitions: configDefinitionsResolved.configDefinitionsGlobal,
     configValueSources: {},
   }
+  // dedupeExtensions(): a Vike extension contributes its global config at most once, even when
+  // installed at several locationIds. The list is sorted by global inheritance order, so the
+  // highest-precedence occurrence is kept. https://github.com/vikejs/vike/issues/3354
+  // We use all of `plusFilesByLocationId` (not just global locations) in order to allow non-global
+  // Vike extensions to create global configs, and to set the value of global configs such as
+  // `+vite` (enabling Vike extensions to add Vite plugins).
+  const plusFilesGlobal = dedupeExtensions(
+    Object.values(plusFilesByLocationId)
+      .flat()
+      .sort((plusFile1, plusFile2) =>
+        sortAfterInheritanceOrderGlobal(plusFile1, plusFile2, plusFilesByLocationId, null),
+      ),
+  )
   objectEntries(configDefinitionsResolved.configDefinitionsGlobal).forEach(([configName, configDef]) => {
     const sources = resolveConfigValueSources(
       configName,
       configDef,
-      // We use `plusFilesByLocationId` in order to allow non-global Vike extensions to create global configs, and to set the value of global configs such as `+vite` (enabling Vike extensions to add Vite plugins).
-      Object.values(plusFilesByLocationId).flat(),
+      plusFilesGlobal,
       userRootDir,
       true,
       plusFilesByLocationId,

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
@@ -905,8 +905,9 @@ function resolveConfigValueSources(
   plusFilesByLocationId: PlusFilesByLocationId,
 ): ConfigValueSource[] {
   // dedupeExtensions(): make Vike extension installation idempotent — a Vike extension contributes
-  // its config value at most once, however many times it's installed (reached over several
-  // `extends`, installed at different paths, or inherited across locationIds).
+  // its config value at most once, however many times it's installed (over several `extends`, at
+  // different paths, or across config inheritance). For a page, `plusFilesRelevant` is ordered by
+  // inheritance, so the occurrence closest to the page's locationId is the one kept.
   // https://github.com/vikejs/vike/issues/3354
   let sources: ConfigValueSource[] = dedupeExtensions(
     plusFilesRelevant.filter((plusFile) => isDefiningConfig(plusFile, configName)),

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
@@ -904,14 +904,16 @@ function resolveConfigValueSources(
   isGlobal: boolean,
   plusFilesByLocationId: PlusFilesByLocationId,
 ): ConfigValueSource[] {
-  // dedupeExtensions(): make Vike extension installation idempotent — a Vike extension contributes
+  let plusFilesConfig = plusFilesRelevant.filter((plusFile) => isDefiningConfig(plusFile, configName))
+  // Make Vike extension installation idempotent. (Don't cumulate the configs twice of an extension installed twice.) Since `plusFilesRelevant` is ordered by inheritance the occurrence closest to the page's locationId is the one kept.
+  // — a Vike extension contributes
   // its config value at most once, however many times it's installed (over several `extends`, at
-  // different paths, or across config inheritance). For a page, `plusFilesRelevant` is ordered by
-  // inheritance, so the occurrence closest to the page's locationId is the one kept.
-  // https://github.com/vikejs/vike/issues/3354
-  let sources: ConfigValueSource[] = dedupeExtensions(
-    plusFilesRelevant.filter((plusFile) => isDefiningConfig(plusFile, configName)),
-  ).flatMap((plusFile) => getConfigValueSources(configName, plusFile, configDef, userRootDir))
+  // different paths, or across config inheritance).
+  plusFilesConfig = dedupeExtensions(plusFilesConfig)
+
+  let sources: ConfigValueSource[] = plusFilesConfig.flatMap((plusFile) =>
+    getConfigValueSources(configName, plusFile, configDef, userRootDir),
+  )
 
   // Filter hydrid global-local configs
   if (!isCallable(configDef.global)) {
@@ -933,14 +935,12 @@ function resolveConfigValueSources(
 function isDefiningConfig(plusFile: PlusFile, configName: string) {
   return getConfigNamesSetByPlusFile(plusFile).includes(configName)
 }
-// Dedupe Vike extensions by their `name` (extension identity), keeping the first occurrence.
-// Non-extension plus files are always kept.
 function dedupeExtensions(plusFiles: PlusFile[]): PlusFile[] {
   const seen = new Set<string>()
   return plusFiles.filter((plusFile) => {
     if (!plusFile.isConfigFile || !plusFile.isExtensionConfig) return true
-    // The extension's `name` is guaranteed by assertExtensionsConventions()
     const name = getNameValue(plusFile)
+    // The extension's `name` is guaranteed by assertExtensionsConventions()
     assert(name)
     if (seen.has(name)) return false
     seen.add(name)

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
@@ -91,6 +91,7 @@ import {
   type PlusFile,
   type PlusFilesByLocationId,
 } from './resolveVikeConfigInternal/getPlusFilesByLocationId.js'
+import { getNameValue } from './resolveVikeConfigInternal/assertExtensions.js'
 import { getEnvVarObject } from './getEnvVarObject.js'
 import { getVikeApiOperation } from '../../../shared-server-node/api-context.js'
 import { getCliOptions } from '../../cli/context.js'
@@ -939,10 +940,8 @@ function dedupeExtensions(plusFiles: PlusFile[]): PlusFile[] {
   return plusFiles.filter((plusFile) => {
     if (!plusFile.isConfigFile || !plusFile.isExtensionConfig) return true
     // The extension's `name` is guaranteed by assertExtensionsConventions()
-    const confVal = getConfVal(plusFile, 'name')
-    assert(confVal?.valueIsLoaded)
-    const name = confVal.value
-    assert(typeof name === 'string')
+    const name = getNameValue(plusFile)
+    assert(name)
     if (seen.has(name)) return false
     seen.add(name)
     return true

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
@@ -905,10 +905,7 @@ function resolveConfigValueSources(
   plusFilesByLocationId: PlusFilesByLocationId,
 ): ConfigValueSource[] {
   let plusFilesConfig = plusFilesRelevant.filter((plusFile) => isDefiningConfig(plusFile, configName))
-  // Make Vike extension installation idempotent. (Don't cumulate the configs twice of an extension installed twice.) Since `plusFilesRelevant` is ordered by inheritance the occurrence closest to the page's locationId is the one kept.
-  // — a Vike extension contributes
-  // its config value at most once, however many times it's installed (over several `extends`, at
-  // different paths, or across config inheritance).
+  // Make Vike extension installation idempotent. (Don't cumulate configs twice of an extension installed twice.) Since `plusFilesRelevant` is ordered by inheritance the occurrence closest to the page's locationId is the one kept.
   plusFilesConfig = dedupeExtensions(plusFilesConfig)
 
   let sources: ConfigValueSource[] = plusFilesConfig.flatMap((plusFile) =>

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal.ts
@@ -88,7 +88,6 @@ import {
 } from '../../../shared-server-client/page-configs/serialize/serializeConfigValues.js'
 import {
   getPlusFilesByLocationId,
-  dedupeExtensions,
   type PlusFile,
   type PlusFilesByLocationId,
 } from './resolveVikeConfigInternal/getPlusFilesByLocationId.js'
@@ -932,6 +931,22 @@ function resolveConfigValueSources(
 }
 function isDefiningConfig(plusFile: PlusFile, configName: string) {
   return getConfigNamesSetByPlusFile(plusFile).includes(configName)
+}
+// Dedupe Vike extensions by their `name` (extension identity), keeping the first occurrence.
+// Non-extension plus files are always kept.
+function dedupeExtensions(plusFiles: PlusFile[]): PlusFile[] {
+  const seen = new Set<string>()
+  return plusFiles.filter((plusFile) => {
+    if (!plusFile.isConfigFile || !plusFile.isExtensionConfig) return true
+    // The extension's `name` is guaranteed by assertExtensionsConventions()
+    const confVal = getConfVal(plusFile, 'name')
+    assert(confVal?.valueIsLoaded)
+    const name = confVal.value
+    assert(typeof name === 'string')
+    if (seen.has(name)) return false
+    seen.add(name)
+    return true
+  })
 }
 function getConfigValueSources(
   configName: string,

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/assertExtensions.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/assertExtensions.ts
@@ -1,5 +1,6 @@
 export { assertExtensionsConventions }
 export { assertExtensionsRequire }
+// TODO/now rename getNameValue getNameConfigValue
 export { getNameValue }
 
 import pc from '@brillout/picocolors'

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/assertExtensions.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/assertExtensions.ts
@@ -1,6 +1,5 @@
 export { assertExtensionsConventions }
 export { assertExtensionsRequire }
-export { getNameValue }
 
 import pc from '@brillout/picocolors'
 import { PROJECT_VERSION } from '../../../../utils/PROJECT_VERSION.js'

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/assertExtensions.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/assertExtensions.ts
@@ -1,5 +1,6 @@
 export { assertExtensionsConventions }
 export { assertExtensionsRequire }
+export { getNameValue }
 
 import pc from '@brillout/picocolors'
 import { PROJECT_VERSION } from '../../../../utils/PROJECT_VERSION.js'

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
@@ -13,7 +13,7 @@ import { type ConfigFile, loadConfigFile, loadValueFile, PointerImportLoaded } f
 import { resolvePointerImport } from './resolvePointerImport.js'
 import { getFilePathResolved } from '../getFilePath.js'
 import type { FilePathResolved } from '../../../../types/FilePath.js'
-import { assertExtensionsConventions, assertExtensionsRequire } from './assertExtensions.js'
+import { assertExtensionsConventions, assertExtensionsRequire, getNameValue } from './assertExtensions.js'
 import '../../assertEnvVite.js'
 
 type PlusFile = PlusFileConfig | PlusFileValue
@@ -83,7 +83,7 @@ async function getPlusFilesByLocationId(
 
         plusFilesByLocationId[locationId] = plusFilesByLocationId[locationId] ?? []
         plusFilesByLocationId[locationId]!.push(plusFile)
-        dedupeExtendsConfigs(extendsConfigs).forEach((extendsConfig) => {
+        extendsConfigs.forEach((extendsConfig) => {
           /* We purposely use the same locationId because the Vike extension's config should only apply to where it's being extended from, for example:
           ```js
           // /pages/admin/+config.js
@@ -133,9 +133,12 @@ async function getPlusFilesByLocationId(
     }),
   )
 
-  // Make lists element order deterministic
-  Object.entries(plusFilesByLocationId).forEach(([_locationId, plusFiles]) => {
+  Object.entries(plusFilesByLocationId).forEach(([locationId, plusFiles]) => {
+    // Make lists element order deterministic
     plusFiles.sort(sortMakeDeterministic)
+    // Make Vike extension installation idempotent: a Vike extension is added at most once per
+    // locationId. https://github.com/vikejs/vike/issues/3354
+    plusFilesByLocationId[locationId as LocationId] = dedupeExtensions(plusFiles)
   })
 
   assertPlusFiles(plusFilesByLocationId)
@@ -184,13 +187,18 @@ function getPlusFileFromConfigFile(
   return plusFile
 }
 
-// Make Vike extension installation idempotent
-function dedupeExtendsConfigs(extendsConfigs: ConfigFile[]): ConfigFile[] {
+// Keep each Vike extension at most once. Extensions are identified by their `name` setting: the
+// same extension can be reached over multiple `extends` and even live at different paths (e.g. two
+// extensions each bundling their own copy of it).
+function dedupeExtensions(plusFiles: PlusFile[]): PlusFile[] {
   const seen = new Set<string>()
-  return extendsConfigs.filter((extendsConfig) => {
-    const key = extendsConfig.filePath.filePathAbsoluteFilesystem
-    if (seen.has(key)) return false
-    seen.add(key)
+  return plusFiles.filter((plusFile) => {
+    if (!plusFile.isConfigFile || !plusFile.isExtensionConfig) return true
+    // `name` is guaranteed by assertExtensionsConventions()
+    const name = getNameValue(plusFile)
+    assert(name)
+    if (seen.has(name)) return false
+    seen.add(name)
     return true
   })
 }

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
@@ -134,12 +134,9 @@ async function getPlusFilesByLocationId(
     }),
   )
 
-  Object.entries(plusFilesByLocationId).forEach(([locationId, plusFiles]) => {
-    // Make lists element order deterministic
+  // Make lists element order deterministic
+  Object.entries(plusFilesByLocationId).forEach(([_locationId, plusFiles]) => {
     plusFiles.sort(sortMakeDeterministic)
-    // Make Vike extension installation idempotent: a Vike extension is added at most once per
-    // locationId. https://github.com/vikejs/vike/issues/3354
-    plusFilesByLocationId[locationId as LocationId] = dedupeExtensions(plusFiles)
   })
 
   assertPlusFiles(plusFilesByLocationId)

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
@@ -1,4 +1,5 @@
 export { getPlusFilesByLocationId }
+export { dedupeExtensions }
 export type { PlusFileValue }
 export type { PlusFile }
 export type { PlusFilesByLocationId }

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
@@ -1,5 +1,4 @@
 export { getPlusFilesByLocationId }
-export { dedupeExtensions }
 export type { PlusFileValue }
 export type { PlusFile }
 export type { PlusFilesByLocationId }
@@ -14,7 +13,7 @@ import { type ConfigFile, loadConfigFile, loadValueFile, PointerImportLoaded } f
 import { resolvePointerImport } from './resolvePointerImport.js'
 import { getFilePathResolved } from '../getFilePath.js'
 import type { FilePathResolved } from '../../../../types/FilePath.js'
-import { assertExtensionsConventions, assertExtensionsRequire, getNameValue } from './assertExtensions.js'
+import { assertExtensionsConventions, assertExtensionsRequire } from './assertExtensions.js'
 import '../../assertEnvVite.js'
 
 type PlusFile = PlusFileConfig | PlusFileValue
@@ -183,22 +182,6 @@ function getPlusFileFromConfigFile(
     extendsFilePaths,
   }
   return plusFile
-}
-
-// Keep each Vike extension at most once. Extensions are identified by their `name` setting: the
-// same extension can be reached over multiple `extends` and even live at different paths (e.g. two
-// extensions each bundling their own copy of it).
-function dedupeExtensions(plusFiles: PlusFile[]): PlusFile[] {
-  const seen = new Set<string>()
-  return plusFiles.filter((plusFile) => {
-    if (!plusFile.isConfigFile || !plusFile.isExtensionConfig) return true
-    // `name` is guaranteed by assertExtensionsConventions()
-    const name = getNameValue(plusFile)
-    assert(name)
-    if (seen.has(name)) return false
-    seen.add(name)
-    return true
-  })
 }
 
 // Make order deterministic (no other purpose)

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
@@ -83,7 +83,6 @@ async function getPlusFilesByLocationId(
 
         plusFilesByLocationId[locationId] = plusFilesByLocationId[locationId] ?? []
         plusFilesByLocationId[locationId]!.push(plusFile)
-        // Make Vike extension installation idempotent: https://github.com/vikejs/vike/issues/3354
         dedupeExtendsConfigs(extendsConfigs).forEach((extendsConfig) => {
           /* We purposely use the same locationId because the Vike extension's config should only apply to where it's being extended from, for example:
         ```js
@@ -185,7 +184,7 @@ function getPlusFileFromConfigFile(
   return plusFile
 }
 
-// Dedupe Vike extensions by their config file path (i.e. by extension identity).
+// Make Vike extension installation idempotent
 function dedupeExtendsConfigs(extendsConfigs: ConfigFile[]): ConfigFile[] {
   const seen = new Set<string>()
   return extendsConfigs.filter((extendsConfig) => {

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/getPlusFilesByLocationId.ts
@@ -83,7 +83,8 @@ async function getPlusFilesByLocationId(
 
         plusFilesByLocationId[locationId] = plusFilesByLocationId[locationId] ?? []
         plusFilesByLocationId[locationId]!.push(plusFile)
-        extendsConfigs.forEach((extendsConfig) => {
+        // Make Vike extension installation idempotent: https://github.com/vikejs/vike/issues/3354
+        dedupeExtendsConfigs(extendsConfigs).forEach((extendsConfig) => {
           /* We purposely use the same locationId because the Vike extension's config should only apply to where it's being extended from, for example:
         ```js
         // /pages/admin/+config.js
@@ -182,6 +183,17 @@ function getPlusFileFromConfigFile(
     extendsFilePaths,
   }
   return plusFile
+}
+
+// Dedupe Vike extensions by their config file path (i.e. by extension identity).
+function dedupeExtendsConfigs(extendsConfigs: ConfigFile[]): ConfigFile[] {
+  const seen = new Set<string>()
+  return extendsConfigs.filter((extendsConfig) => {
+    const key = extendsConfig.filePath.filePathAbsoluteFilesystem
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
 }
 
 // Make order deterministic (no other purpose)


### PR DESCRIPTION
Fixes #3354

## Problem

When the same Vike extension is reached over multiple `extends` paths, its config file is loaded and added **once per `extends` occurrence**. For example, when two Vike extensions both self-install `vike-data`:

```js
// /pages/+config.js
export default { extends: [extensionA, extensionB] }
// extensionA → extends: [vikeData]
// extensionB → extends: [vikeData]
```

`vike-data`'s config is added twice at the same `locationId`. For **cumulative** settings, this means `vike-data`'s contributions land twice (once per `extends`).

## Fix

In `getPlusFilesByLocationId()`, the flattened transitive list of `extends` configs is now deduplicated by config file path (i.e. by extension identity) before being turned into plus files. An extension is therefore installed only once, regardless of how many `extends` paths reach it.

Deduplication is by `filePathAbsoluteFilesystem`, the file's real identity:
- The same extension (same resolved file) reached via different import paths is correctly deduped to one.
- Two genuinely different extensions never collide (distinct files ⇒ distinct paths).
- Final ordering is unaffected — plus files are re-sorted deterministically by path afterwards.

This is scoped to the diamond case the issue describes (extensions self-installing a shared extension, which always lands at the same `locationId`). Non-cumulative configs are unaffected (a duplicated source was already overridden by its identical self).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyirhuWubZ32ZWoiscPWbr