### PR TITLE
fix: don't crash request logger on redirect from +middleware (fix #3357)

### DIFF
--- a/packages/vike/src/server/runtime/renderPageServer.ts
+++ b/packages/vike/src/server/runtime/renderPageServer.ts
@@ -459,7 +459,9 @@ function logHttpResponse(urlOriginalPretty: string, pageContextReturn: PageConte
         const headerRedirect = pageContextReturn.httpResponse.headers
           .slice()
           .reverse()
-          .find((header) => header[0] === 'Location')
+          // Case-insensitive: a redirect returned by a +middleware comes from a Web Response whose
+          // Headers object lower-cases header names (`location`), while Vike's own redirect() uses `Location`.
+          .find((header) => header[0].toLowerCase() === 'location')
         assert(headerRedirect)
         const urlRedirect = headerRedirect[1]
         urlOriginalPretty = urlRedirect

--- a/test/plusMiddlewares/.testRun.ts
+++ b/test/plusMiddlewares/.testRun.ts
@@ -27,6 +27,14 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     expect(response.status).toBe(200)
     expect(await response.text()).toBe('OK')
   })
+
+  // https://github.com/vikejs/vike/issues/3357
+  test('Middleware returning a redirect (3xx) Response', async () => {
+    const response: Response = await fetch(`${getServerUrl()}/redirect-middleware`, { redirect: 'manual' })
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get('Location')).toBe('/')
+  })
 }
 
 async function testCounter() {

--- a/test/plusMiddlewares/.testRun.ts
+++ b/test/plusMiddlewares/.testRun.ts
@@ -28,7 +28,6 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
     expect(await response.text()).toBe('OK')
   })
 
-  // https://github.com/vikejs/vike/issues/3357
   test('Middleware returning a redirect (3xx) Response', async () => {
     const response: Response = await fetch(`${getServerUrl()}/redirect-middleware`, { redirect: 'manual' })
 

--- a/test/plusMiddlewares/pages/+middleware.ts
+++ b/test/plusMiddlewares/pages/+middleware.ts
@@ -10,10 +10,6 @@ const middleware = enhance(someUniversalMiddleware, {
   path: '/middleware',
 })
 
-// A +middleware returning a redirect (3xx) Response.
-// Using a capital-L `Location` header on purpose: the Web `Headers` object lower-cases it to
-// `location`, which used to crash Vike's request logger (`assert(headerRedirect)`). See:
-// https://github.com/vikejs/vike/issues/3357
 const redirectUniversalMiddleware: UniversalMiddleware = async () => {
   return new Response(null, { status: 303, headers: { Location: '/' } })
 }

--- a/test/plusMiddlewares/pages/+middleware.ts
+++ b/test/plusMiddlewares/pages/+middleware.ts
@@ -10,4 +10,18 @@ const middleware = enhance(someUniversalMiddleware, {
   path: '/middleware',
 })
 
-export default middleware
+// A +middleware returning a redirect (3xx) Response.
+// Using a capital-L `Location` header on purpose: the Web `Headers` object lower-cases it to
+// `location`, which used to crash Vike's request logger (`assert(headerRedirect)`). See:
+// https://github.com/vikejs/vike/issues/3357
+const redirectUniversalMiddleware: UniversalMiddleware = async () => {
+  return new Response(null, { status: 303, headers: { Location: '/' } })
+}
+
+const redirectMiddleware = enhance(redirectUniversalMiddleware, {
+  name: 'redirectMiddleware',
+  method: 'GET',
+  path: '/redirect-middleware',
+})
+
+export default [middleware, redirectMiddleware]


### PR DESCRIPTION
## Problem

Returning a redirect (`3xx`) `Response` from a universal `+middleware` crashed Vike's request logger. Vike printed *"You stumbled upon a Vike bug … A maintainer will fix the bug"* and the request failed (returning `404` instead of the redirect).

Fixes #3357.

## Root cause

A redirect `Response` returned from a `+middleware` is converted via `createHttpResponseFromUniversalMiddleware()` using `Array.from(response.headers.entries())`. The Web `Headers` object **lower-cases** header names, so a middleware's `Location` header becomes `location` in `httpResponse.headers`.

`logHttpResponse()` looked up the redirect target with a capital `L`:

```js
.find((header) => header[0] === 'Location') // never matches `location`
```

so the lookup returned `undefined` and the subsequent `assert(headerRedirect)` threw — purely in the **logging** path, turning a perfectly valid redirect into a failed request.

Note that Vike's own `redirect()` helper (`createHttpResponseRedirect()`) uses a capital-`L` `'Location'`, so the comparison must be case-insensitive to handle **both** sources.

## Fix

Compare the header name case-insensitively:

```js
.find((header) => header[0].toLowerCase() === 'location')
```

## Test

Added a regression test to `test/plusMiddlewares`:
- A second `+middleware` that returns `new Response(null, { status: 303, headers: { Location: '/' } })` (capital-`L` on purpose, to reproduce the Web-`Headers` lower-casing).
- A test asserting the redirect returns `303` with `Location: /`.

I verified the test **fails without the fix** (reproducing the exact `logHttpResponse` crash from the issue, request returns `404`) and **passes with it**, in both `dev` and `preview` modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoCFn4FqWSG57km9dMo2uY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoCFn4FqWSG57km9dMo2uY)_