### PR TITLE
chore(deps): bump @vikejs/express from 0.2.2 to 0.2.3 (+ type fix)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,8 +1842,8 @@ importers:
         specifier: ^0.4.18
         version: 0.4.18(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.11.16)
       '@vikejs/express':
-        specifier: ^0.2.2
-        version: 0.2.2(@hattip/core@0.0.49)(@types/express@5.0.6)(express@5.2.1)(vike@packages+vike)
+        specifier: ^0.2.3
+        version: 0.2.3(@hattip/core@0.0.49)(@types/express@5.0.6)(express@5.2.1)(srvx@0.11.16)(vike@packages+vike)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -4852,6 +4852,9 @@ packages:
   '@universal-middleware/express@0.4.27':
     resolution: {integrity: sha512-leJeb617DqDmwVqTFtPg9YISlYiln6B6Srq8GFo01aNmwGqt5rqA6f0nP4TU9lFdKekUAMZ932I3n6BZWkOItg==}
 
+  '@universal-middleware/express@0.4.30':
+    resolution: {integrity: sha512-vkaqurRbPFMYSACaG+iWpDbFlvbV/GTQ0wHx8Aqg9I7f5HxFHoos4F7E/oUIa352FXcJPflQM0CJXgkHTW+QeQ==}
+
   '@universal-middleware/fastify@0.5.26':
     resolution: {integrity: sha512-DUImESs9taUeMOSvJcSB/gvK0M90wQXXwRNP5Rhjto5GTXiHair2yRjxhhjVqXAms63G/du5xrzoOIO1JBB3NQ==}
 
@@ -4962,8 +4965,8 @@ packages:
   '@vercel/routing-utils@6.2.0':
     resolution: {integrity: sha512-YI2cGYZmJKEyGSEgf5Fw5rVuW7X1bTOQ7/pnLRNTFMH3YB3qqP5erCLCJGv2kIvNo1iQAPINHQRJj6ykEdGoPg==}
 
-  '@vikejs/express@0.2.2':
-    resolution: {integrity: sha512-wXM3s2p379JbxisBtYeKjD9lMUtKQL5g1ktZLrQ+K6g3KxDl3JnKjYS+zMwsT5Zm3v+ciWbik52/IzhBPVm8xg==}
+  '@vikejs/express@0.2.3':
+    resolution: {integrity: sha512-/UrbJbhh8jm8P+Gv4/Ek8g8ypQggmSNeXQW5383X7HjgvMPPmJxh9pnwe+NMn5gCFIN8xtQnuYE1KANGqUkHzQ==}
     peerDependencies:
       express: ^4.0.0 || ^5.0.0
       vike: ^0.4.255
@@ -10761,6 +10764,21 @@ snapshots:
       - hono
       - srvx
 
+  '@universal-middleware/express@0.4.30(@hattip/core@0.0.49)(@types/express@5.0.6)(srvx@0.11.16)':
+    dependencies:
+      '@universal-middleware/core': 0.4.18(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.11.16)
+      '@universal-middleware/node': 0.2.1(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.11.16)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
   '@universal-middleware/fastify@0.5.26(@hattip/core@0.0.49)(@types/express@5.0.6)(srvx@0.11.16)':
     dependencies:
       '@universal-middleware/core': 0.4.18(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.11.16)
@@ -10967,11 +10985,10 @@ snapshots:
     optionalDependencies:
       ajv: 6.15.0
 
-  '@vikejs/express@0.2.2(@hattip/core@0.0.49)(@types/express@5.0.6)(express@5.2.1)(vike@packages+vike)':
+  '@vikejs/express@0.2.3(@hattip/core@0.0.49)(@types/express@5.0.6)(express@5.2.1)(srvx@0.11.16)(vike@packages+vike)':
     dependencies:
-      '@universal-middleware/express': 0.4.27(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.11.16)
+      '@universal-middleware/express': 0.4.30(@hattip/core@0.0.49)(@types/express@5.0.6)(srvx@0.11.16)
       express: 5.2.1
-      srvx: 0.11.16
       vike: link:packages/vike
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -10982,6 +10999,7 @@ snapshots:
       - fastify
       - h3
       - hono
+      - srvx
 
   '@vikejs/hono@0.2.1(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.11.16)(vike@packages+vike)':
     dependencies:

--- a/test/universal-deploy/+server.ts
+++ b/test/universal-deploy/+server.ts
@@ -11,7 +11,11 @@ async function serve() {
 
   vike(app)
 
-  return toFetchHandler(app)
+  // `toFetchHandler()` (i.e. `connectToWeb()`) resolves to `undefined` when no middleware
+  // handles the request. Vike's catch-all always responds, but we add a fallback to satisfy
+  // the `Server['fetch']` type which requires a `Response` to always be returned.
+  const handler = toFetchHandler(app)
+  return async (request: Request): Promise<Response> => (await handler(request)) ?? new Response(null, { status: 404 })
 }
 
 export default {

--- a/test/universal-deploy/package.json
+++ b/test/universal-deploy/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@universal-middleware/core": "^0.4.18",
-    "@vikejs/express": "^0.2.2",
+    "@vikejs/express": "^0.2.3",
     "@vitejs/plugin-react": "^4.7.0",
     "express": "^5.2.1",
     "react": "^19.2.6",


### PR DESCRIPTION
Supersedes #3360.

Dependabot's #3360 bumps `@vikejs/express` `0.2.2` → `0.2.3` but fails CI on **TypeScript - Ubuntu - Node.js 20**. This PR contains the same bump plus the fix needed to keep CI green.

## The failure

```
test/universal-deploy/+server.ts(18,3): error TS2322:
Type 'WebHandler<Context, unknown>' is not assignable to type '(request: Request) => Response | Promise<Response>'.
  Type 'Response | Promise<Response | undefined> | undefined' is not assignable to type 'Response | Promise<Response>'.
    Type 'undefined' is not assignable to type 'Response | Promise<Response>'.
```

## Root cause

`@vikejs/express` changed how `toFetchHandler` is implemented:

| | `toFetchHandler` source | Return type |
|---|---|---|
| `0.2.2` | re-export of srvx's `toFetchHandler` (`srvx/node`) | `(request) => Response \| Promise<Response>` |
| `0.2.3` | `connectToWeb` from `@universal-middleware/express` | `(request, context?, runtime?) => Response \| undefined \| Promise<Response \| undefined>` |

The new `WebHandler` can resolve to `undefined` (the universal-middleware convention for "no middleware handled the request"). That `undefined` is not assignable to `Server['fetch']` — i.e. [`Fetchable.fetch`](https://github.com/universal-deploy/universal-deploy/blob/main/packages/store/src/types.ts), which requires `(request: Request) => Response | Promise<Response>`.

This matches the adapter's deliberate move away from srvx's `toFetchHandler` (see the `srvx#132` note in `docs/components/DeprecatedServer.mdx`).

## The fix

`test/universal-deploy/+server.ts` now wraps the handler with a `404` fallback so it always resolves to a `Response`. Vike's catch-all always responds, so the fallback is never hit at runtime — it only makes the type honest:

```ts
const handler = toFetchHandler(app)
return async (request: Request): Promise<Response> => (await handler(request)) ?? new Response(null, { status: 404 })
```

Verified locally (build + the exact `test-types` command): `test/universal-deploy/tsconfig.json` now type-checks cleanly.

## Heads-up (out of scope here)

The documented pattern `fetch: toFetchHandler(app)` ([`docs/pages/server/+Page.mdx`](https://github.com/vikejs/vike/blob/main/docs/pages/server/+Page.mdx)) is affected by the same `undefined`-in-return-type change — any user on `@vikejs/express@0.2.3` following the docs with the `Server`/`Fetchable` type will hit it. Properly resolving that would mean tightening `connectToWeb`'s return type in `vike-server-adapters`, so it's left out of this dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSpE9DJSSi9zZSxgGgQMu5)_