### PR TITLE
sync-github-releases: rename `try`→`check`, sync all packages by default, run with Node

### DIFF
--- a/.github/workflows/sync-github-releases.yml
+++ b/.github/workflows/sync-github-releases.yml
@@ -18,15 +18,15 @@ jobs:
       contents: write
     environment: release
     steps:
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
-          bun-version: 1.3.13
+          node-version: 22
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Create GitHub releases
-        run: bun ./.github/workflows/sync-github-releases/index.ts
+        run: node --experimental-strip-types --no-warnings=ExperimentalWarning ./.github/workflows/sync-github-releases/index.ts
         env:
           # GITHUB_EVENT_NAME, GITHUB_SHA and GITHUB_EVENT_PATH are provided automatically
           GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/sync-github-releases.yml
+++ b/.github/workflows/sync-github-releases.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Create GitHub releases
-        run: node --experimental-strip-types --no-warnings=ExperimentalWarning ./.github/workflows/sync-github-releases/index.ts
+        run: node ./.github/workflows/sync-github-releases/index.ts
         env:
           # GITHUB_EVENT_NAME, GITHUB_SHA and GITHUB_EVENT_PATH are provided automatically
           GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -51,4 +51,4 @@ GITHUB_TOKEN=<token> pnpm -C .github/workflows/sync-github-releases run check --
 GITHUB_TOKEN=<token> pnpm -C .github/workflows/sync-github-releases run run -- packages/vike
 ```
 
-> Requires [Bun](https://bun.sh) — the scripts run the TypeScript directly with `bun`.
+> Requires [Node.js](https://nodejs.org) ≥ 22.6 — the scripts run the TypeScript directly via type stripping.

--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -14,8 +14,7 @@ below run the same tooling by hand.
 1. **Pick which package(s) to sync** (`getPackageDirsToSync()`):
    - an explicit `<package-dir>` argument, or
    - on `push` (CI): the packages whose `CHANGELOG.md` changed, or
-   - on `workflow_dispatch` (CI): every package, or
-   - locally: the sole package, or an error asking for an explicit `<package-dir>`.
+   - otherwise (manual `workflow_dispatch`, or no `<package-dir>`): every package.
 
    Then, for each package:
 2. **Parse** its `CHANGELOG.md` into one entry per version (`parseChangelog()`).
@@ -34,12 +33,12 @@ GITHUB_TOKEN=<token> pnpm -C .github/workflows/sync-github-releases run <script>
 ```
 
 Each script needs a `GITHUB_TOKEN` ([personal access token](https://github.com/settings/tokens)) with the
-scope below. `<package-dir>` is a path such as `packages/vike`.
+scope below. `<package-dir>` is a path such as `packages/vike`; omit it to sync every package.
 
 | Script | Description | Token scope |
 | --- | --- | --- |
-| `run -- <package-dir>` | Create/update the package's GitHub Releases from its `CHANGELOG.md`. | `contents: write` |
-| `check -- <package-dir>` | Dry-run of `run`: log what would change without writing anything. | `contents: read` |
+| `run [-- <package-dir>]` | Create/update GitHub Releases from `CHANGELOG.md`. Without a `<package-dir>`, syncs every package. | `contents: write` |
+| `check [-- <package-dir>]` | Dry-run of `run`: log what would change without writing anything. | `contents: read` |
 | `delete-all` | **Destructive** — delete every GitHub Release in the repo. | `contents: write` |
 
 ### Examples

--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -39,14 +39,14 @@ scope below. `<package-dir>` is a path such as `packages/vike`.
 | Script | Description | Token scope |
 | --- | --- | --- |
 | `run -- <package-dir>` | Create/update the package's GitHub Releases from its `CHANGELOG.md`. | `contents: write` |
-| `try -- <package-dir>` | Dry-run of `run`: log what would change without writing anything. | `contents: read` |
+| `check -- <package-dir>` | Dry-run of `run`: log what would change without writing anything. | `contents: read` |
 | `delete-all` | **Destructive** — delete every GitHub Release in the repo. | `contents: write` |
 
 ### Examples
 
 ```bash
 # Preview the changes for the `vike` package (no writes):
-GITHUB_TOKEN=<token> pnpm -C .github/workflows/sync-github-releases run try -- packages/vike
+GITHUB_TOKEN=<token> pnpm -C .github/workflows/sync-github-releases run check -- packages/vike
 
 # Create/update the releases for real:
 GITHUB_TOKEN=<token> pnpm -C .github/workflows/sync-github-releases run run -- packages/vike

--- a/.github/workflows/sync-github-releases/github-utils.ts
+++ b/.github/workflows/sync-github-releases/github-utils.ts
@@ -7,7 +7,7 @@ export { getRepository }
 import assert from 'node:assert'
 import { execSync } from 'node:child_process'
 import { setTimeout } from 'node:timers/promises'
-import type { Release } from './types.js'
+import type { Release } from './types.ts'
 
 const API_URL = process.env.GITHUB_API_URL ?? 'https://api.github.com'
 const REPOSITORY = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
@@ -87,7 +87,7 @@ async function githubRequest<T = void>(
 function getGithubToken(): string {
   const token = process.env.GITHUB_TOKEN
   if (!token) {
-    throw new Error( 'GITHUB_TOKEN must be set or use --dry-run — see README.md')
+    throw new Error('GITHUB_TOKEN must be set or use --dry-run — see README.md')
   }
   return token
 }

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { getRepository } from './github-utils'
-import { getReleasePlan, parseChangelog, toPackageDirs } from './index'
+import { getRepository } from './github-utils.ts'
+import { getReleasePlan, parseChangelog, toPackageDirs } from './index.ts'
 
 function readFixture(name: string): string {
   return readFileSync(path.join(__dirname, 'fixtures', name), 'utf8')

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -22,8 +22,7 @@ import type { Release } from './types.ts'
 import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './github-utils.ts'
 
 async function main(): Promise<void> {
-  // The package.json scripts run from this folder; switch to the repo root so the git commands and
-  // package-dir paths below resolve against it.
+  // The scripts run from this folder, but the git commands and package paths below assume the repo root.
   process.chdir(getRepoRoot())
 
   const args = process.argv.slice(2)
@@ -107,8 +106,7 @@ async function syncPackage({
 }
 
 function getPackageDirsToSync(): string[] {
-  // On push, sync only the packages whose CHANGELOG.md changed; otherwise (manual workflow_dispatch
-  // or a local run with no <package-dir>) sync every package.
+  // A push syncs only its changed packages; workflow_dispatch or a local run syncs every package.
   const pushedChangelogFiles = getPushedChangelogFiles()
   if (pushedChangelogFiles) return toPackageDirs(pushedChangelogFiles)
   return toPackageDirs(getTrackedChangelogFiles())
@@ -199,11 +197,9 @@ function getReleasePlan({
   githubReleases: Release[]
   changelogSections: ChangelogSections
 }) {
-  // changelogSections is newest-first; .reverse() creates the missing releases oldest-first. This
-  // matters because create-release defaults to make_latest=true: whichever release is created last
-  // becomes the repo's "Latest", so the newest must go last. (The releases list itself is ordered by
-  // GitHub on tag semver, not creation order, so backfilled older releases still slot in correctly:
-  // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
+  // changelogSections is newest-first; .reverse() creates the missing releases oldest-first so the
+  // newest is created last: create-release defaults to make_latest=true, so the last release
+  // created wins the repo's "Latest" badge.
   const releasesToCreate: ReleasesToCreate[] = Object.keys(changelogSections)
     .filter((tagName) => !githubReleases.some((release) => release.tag_name === tagName))
     .reverse()

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -22,7 +22,8 @@ import type { Release } from './types.ts'
 import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './github-utils.ts'
 
 async function main(): Promise<void> {
-  // The scripts run from this folder, but the git commands and package paths below assume the repo root.
+  // The package.json scripts run from this folder; switch to the repo root so the git commands and
+  // package-dir paths below resolve against it.
   process.chdir(getRepoRoot())
 
   const args = process.argv.slice(2)
@@ -106,7 +107,8 @@ async function syncPackage({
 }
 
 function getPackageDirsToSync(): string[] {
-  // A push syncs only its changed packages; workflow_dispatch or a local run syncs every package.
+  // On push, sync only the packages whose CHANGELOG.md changed; otherwise (manual workflow_dispatch
+  // or a local run with no <package-dir>) sync every package.
   const pushedChangelogFiles = getPushedChangelogFiles()
   if (pushedChangelogFiles) return toPackageDirs(pushedChangelogFiles)
   return toPackageDirs(getTrackedChangelogFiles())
@@ -197,9 +199,11 @@ function getReleasePlan({
   githubReleases: Release[]
   changelogSections: ChangelogSections
 }) {
-  // changelogSections is newest-first; .reverse() creates the missing releases oldest-first so the
-  // newest is created last: create-release defaults to make_latest=true, so the last release
-  // created wins the repo's "Latest" badge.
+  // changelogSections is newest-first; .reverse() creates the missing releases oldest-first. This
+  // matters because create-release defaults to make_latest=true: whichever release is created last
+  // becomes the repo's "Latest", so the newest must go last. (The releases list itself is ordered by
+  // GitHub on tag semver, not creation order, so backfilled older releases still slot in correctly:
+  // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
   const releasesToCreate: ReleasesToCreate[] = Object.keys(changelogSections)
     .filter((tagName) => !githubReleases.some((release) => release.tag_name === tagName))
     .reverse()

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -18,8 +18,8 @@ import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { Release } from './types'
-import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './github-utils'
+import type { Release } from './types.ts'
+import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './github-utils.ts'
 
 async function main(): Promise<void> {
   // The package.json scripts run from this folder; switch to the repo root so the git commands and

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -22,6 +22,10 @@ import type { Release } from './types'
 import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './github-utils'
 
 async function main(): Promise<void> {
+  // The package.json scripts run from this folder; switch to the repo root so the git commands and
+  // package-dir paths below resolve against it.
+  process.chdir(getRepoRoot())
+
   const args = process.argv.slice(2)
   const dryRun = args.includes('--dry-run')
 
@@ -103,18 +107,15 @@ async function syncPackage({
 }
 
 function getPackageDirsToSync(): string[] {
+  // On push, sync only the packages whose CHANGELOG.md changed; otherwise (manual workflow_dispatch
+  // or a local run with no <package-dir>) sync every package.
   const pushedChangelogFiles = getPushedChangelogFiles()
   if (pushedChangelogFiles) return toPackageDirs(pushedChangelogFiles)
+  return toPackageDirs(getTrackedChangelogFiles())
+}
 
-  const packageDirs = toPackageDirs(getTrackedChangelogFiles())
-
-  // Other CI triggers (e.g. a manual workflow_dispatch) reach here: sync every package.
-  // GITHUB_ACTIONS is GitHub's documented signal for telling a CI run apart from a local one.
-  if (process.env.GITHUB_ACTIONS) return packageDirs
-
-  // Local run: default to the sole package, else require an explicit `<package-dir>`.
-  if (packageDirs.length === 1) return packageDirs
-  throw new Error('Usage: <package-dir> [--dry-run]')
+function getRepoRoot(): string {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
 }
 
 function toPackageDirs(files: string[]): string[] {

--- a/.github/workflows/sync-github-releases/package.json
+++ b/.github/workflows/sync-github-releases/package.json
@@ -1,12 +1,14 @@
 {
   "scripts": {
     "// Sync GitHub Releases with each package's CHANGELOG.md — see ./README.md for full usage": "",
+    "// Run a .ts file with Node.js <=23 — these two flags aren't needed anymore on Node.js 24+": "",
+    "node-ts": "node --experimental-strip-types --no-warnings=ExperimentalWarning",
     "// run [<package-dir>]: create/update GitHub Releases; without an arg, syncs every package (needs a contents:write token)": "",
-    "run": "bun ./index.ts",
+    "run": "pnpm node-ts ./index.ts",
     "// check [<package-dir>]: dry-run of `run`, logging changes without writing (needs a contents:read token)": "",
-    "check": "bun ./index.ts --dry-run",
+    "check": "pnpm node-ts ./index.ts --dry-run",
     "// delete-all: delete every GitHub Release in the repo — destructive (needs a contents:write token)": "",
-    "delete-all": "bun ./remove-all-releases.ts"
+    "delete-all": "pnpm node-ts ./remove-all-releases.ts"
   },
   "devDependencies": {
     "@types/node": "^24.10.2",

--- a/.github/workflows/sync-github-releases/package.json
+++ b/.github/workflows/sync-github-releases/package.json
@@ -3,8 +3,8 @@
     "// Sync GitHub Releases with each package's CHANGELOG.md — see ./README.md for full usage": "",
     "// run <package-dir>: create/update the package's GitHub Releases (needs a contents:write token)": "",
     "run": "sh -c 'bun ./index.ts \"$1\"' --",
-    "// try <package-dir>: dry-run of `run`, logging changes without writing (needs a contents:read token)": "",
-    "try": "sh -c 'bun ./index.ts \"$1\" --dry-run' --",
+    "// check <package-dir>: dry-run of `run`, logging changes without writing (needs a contents:read token)": "",
+    "check": "sh -c 'bun ./index.ts \"$1\" --dry-run' --",
     "// delete-all: delete every GitHub Release in the repo — destructive (needs a contents:write token)": "",
     "delete-all": "sh -c 'bun ./remove-all-releases.ts' --"
   },

--- a/.github/workflows/sync-github-releases/package.json
+++ b/.github/workflows/sync-github-releases/package.json
@@ -1,12 +1,12 @@
 {
   "scripts": {
     "// Sync GitHub Releases with each package's CHANGELOG.md — see ./README.md for full usage": "",
-    "// run <package-dir>: create/update the package's GitHub Releases (needs a contents:write token)": "",
-    "run": "sh -c 'bun ./index.ts \"$1\"' --",
-    "// check <package-dir>: dry-run of `run`, logging changes without writing (needs a contents:read token)": "",
-    "check": "sh -c 'bun ./index.ts \"$1\" --dry-run' --",
+    "// run [<package-dir>]: create/update GitHub Releases; without an arg, syncs every package (needs a contents:write token)": "",
+    "run": "bun ./index.ts",
+    "// check [<package-dir>]: dry-run of `run`, logging changes without writing (needs a contents:read token)": "",
+    "check": "bun ./index.ts --dry-run",
     "// delete-all: delete every GitHub Release in the repo — destructive (needs a contents:write token)": "",
-    "delete-all": "sh -c 'bun ./remove-all-releases.ts' --"
+    "delete-all": "bun ./remove-all-releases.ts"
   },
   "devDependencies": {
     "@types/node": "^24.10.2",

--- a/.github/workflows/sync-github-releases/remove-all-releases.ts
+++ b/.github/workflows/sync-github-releases/remove-all-releases.ts
@@ -9,7 +9,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 }
 
 import { fileURLToPath } from 'node:url'
-import { fetchGithubReleases, getGithubToken, getRepository, githubRequest } from './github-utils'
+import { fetchGithubReleases, getGithubToken, getRepository, githubRequest } from './github-utils.ts'
 
 async function removeAllReleases() {
   const token = getGithubToken()

--- a/.github/workflows/sync-github-releases/tsconfig.json
+++ b/.github/workflows/sync-github-releases/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "noImplicitAny": true,
     "checkJs": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Three requested changes to the `sync-github-releases` tooling, one per commit, on top of `brillout/sync-github-releases` (the `wip` commit).

### 1. Rename the `try` script to `check`
`package.json` + README.

### 2. Sync every package when no `<package-dir>` is given
`getPackageDirsToSync()` no longer special-cases local runs (sole package / error). Outside of a `push` (which still syncs only the *changed* packages), **every** package is synced — same as `workflow_dispatch` already did. So `pnpm run check` with no arg now dry-runs all packages.

Two fixes were needed to make this actually work via the scripts:
- **Repo-root resolution.** `pnpm -C <dir> run` executes with cwd = that folder, but `index.ts` uses `git ls-files` / package-dir paths that assume the repo root — so from the scripts it found *no* changelogs. It now `process.chdir(getRepoRoot())` (`git rev-parse --show-toplevel`) at startup.
- **Dropped the `sh -c '... "$1"' --` wrapper.** With it, `pnpm run check -- packages/vike` double-counted `--` and silently synced everything. The scripts are now plain (`bun ./index.ts --dry-run`), so `index.ts`'s order-independent arg parsing handles `run check`, `run check packages/vike`, and `run check -- packages/vike` all correctly.

### 3. Run with Node.js instead of Bun
- Added the `node-ts` script (`node --experimental-strip-types --no-warnings=ExperimentalWarning`); `run`/`check`/`delete-all` use it, and the workflow installs Node 22 and invokes `index.ts` the same way.
- **Node's ESM resolver needs explicit extensions**, so relative imports moved from extensionless/`.js` to **`.ts`** (Bun resolved them without extensions; Node does not — verified on Node 22.22). `tsconfig` gets `allowImportingTsExtensions` + `noEmit` to match.
- Fixed a stray space (`Error( '…`) the `wip` commit left, which `biome ci` flags.

### Validation
Done locally (repo deps aren't installed here, so vitest/tsc couldn't run in-repo):
- ✅ Node runs `index.ts` and `remove-all-releases.ts` with the `.ts` imports — via the YAML-style `node …` invocation and via all three `pnpm` scripts.
- ✅ Arg forwarding: no-arg → all packages; `packages/vike` and `-- packages/vike` → just that package.
- ✅ Vite/vitest resolves explicit `.ts` imports (confirmed with a standalone vitest run), so the unit test is unaffected.

Note: the workflow runs `node` directly (with the two flags) rather than via the `node-ts` script, to keep cwd = repo root and avoid a nested `pnpm` call — happy to switch it to the script if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ8mYCy7NfNW7zhmMA9dhB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ8mYCy7NfNW7zhmMA9dhB)_