### PR TITLE
sync-github-releases: follow-up improvements (reconcile from changelog, per-package tags, tag-healing, …)

### DIFF
--- a/.github/workflows/sync-github-releases.yml
+++ b/.github/workflows/sync-github-releases.yml
@@ -11,6 +11,12 @@ on:
 permissions:
   contents: read
 
+# Serialize runs: two quick CHANGELOG.md pushes would otherwise race to create the same release
+# (the loser fails with 422 already_exists). Don't cancel an in-progress run — let a backfill finish.
+concurrency:
+  group: sync-github-releases
+  cancel-in-progress: false
+
 jobs:
   sync_github_releases:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -1,7 +1,8 @@
 # Sync GitHub Releases
 
 Keeps each package's [GitHub Releases](https://github.com/vikejs/vike/releases) in sync with its
-`CHANGELOG.md`: creates any missing release and rewrites any whose notes have drifted from the changelog.
+`CHANGELOG.md`: creates any missing release, rewrites any whose notes have drifted from the changelog,
+and deletes any whose version is no longer in the changelog.
 
 In CI this runs automatically via [`../sync-github-releases.yml`](../sync-github-releases.yml) — on every
 push to `main` that touches a `packages/**/CHANGELOG.md`, and on manual `workflow_dispatch`. The scripts
@@ -19,7 +20,7 @@ below run the same tooling by hand.
    Then, for each package:
 2. **Parse** its `CHANGELOG.md` into one entry per version (`parseChangelog()`).
 3. **Fetch** the package's existing GitHub Releases.
-4. **Plan the changes** (`getReleasePlan()`): create a release for every changelog version that doesn't have one yet, and update any whose notes have drifted from the changelog.
+4. **Plan the changes** (`getReleasePlan()`): create a release for every changelog version that doesn't have one yet, update any whose notes have drifted from the changelog, and delete any of the package's releases whose version is no longer in the changelog.
 5. **Apply** the plan through the GitHub API — or, with `--dry-run`, just log what would change.
 
 It's safe to run against any current state: older missing releases are created too, and [GitHub orders the releases list by tag version](https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257), so they still land in the right place.

--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -25,6 +25,8 @@ below run the same tooling by hand.
 
 It's safe to run against any current state: older missing releases are created too, and [GitHub orders the releases list by tag version](https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257), so they still land in the right place.
 
+A release is tagged from its git tag. The newest version must already be tagged — the sync hard-fails rather than tag the wrong commit — while an older missing tag is recreated at the release commit deduced from the changelog's own history (and hard-fails if it can't be deduced).
+
 ## Scripts
 
 Run from anywhere in the repo:

--- a/.github/workflows/sync-github-releases/github-utils.ts
+++ b/.github/workflows/sync-github-releases/github-utils.ts
@@ -12,10 +12,12 @@ import type { Release } from './types.ts'
 const API_URL = process.env.GITHUB_API_URL ?? 'https://api.github.com'
 const REPOSITORY = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
 const DEFAULT_BRANCH = process.env.GITHUB_DEFAULT_BRANCH ?? 'main'
-// Pause between requests so bursts (e.g. backfilling many releases) stay under GitHub's secondary
-// rate limit — its burst/concurrency limit, separate from the hourly primary quota.
+// Pause between write requests so bursts (e.g. backfilling many releases) stay under GitHub's
+// secondary rate limit — its burst/concurrency limit, separate from the hourly primary quota.
 // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 const RATE_LIMIT_DELAY_MS = 500
+// Writes performed so far, to delay only *between* them (not before the first, nor after reads).
+let writeCount = 0
 
 async function fetchGithubReleases(owner: string, repo: string, token: string): Promise<Release[]> {
   const githubReleases: Release[] = []
@@ -60,6 +62,15 @@ async function githubRequest<T = void>(
     if (body !== undefined) console.log(JSON.stringify(body, null, 2))
     return undefined as T
   }
+
+  // Throttle between writes only: reads aren't the rate-limit concern, and a lone write — the common
+  // case of a single new release — shouldn't wait at all. So a backfill of N writes pays N-1 delays,
+  // while one write pays none.
+  if (method !== 'GET') {
+    if (writeCount > 0) await setTimeout(RATE_LIMIT_DELAY_MS)
+    writeCount++
+  }
+
   const response = await fetch(new URL(pathname, API_URL), {
     method,
     headers: {
@@ -79,9 +90,7 @@ async function githubRequest<T = void>(
     )
   }
 
-  const data = response.status === 204 ? undefined : await response.json()
-  await setTimeout(RATE_LIMIT_DELAY_MS)
-  return data as T
+  return response.status === 204 ? (undefined as T) : ((await response.json()) as T)
 }
 
 function getGithubToken(): string {

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -2,7 +2,14 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { getRepository } from './github-utils.ts'
-import { getReleasePlan, getTagName, parseChangelog, toPackageDirs, withSourceOfTruth } from './index.ts'
+import {
+  chooseCreateCommitish,
+  getReleasePlan,
+  getTagName,
+  parseChangelog,
+  toPackageDirs,
+  withSourceOfTruth,
+} from './index.ts'
 
 function readFixture(name: string): string {
   return readFileSync(path.join(__dirname, 'fixtures', name), 'utf8')
@@ -230,6 +237,32 @@ describe('withSourceOfTruth()', () => {
   it('appends a footer linking back to the changelog', () => {
     expect(withSourceOfTruth('### Features\n\n* Something', 'https://github.com/vikejs/vike/blob/main/packages/vike/CHANGELOG.md')).toBe(
       '### Features\n\n* Something\n\n_Source of truth: [`CHANGELOG.md`](https://github.com/vikejs/vike/blob/main/packages/vike/CHANGELOG.md)._',
+    )
+  })
+})
+
+describe('chooseCreateCommitish()', () => {
+  const base = { tagName: 'v0.4.0', defaultBranch: 'main' }
+
+  it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
+    expect(chooseCreateCommitish({ ...base, tagExists: true, isNewest: false, deducedCommit: null })).toBe('main')
+    // Even for the newest release, an existing tag is fine.
+    expect(chooseCreateCommitish({ ...base, tagExists: true, isNewest: true, deducedCommit: null })).toBe('main')
+  })
+
+  it('hard-fails when the newest release has no tag', () => {
+    expect(() => chooseCreateCommitish({ ...base, tagExists: false, isNewest: true, deducedCommit: null })).toThrow(
+      /latest release must already be tagged/,
+    )
+  })
+
+  it('tags an older release at the deduced commit', () => {
+    expect(chooseCreateCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: 'abc123' })).toBe('abc123')
+  })
+
+  it('hard-fails when an older release has no tag and no deducible commit', () => {
+    expect(() => chooseCreateCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: null })).toThrow(
+      /couldn't be deduced/,
     )
   })
 })

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { getRepository } from './github-utils.ts'
-import { getReleasePlan, parseChangelog, toPackageDirs } from './index.ts'
+import { getReleasePlan, getTagName, parseChangelog, toPackageDirs } from './index.ts'
 
 function readFixture(name: string): string {
   return readFileSync(path.join(__dirname, 'fixtures', name), 'utf8')
@@ -90,6 +90,8 @@ describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
     const plan = getReleasePlan({
       defaultBranch: 'main',
+      packageName: 'vike',
+      multiplePackages: false,
       changelogSections: {
         'v1.0.1': 'New release notes',
         'v1.0.0': 'Updated old notes',
@@ -124,6 +126,8 @@ describe('getReleasePlan()', () => {
   it('updates the current release instead of creating a duplicate', () => {
     const plan = getReleasePlan({
       defaultBranch: 'main',
+      packageName: 'vike',
+      multiplePackages: false,
       changelogSections: {
         'v1.0.1': 'Fresh release notes',
       },
@@ -139,6 +143,8 @@ describe('getReleasePlan()', () => {
   it('leaves GitHub releases without a matching changelog entry untouched', () => {
     const plan = getReleasePlan({
       defaultBranch: 'main',
+      packageName: 'vike',
+      multiplePackages: false,
       changelogSections: { 'v1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
@@ -148,6 +154,45 @@ describe('getReleasePlan()', () => {
     })
 
     expect(plan).toEqual({ releasesToCreate: [], releasesToUpdate: [] })
+  })
+
+  it('qualifies tags with the package name when several packages share the repo', () => {
+    const plan = getReleasePlan({
+      defaultBranch: 'main',
+      packageName: 'create-vike-core',
+      multiplePackages: true,
+      changelogSections: {
+        'v0.0.2': 'New notes',
+        'v0.0.1': 'Old notes',
+      },
+      // The existing release is matched by its namespaced tag — no duplicate is created for it, and
+      // it isn't confused with another package's bare `v0.0.1` release.
+      githubReleases: [{ id: 1, tag_name: 'create-vike-core@0.0.1', body: 'Old notes' }],
+    })
+
+    expect(plan).toEqual({
+      releasesToCreate: [
+        {
+          tag_name: 'create-vike-core@0.0.2',
+          target_commitish: 'main',
+          name: 'create-vike-core@0.0.2',
+          body: 'New notes',
+        },
+      ],
+      releasesToUpdate: [],
+    })
+  })
+})
+
+describe('getTagName()', () => {
+  it('keeps the bare vX.Y.Z tag for a single package', () => {
+    expect(getTagName('v0.4.259', 'vike', false)).toBe('v0.4.259')
+    expect(getTagName('v0.1.0-beta.6', 'vike', false)).toBe('v0.1.0-beta.6')
+  })
+
+  it('qualifies the tag with the package name when there are several packages', () => {
+    expect(getTagName('v0.0.391', 'create-vike-core', true)).toBe('create-vike-core@0.0.391')
+    expect(getTagName('v0.1.0-beta.6', 'vike', true)).toBe('vike@0.1.0-beta.6')
   })
 })
 

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -135,6 +135,20 @@ describe('getReleasePlan()', () => {
       releasesToUpdate: [{ release_id: 3, tag_name: 'v1.0.1', body: 'Fresh release notes' }],
     })
   })
+
+  it('leaves GitHub releases without a matching changelog entry untouched', () => {
+    const plan = getReleasePlan({
+      defaultBranch: 'main',
+      changelogSections: { 'v1.0.0': 'Notes' },
+      githubReleases: [
+        { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
+        // No changelog entry for this tag — it must not be queued for a spurious (undefined-body) update.
+        { id: 2, tag_name: 'v0.0.1-orphan', body: 'Unrelated release' },
+      ],
+    })
+
+    expect(plan).toEqual({ releasesToCreate: [], releasesToUpdate: [] })
+  })
 })
 
 describe('toPackageDirs()', () => {

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { getRepository } from './github-utils.ts'
-import { getReleasePlan, getTagName, parseChangelog, toPackageDirs } from './index.ts'
+import { getReleasePlan, getTagName, parseChangelog, toPackageDirs, withSourceOfTruth } from './index.ts'
 
 function readFixture(name: string): string {
   return readFileSync(path.join(__dirname, 'fixtures', name), 'utf8')
@@ -223,6 +223,14 @@ describe('getReleasePlan()', () => {
       releasesToUpdate: [],
       releasesToDelete: [],
     })
+  })
+})
+
+describe('withSourceOfTruth()', () => {
+  it('appends a footer linking back to the changelog', () => {
+    expect(withSourceOfTruth('### Features\n\n* Something', 'https://github.com/vikejs/vike/blob/main/packages/vike/CHANGELOG.md')).toBe(
+      '### Features\n\n* Something\n\n_Source of truth: [`CHANGELOG.md`](https://github.com/vikejs/vike/blob/main/packages/vike/CHANGELOG.md)._',
+    )
   })
 })
 

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -235,7 +235,12 @@ describe('getReleasePlan()', () => {
 
 describe('withSourceOfTruth()', () => {
   it('appends a footer linking back to the changelog', () => {
-    expect(withSourceOfTruth('### Features\n\n* Something', 'https://github.com/vikejs/vike/blob/main/packages/vike/CHANGELOG.md')).toBe(
+    expect(
+      withSourceOfTruth(
+        '### Features\n\n* Something',
+        'https://github.com/vikejs/vike/blob/main/packages/vike/CHANGELOG.md',
+      ),
+    ).toBe(
       '### Features\n\n* Something\n\n_Source of truth: [`CHANGELOG.md`](https://github.com/vikejs/vike/blob/main/packages/vike/CHANGELOG.md)._',
     )
   })
@@ -257,7 +262,9 @@ describe('chooseCreateCommitish()', () => {
   })
 
   it('tags an older release at the deduced commit', () => {
-    expect(chooseCreateCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: 'abc123' })).toBe('abc123')
+    expect(chooseCreateCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: 'abc123' })).toBe(
+      'abc123',
+    )
   })
 
   it('hard-fails when an older release has no tag and no deducible commit', () => {

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -23,14 +23,14 @@ function withEnvUnset(name: string, fn: () => void): void {
 }
 
 describe('parseChangelog()', () => {
-  it('maps changelog headings to version tags', () => {
-    const changelog = `## [1.0.1](https://example.org) (2026-03-01)
+  it('maps changelog headings to version tags and appends the compare link', () => {
+    const changelog = `## [1.0.1](https://github.com/owner/repo/compare/v1.0.0...v1.0.1) (2026-03-01)
 
 ### Features
 
 * Added release automation.
 
-## [1.0.0](https://example.org) (2026-02-28)
+## [1.0.0](https://github.com/owner/repo/releases/tag/v1.0.0) (2026-02-28)
 
 ### Bug Fixes
 
@@ -38,7 +38,10 @@ describe('parseChangelog()', () => {
 `
 
     expect(parseChangelog(changelog)).toEqual({
-      'v1.0.1': '### Features\n\n* Added release automation.',
+      // Compare link surfaced as a "Full Changelog" footer.
+      'v1.0.1':
+        '### Features\n\n* Added release automation.\n\n**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.1',
+      // Non-`/compare/` link → no footer.
       'v1.0.0': '### Bug Fixes\n\n* Fixed old release notes.',
     })
   })

--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -120,6 +120,7 @@ describe('getReleasePlan()', () => {
         },
       ],
       releasesToUpdate: [{ release_id: 1, tag_name: 'v1.0.0', body: 'Updated old notes' }],
+      releasesToDelete: [],
     })
   })
 
@@ -137,10 +138,11 @@ describe('getReleasePlan()', () => {
     expect(plan).toEqual({
       releasesToCreate: [],
       releasesToUpdate: [{ release_id: 3, tag_name: 'v1.0.1', body: 'Fresh release notes' }],
+      releasesToDelete: [],
     })
   })
 
-  it('leaves GitHub releases without a matching changelog entry untouched', () => {
+  it('leaves releases we do not own untouched (no spurious update or delete)', () => {
     const plan = getReleasePlan({
       defaultBranch: 'main',
       packageName: 'vike',
@@ -148,12 +150,48 @@ describe('getReleasePlan()', () => {
       changelogSections: { 'v1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
-        // No changelog entry for this tag — it must not be queued for a spurious (undefined-body) update.
-        { id: 2, tag_name: 'v0.0.1-orphan', body: 'Unrelated release' },
+        // Not one of our vX.Y.Z tags: must not be updated (no undefined body) nor deleted.
+        { id: 2, tag_name: 'nightly', body: 'Unrelated release' },
       ],
     })
 
-    expect(plan).toEqual({ releasesToCreate: [], releasesToUpdate: [] })
+    expect(plan).toEqual({ releasesToCreate: [], releasesToUpdate: [], releasesToDelete: [] })
+  })
+
+  it('deletes a release whose version was removed from the changelog', () => {
+    const plan = getReleasePlan({
+      defaultBranch: 'main',
+      packageName: 'vike',
+      multiplePackages: false,
+      changelogSections: { 'v1.0.0': 'Notes' },
+      githubReleases: [
+        { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
+        // Owned tag, no longer in the changelog → delete.
+        { id: 2, tag_name: 'v0.9.0', body: 'Removed from changelog' },
+      ],
+    })
+
+    expect(plan).toEqual({
+      releasesToCreate: [],
+      releasesToUpdate: [],
+      releasesToDelete: [{ release_id: 2, tag_name: 'v0.9.0' }],
+    })
+  })
+
+  it('only deletes releases in its own namespace', () => {
+    const plan = getReleasePlan({
+      defaultBranch: 'main',
+      packageName: 'create-vike-core',
+      multiplePackages: true,
+      changelogSections: { 'v0.0.1': 'Notes' },
+      githubReleases: [
+        { id: 1, tag_name: 'create-vike-core@0.0.1', body: 'Notes' },
+        // Another package's release — not ours to delete.
+        { id: 2, tag_name: 'vike@0.4.0', body: 'Another package' },
+      ],
+    })
+
+    expect(plan).toEqual({ releasesToCreate: [], releasesToUpdate: [], releasesToDelete: [] })
   })
 
   it('qualifies tags with the package name when several packages share the repo', () => {
@@ -180,6 +218,7 @@ describe('getReleasePlan()', () => {
         },
       ],
       releasesToUpdate: [],
+      releasesToDelete: [],
     })
   })
 })

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -10,6 +10,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 export { getReleasePlan }
 export { parseChangelog }
 export { toPackageDirs }
+export { getTagName }
 
 import assert from 'node:assert'
 import { execFileSync } from 'node:child_process'
@@ -41,9 +42,14 @@ async function main(): Promise<void> {
   const defaultBranch = getDefaultBranch()
   const token = getGithubToken()
 
+  // When several packages publish to the same repo they share its tag namespace, so releases are
+  // qualified with the package name (see getTagName()). Determined from every tracked CHANGELOG.md,
+  // not just the package(s) being synced now.
+  const multiplePackages = toPackageDirs(getTrackedChangelogFiles()).length > 1
+
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)
-    await syncPackage({ packageDir, owner, repo, defaultBranch, token, dryRun })
+    await syncPackage({ packageDir, owner, repo, defaultBranch, token, dryRun, multiplePackages })
   }
 }
 
@@ -54,6 +60,7 @@ async function syncPackage({
   defaultBranch,
   token,
   dryRun,
+  multiplePackages,
 }: {
   packageDir: string
   owner: string
@@ -61,6 +68,7 @@ async function syncPackage({
   defaultBranch: string
   token: string
   dryRun: boolean
+  multiplePackages: boolean
 }): Promise<void> {
   const require = createRequire(import.meta.url)
 
@@ -68,7 +76,7 @@ async function syncPackage({
   const packageJsonPath = path.join(packageDirPath, 'package.json')
   const changelogPath = path.join(packageDirPath, 'CHANGELOG.md')
 
-  const packageJson = require(packageJsonPath) as { version: string }
+  const packageJson = require(packageJsonPath) as { version: string; name: string }
 
   const versionTag = `v${packageJson.version}`
   const changelog = await readFile(changelogPath, 'utf8')
@@ -81,6 +89,8 @@ async function syncPackage({
     defaultBranch,
     githubReleases,
     changelogSections,
+    packageName: packageJson.name,
+    multiplePackages,
   })
 
   for (const releaseToCreate of releasesToCreate) {
@@ -190,14 +200,26 @@ type ReleasesToUpdate = {
   tag_name: string
   body: string
 }
+// The git tag / GitHub Release tag for a changelog version. A single package keeps the historical
+// bare `vX.Y.Z`. Several packages share the repo's tag namespace, so their tags are qualified with
+// the package name (e.g. `create-vike-core@0.0.391`) to avoid collisions.
+function getTagName(versionTag: string, packageName: string, multiplePackages: boolean): string {
+  if (!multiplePackages) return versionTag
+  return `${packageName}@${versionTag.replace(/^v/, '')}`
+}
+
 function getReleasePlan({
   defaultBranch,
   githubReleases,
   changelogSections,
+  packageName,
+  multiplePackages,
 }: {
   defaultBranch: string
   githubReleases: Release[]
   changelogSections: ChangelogSections
+  packageName: string
+  multiplePackages: boolean
 }) {
   // Reconcile from the changelog (the source of truth), not from the GitHub Releases: iterating the
   // releases for updates would try to rewrite any release whose tag isn't in the changelog (e.g. a
@@ -212,8 +234,9 @@ function getReleasePlan({
   // last becomes the repo's "Latest". (The releases list itself is ordered by GitHub on tag semver,
   // not creation order, so backfilled older releases still slot in correctly:
   // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
-  for (const tagName of Object.keys(changelogSections).reverse()) {
-    const body = changelogSections[tagName]
+  for (const versionTag of Object.keys(changelogSections).reverse()) {
+    const body = changelogSections[versionTag]
+    const tagName = getTagName(versionTag, packageName, multiplePackages)
     const existingRelease = releasesByTag.get(tagName)
     if (!existingRelease) {
       releasesToCreate.push({ tag_name: tagName, target_commitish: defaultBranch, name: tagName, body })

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -13,7 +13,6 @@ export { toPackageDirs }
 export { getTagName }
 export { withSourceOfTruth }
 
-import assert from 'node:assert'
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
@@ -77,12 +76,10 @@ async function syncPackage({
   const packageJsonPath = path.join(packageDirPath, 'package.json')
   const changelogPath = path.join(packageDirPath, 'CHANGELOG.md')
 
-  const packageJson = require(packageJsonPath) as { version: string; name: string }
+  const packageJson = require(packageJsonPath) as { name: string }
 
-  const versionTag = `v${packageJson.version}`
   const changelog = await readFile(changelogPath, 'utf8')
   const changelogSections = parseChangelog(changelog)
-  assertChangelog(versionTag, changelogSections)
 
   // These releases are generated, so point each one back to the changelog it mirrors (the source of
   // truth) to discourage editing the GitHub Release directly — a sync would overwrite it.
@@ -200,15 +197,6 @@ function parseChangelog(changelog: string): ChangelogSections {
   })
 
   return changelogSections
-}
-function assertChangelog(versionTag: string, changelogSections: ChangelogSections) {
-  const latestRelease = Object.keys(changelogSections)[0]
-  assert(
-    latestRelease === versionTag,
-    `The latest changelog entry is ${latestRelease}, but the current version is ${versionTag}`,
-  )
-  const currentBody = changelogSections[versionTag]
-  assert(currentBody, `Missing changelog entry for ${versionTag}`)
 }
 
 type ReleasesToCreate = {

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -103,7 +103,10 @@ async function syncPackage({
   // (for the changelog-history lookup) and remember the newest tag (the just-released version).
   const versionTags = Object.keys(changelogSections)
   const versionByTag = new Map(
-    versionTags.map((versionTag) => [getTagName(versionTag, packageJson.name, multiplePackages), versionTag.replace(/^v/, '')]),
+    versionTags.map((versionTag) => [
+      getTagName(versionTag, packageJson.name, multiplePackages),
+      versionTag.replace(/^v/, ''),
+    ]),
   )
   const newestTag = versionTags.length > 0 ? getTagName(versionTags[0], packageJson.name, multiplePackages) : ''
 
@@ -115,8 +118,15 @@ async function syncPackage({
     const tagExists = gitTagExists(tagName)
     const isNewest = tagName === newestTag
     const deducedCommit = !tagExists && !isNewest ? findReleaseCommit(versionByTag.get(tagName)!) : null
-    releaseToCreate.target_commitish = chooseCreateCommitish({ tagName, tagExists, isNewest, deducedCommit, defaultBranch })
-    if (!tagExists && !isNewest) console.warn(`Tag ${tagName} is missing — creating its release at deduced commit ${deducedCommit}`)
+    releaseToCreate.target_commitish = chooseCreateCommitish({
+      tagName,
+      tagExists,
+      isNewest,
+      deducedCommit,
+      defaultBranch,
+    })
+    if (!tagExists && !isNewest)
+      console.warn(`Tag ${tagName} is missing — creating its release at deduced commit ${deducedCommit}`)
 
     // https://docs.github.com/en/rest/releases/releases#create-a-release
     await githubRequest(`/repos/${owner}/${repo}/releases`, {
@@ -347,7 +357,9 @@ function getReleasePlan({
 
   // Delete this package's releases whose version is no longer in the changelog (the source of truth).
   const releasesToDelete: ReleasesToDelete[] = githubReleases
-    .filter((release) => isOwnedTag(release.tag_name, packageName, multiplePackages) && !expectedTags.has(release.tag_name))
+    .filter(
+      (release) => isOwnedTag(release.tag_name, packageName, multiplePackages) && !expectedTags.has(release.tag_name),
+    )
     .map((release) => ({ release_id: release.id, tag_name: release.tag_name }))
 
   return { releasesToCreate, releasesToUpdate, releasesToDelete }

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -11,6 +11,7 @@ export { getReleasePlan }
 export { parseChangelog }
 export { toPackageDirs }
 export { getTagName }
+export { withSourceOfTruth }
 
 import assert from 'node:assert'
 import { execFileSync } from 'node:child_process'
@@ -82,6 +83,13 @@ async function syncPackage({
   const changelog = await readFile(changelogPath, 'utf8')
   const changelogSections = parseChangelog(changelog)
   assertChangelog(versionTag, changelogSections)
+
+  // These releases are generated, so point each one back to the changelog it mirrors (the source of
+  // truth) to discourage editing the GitHub Release directly — a sync would overwrite it.
+  const changelogUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${packageDir}/CHANGELOG.md`
+  for (const versionTag of Object.keys(changelogSections)) {
+    changelogSections[versionTag] = withSourceOfTruth(changelogSections[versionTag], changelogUrl)
+  }
 
   const githubReleases = await fetchGithubReleases(owner, repo, token)
 
@@ -232,6 +240,11 @@ function getTagName(versionTag: string, packageName: string, multiplePackages: b
 function isOwnedTag(tagName: string, packageName: string, multiplePackages: boolean): boolean {
   if (multiplePackages) return tagName.startsWith(`${packageName}@`)
   return /^v\d+\.\d+\.\d+/.test(tagName)
+}
+
+// Footer appended to every release body, linking back to the changelog the release is generated from.
+function withSourceOfTruth(body: string, changelogUrl: string): string {
+  return `${body}\n\n_Source of truth: [\`CHANGELOG.md\`](${changelogUrl})._`
 }
 
 function getReleasePlan({

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -12,6 +12,7 @@ export { parseChangelog }
 export { toPackageDirs }
 export { getTagName }
 export { withSourceOfTruth }
+export { chooseCreateCommitish }
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
@@ -98,7 +99,25 @@ async function syncPackage({
     multiplePackages,
   })
 
+  // changelogSections is keyed by `vX.Y.Z`; map each release tag back to its raw changelog version
+  // (for the changelog-history lookup) and remember the newest tag (the just-released version).
+  const versionTags = Object.keys(changelogSections)
+  const versionByTag = new Map(
+    versionTags.map((versionTag) => [getTagName(versionTag, packageJson.name, multiplePackages), versionTag.replace(/^v/, '')]),
+  )
+  const newestTag = versionTags.length > 0 ? getTagName(versionTags[0], packageJson.name, multiplePackages) : ''
+
   for (const releaseToCreate of releasesToCreate) {
+    const tagName = releaseToCreate.tag_name
+    // A release needs a tag to point at. When the tag is missing, GitHub would otherwise create it at
+    // the default branch's HEAD — the wrong commit for a backfilled release. Deduce the real commit
+    // from the changelog's history and tag that instead (or refuse, rather than tag the wrong commit).
+    const tagExists = gitTagExists(tagName)
+    const isNewest = tagName === newestTag
+    const deducedCommit = !tagExists && !isNewest ? findReleaseCommit(versionByTag.get(tagName)!) : null
+    releaseToCreate.target_commitish = chooseCreateCommitish({ tagName, tagExists, isNewest, deducedCommit, defaultBranch })
+    if (!tagExists && !isNewest) console.warn(`Tag ${tagName} is missing — creating its release at deduced commit ${deducedCommit}`)
+
     // https://docs.github.com/en/rest/releases/releases#create-a-release
     await githubRequest(`/repos/${owner}/${repo}/releases`, {
       token,
@@ -106,7 +125,7 @@ async function syncPackage({
       body: releaseToCreate,
       dryRun,
     })
-    if (!dryRun) console.log(`Created release ${releaseToCreate.tag_name}`)
+    if (!dryRun) console.log(`Created release ${tagName}`)
   }
 
   for (const releaseToUpdate of releasesToUpdate) {
@@ -179,6 +198,25 @@ function getTrackedChangelogFiles(): string[] {
   return stdout.split('\n').filter(Boolean)
 }
 
+function gitTagExists(tagName: string): boolean {
+  try {
+    execFileSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${tagName}`], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// The commit that introduced this version's changelog entry — i.e. the release commit, which is where
+// its tag belongs. Pickaxe (`-S`, a literal-string search) the changelog history for the heading's
+// link opener `[<version>](`; the oldest commit that changed its count is the one that added it.
+function findReleaseCommit(version: string): string | null {
+  const stdout = execFileSync('git', ['log', '--reverse', '--format=%H', `-S[${version}](`, '--', '*CHANGELOG.md'], {
+    encoding: 'utf8',
+  })
+  return stdout.split('\n').filter(Boolean)[0] ?? null
+}
+
 type ChangelogSections = Record<string, string>
 function parseChangelog(changelog: string): ChangelogSections {
   const changelogSections: ChangelogSections = {}
@@ -233,6 +271,39 @@ function isOwnedTag(tagName: string, packageName: string, multiplePackages: bool
 // Footer appended to every release body, linking back to the changelog the release is generated from.
 function withSourceOfTruth(body: string, changelogUrl: string): string {
   return `${body}\n\n_Source of truth: [\`CHANGELOG.md\`](${changelogUrl})._`
+}
+
+// The commit a to-be-created release should be tagged at (its `target_commitish`).
+//  - Tag already exists: GitHub uses it and ignores target_commitish — pass the branch as a no-op.
+//  - Tag missing on the newest release: hard fail. The just-released version must already be tagged;
+//    tagging it now would point at the default branch's HEAD (the wrong commit).
+//  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history,
+//    or hard fail if it couldn't be deduced — never silently tag the wrong commit.
+function chooseCreateCommitish({
+  tagName,
+  tagExists,
+  isNewest,
+  deducedCommit,
+  defaultBranch,
+}: {
+  tagName: string
+  tagExists: boolean
+  isNewest: boolean
+  deducedCommit: string | null
+  defaultBranch: string
+}): string {
+  if (tagExists) return defaultBranch
+  if (isNewest) {
+    throw new Error(
+      `Refusing to create release ${tagName}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
+    )
+  }
+  if (!deducedCommit) {
+    throw new Error(
+      `Refusing to create release ${tagName}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
+    )
+  }
+  return deducedCommit
 }
 
 function getReleasePlan({

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -85,7 +85,7 @@ async function syncPackage({
 
   const githubReleases = await fetchGithubReleases(owner, repo, token)
 
-  const { releasesToCreate, releasesToUpdate } = getReleasePlan({
+  const { releasesToCreate, releasesToUpdate, releasesToDelete } = getReleasePlan({
     defaultBranch,
     githubReleases,
     changelogSections,
@@ -113,6 +113,16 @@ async function syncPackage({
       dryRun,
     })
     if (!dryRun) console.log(`Updated release ${releaseToUpdate.tag_name}`)
+  }
+
+  for (const releaseToDelete of releasesToDelete) {
+    // https://docs.github.com/en/rest/releases/releases#delete-a-release
+    await githubRequest(`/repos/${owner}/${repo}/releases/${releaseToDelete.release_id}`, {
+      token,
+      method: 'DELETE',
+      dryRun,
+    })
+    if (!dryRun) console.log(`Deleted release ${releaseToDelete.tag_name}`)
   }
 }
 
@@ -200,12 +210,24 @@ type ReleasesToUpdate = {
   tag_name: string
   body: string
 }
+type ReleasesToDelete = {
+  release_id: number
+  tag_name: string
+}
 // The git tag / GitHub Release tag for a changelog version. A single package keeps the historical
 // bare `vX.Y.Z`. Several packages share the repo's tag namespace, so their tags are qualified with
 // the package name (e.g. `create-vike-core@0.0.391`) to avoid collisions.
 function getTagName(versionTag: string, packageName: string, multiplePackages: boolean): string {
   if (!multiplePackages) return versionTag
   return `${packageName}@${versionTag.replace(/^v/, '')}`
+}
+
+// Whether a GitHub Release tag belongs to the package being synced — i.e. is a candidate for
+// deletion once its changelog entry is gone. Mirrors getTagName()'s two schemes, so a release of
+// another package (or a tag we never created, e.g. `nightly`) is never deleted.
+function isOwnedTag(tagName: string, packageName: string, multiplePackages: boolean): boolean {
+  if (multiplePackages) return tagName.startsWith(`${packageName}@`)
+  return /^v\d+\.\d+\.\d+/.test(tagName)
 }
 
 function getReleasePlan({
@@ -226,6 +248,7 @@ function getReleasePlan({
   // release of another package, or a manually-created one) with an `undefined` body. Driving both
   // create and update off the changelog can only ever touch the versions the changelog declares.
   const releasesByTag = new Map(githubReleases.map((release) => [release.tag_name, release]))
+  const expectedTags = new Set<string>()
   const releasesToCreate: ReleasesToCreate[] = []
   const releasesToUpdate: ReleasesToUpdate[] = []
 
@@ -237,6 +260,7 @@ function getReleasePlan({
   for (const versionTag of Object.keys(changelogSections).reverse()) {
     const body = changelogSections[versionTag]
     const tagName = getTagName(versionTag, packageName, multiplePackages)
+    expectedTags.add(tagName)
     const existingRelease = releasesByTag.get(tagName)
     if (!existingRelease) {
       releasesToCreate.push({ tag_name: tagName, target_commitish: defaultBranch, name: tagName, body })
@@ -245,5 +269,10 @@ function getReleasePlan({
     }
   }
 
-  return { releasesToCreate, releasesToUpdate }
+  // Delete this package's releases whose version is no longer in the changelog (the source of truth).
+  const releasesToDelete: ReleasesToDelete[] = githubReleases
+    .filter((release) => isOwnedTag(release.tag_name, packageName, multiplePackages) && !expectedTags.has(release.tag_name))
+    .map((release) => ({ release_id: release.id, tag_name: release.tag_name }))
+
+  return { releasesToCreate, releasesToUpdate, releasesToDelete }
 }

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -177,13 +177,17 @@ function getTrackedChangelogFiles(): string[] {
 type ChangelogSections = Record<string, string>
 function parseChangelog(changelog: string): ChangelogSections {
   const changelogSections: ChangelogSections = {}
-  // Matches changelog headings: `## [0.4.257](...)` or `# [0.1.0-beta.6](...)`
-  const matches = [...changelog.matchAll(/^##? \[(\d+\.\d+\.\d+[^\]]*)\]/gm)]
+  // Group 1 is the version; group 2 (optional) is the heading's link. release-me links the version to
+  // a `…/compare/…` URL — `## [0.4.257](…/compare/…)` — which we surface as the release's "Full
+  // Changelog". (The very first release links to a `…/tree/…` URL instead, which we skip.)
+  const matches = [...changelog.matchAll(/^##? \[(\d+\.\d+\.\d+[^\]]*)\](?:\(([^)]+)\))?/gm)]
 
   matches.forEach((match, index) => {
     const start = changelog.indexOf('\n', match.index)
     const end = matches[index + 1]?.index ?? changelog.length
-    const notes = changelog.slice(start, end).trim()
+    let notes = changelog.slice(start, end).trim()
+    const headingUrl = match[2]
+    if (headingUrl?.includes('/compare/')) notes += `\n\n**Full Changelog**: ${headingUrl}`
     changelogSections[`v${match[1]}`] = notes
   })
 

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -199,28 +199,28 @@ function getReleasePlan({
   githubReleases: Release[]
   changelogSections: ChangelogSections
 }) {
-  // changelogSections is newest-first; .reverse() creates the missing releases oldest-first. This
-  // matters because create-release defaults to make_latest=true: whichever release is created last
-  // becomes the repo's "Latest", so the newest must go last. (The releases list itself is ordered by
-  // GitHub on tag semver, not creation order, so backfilled older releases still slot in correctly:
-  // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
-  const releasesToCreate: ReleasesToCreate[] = Object.keys(changelogSections)
-    .filter((tagName) => !githubReleases.some((release) => release.tag_name === tagName))
-    .reverse()
-    .map((tagName) => ({
-      tag_name: tagName,
-      target_commitish: defaultBranch,
-      name: tagName,
-      body: changelogSections[tagName],
-    }))
+  // Reconcile from the changelog (the source of truth), not from the GitHub Releases: iterating the
+  // releases for updates would try to rewrite any release whose tag isn't in the changelog (e.g. a
+  // release of another package, or a manually-created one) with an `undefined` body. Driving both
+  // create and update off the changelog can only ever touch the versions the changelog declares.
+  const releasesByTag = new Map(githubReleases.map((release) => [release.tag_name, release]))
+  const releasesToCreate: ReleasesToCreate[] = []
+  const releasesToUpdate: ReleasesToUpdate[] = []
 
-  const releasesToUpdate: ReleasesToUpdate[] = githubReleases
-    .map((release) => {
-      const body = changelogSections[release.tag_name]
-      if (body === release.body?.trim()) return null
-      return { release_id: release.id, tag_name: release.tag_name, body }
-    })
-    .filter((release) => release !== null)
+  // changelogSections is newest-first; iterate oldest-first so the newest release is created last.
+  // This matters because create-release defaults to make_latest=true: whichever release is created
+  // last becomes the repo's "Latest". (The releases list itself is ordered by GitHub on tag semver,
+  // not creation order, so backfilled older releases still slot in correctly:
+  // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
+  for (const tagName of Object.keys(changelogSections).reverse()) {
+    const body = changelogSections[tagName]
+    const existingRelease = releasesByTag.get(tagName)
+    if (!existingRelease) {
+      releasesToCreate.push({ tag_name: tagName, target_commitish: defaultBranch, name: tagName, body })
+    } else if (existingRelease.body?.trim() !== body) {
+      releasesToUpdate.push({ release_id: existingRelease.id, tag_name: tagName, body })
+    }
+  }
 
   return { releasesToCreate, releasesToUpdate }
 }


### PR DESCRIPTION
Follow-up to the review of #3367 — implements the agreed points, **one per commit**. Targets `brillout/sync-github-releases` (the feature branch) since it isn't on `main` yet.

All 23 unit tests pass, `tsc` is clean, and Biome is clean.

### Commits (one per review point)

| Point | Commit | What |
| --- | --- | --- |
| **B1** | reconcile from the changelog, not the releases | Drive both create *and* update off the changelog (the source of truth) in one pass. Fixes the latent bug where a release whose tag isn't in the changelog was queued for a no-op `undefined`-body PATCH (+ misleading "Updated release" log). |
| **B2** | namespace release tags per package | `getTagName()`: a single package keeps the bare `vX.Y.Z`; multiple packages (more than one tracked `CHANGELOG.md`) qualify with `package.json#name`, e.g. `create-vike-core@0.0.391`. |
| **(new)** | delete releases removed from the changelog | `getReleasePlan()` now returns `releasesToDelete`: the package's own releases (scoped by `isOwnedTag()`) whose version is gone from the changelog. Other packages' releases and tags we never created (e.g. `nightly`) are left alone. |
| **E1** | surface the compare link | Capture the heading's `…/compare/…` URL and append it as a **Full Changelog** footer (the first release's `/tree/` link is skipped). |
| **(new)** | source-of-truth footer | Every body ends with `Source of truth: CHANGELOG.md` linking to the package's changelog, discouraging hand-edits (a sync overwrites them). |
| **E2** | drop `assertChangelog` | It added nothing to source-of-truth syncing and could spuriously hard-fail; also removes the only use of `package.json#version` and `node:assert` here. |
| **C1** | don't tag releases at the wrong commit | `chooseCreateCommitish()`: existing tag → used as-is; missing tag on the **newest** release → hard fail; missing tag on an **older** release → tag the commit deduced from the changelog's own git history (`findReleaseCommit`), else hard fail. Never silently tags `main`'s HEAD. |
| **C2** | concurrency group | Serialize runs so two quick CHANGELOG pushes don't race to create the same release. |
| **C4** | throttle between writes only | A single new release no longer pays ~1s of needless rate-limit sleeps; a backfill of N writes still pays N−1 delays. |

### On C1 "deduce the commit from CHANGELOG.md"

The changelog text itself doesn't carry the release commit's SHA (the compare link is circular; the bullet SHAs are the individual fixes, not the version-bump/tag commit). So the deduction uses the changelog's **git history**: the commit that *added* the `[<version>](` heading is the release commit, and the tag is created there. This also self-limits safely — a version that was never really released (e.g. a changelog typo) has no such commit, so it hard-fails instead of fabricating a tag.

### D1 — intentionally skipped

> for the push use case, maybe we can read the diff … BUT ONLY DO IT if it's relatively trivial and a quick-win

It isn't a quick-win: robustly attributing diff hunks to changelog sections is fiddly (body-only edits don't touch the heading line), and it works against the new delete-on-removal feature, which needs the full picture. Left as-is.

### Notes / trade-offs worth a glance

- **B2 transition:** if a second `CHANGELOG.md` ever appears, vike's tags switch from `vX.Y.Z` to `vike@X.Y.Z` — its existing bare-`v` releases would then look un-owned. Fine for the current single-package reality; flagging in case multi-package is adopted.
- **Deletes are outward-facing.** Deleting a Release doesn't delete its git tag, so it's recoverable, but it does remove notes/notifications — `--dry-run`/`check` lists them first.
- Existing releases will show a one-time "update" on first run after this lands (they gain the compare link + source-of-truth footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m)_