### PR TITLE
sync-github-releases: fix delete/make_latest safety + tidy target_commitish

### DIFF
--- a/.github/workflows/sync-github-releases/index.spec.ts
+++ b/.github/workflows/sync-github-releases/index.spec.ts
@@ -99,7 +99,6 @@ describe('parseChangelog()', () => {
 describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
     const plan = getReleasePlan({
-      defaultBranch: 'main',
       packageName: 'vike',
       multiplePackages: false,
       changelogSections: {
@@ -118,13 +117,11 @@ describe('getReleasePlan()', () => {
       releasesToCreate: [
         {
           tag_name: 'v0.8.0',
-          target_commitish: 'main',
           name: 'v0.8.0',
           body: 'Missing past notes',
         },
         {
           tag_name: 'v1.0.1',
-          target_commitish: 'main',
           name: 'v1.0.1',
           body: 'New release notes',
         },
@@ -136,7 +133,6 @@ describe('getReleasePlan()', () => {
 
   it('updates the current release instead of creating a duplicate', () => {
     const plan = getReleasePlan({
-      defaultBranch: 'main',
       packageName: 'vike',
       multiplePackages: false,
       changelogSections: {
@@ -154,7 +150,6 @@ describe('getReleasePlan()', () => {
 
   it('leaves releases we do not own untouched (no spurious update or delete)', () => {
     const plan = getReleasePlan({
-      defaultBranch: 'main',
       packageName: 'vike',
       multiplePackages: false,
       changelogSections: { 'v1.0.0': 'Notes' },
@@ -170,7 +165,6 @@ describe('getReleasePlan()', () => {
 
   it('deletes a release whose version was removed from the changelog', () => {
     const plan = getReleasePlan({
-      defaultBranch: 'main',
       packageName: 'vike',
       multiplePackages: false,
       changelogSections: { 'v1.0.0': 'Notes' },
@@ -190,7 +184,6 @@ describe('getReleasePlan()', () => {
 
   it('only deletes releases in its own namespace', () => {
     const plan = getReleasePlan({
-      defaultBranch: 'main',
       packageName: 'create-vike-core',
       multiplePackages: true,
       changelogSections: { 'v0.0.1': 'Notes' },
@@ -206,7 +199,6 @@ describe('getReleasePlan()', () => {
 
   it('qualifies tags with the package name when several packages share the repo', () => {
     const plan = getReleasePlan({
-      defaultBranch: 'main',
       packageName: 'create-vike-core',
       multiplePackages: true,
       changelogSections: {
@@ -222,7 +214,6 @@ describe('getReleasePlan()', () => {
       releasesToCreate: [
         {
           tag_name: 'create-vike-core@0.0.2',
-          target_commitish: 'main',
           name: 'create-vike-core@0.0.2',
           body: 'New notes',
         },

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -92,7 +92,6 @@ async function syncPackage({
   const githubReleases = await fetchGithubReleases(owner, repo, token)
 
   const { releasesToCreate, releasesToUpdate, releasesToDelete } = getReleasePlan({
-    defaultBranch,
     githubReleases,
     changelogSections,
     packageName: packageJson.name,
@@ -118,13 +117,7 @@ async function syncPackage({
     const tagExists = gitTagExists(tagName)
     const isNewest = tagName === newestTag
     const deducedCommit = !tagExists && !isNewest ? findReleaseCommit(versionByTag.get(tagName)!) : null
-    releaseToCreate.target_commitish = chooseCreateCommitish({
-      tagName,
-      tagExists,
-      isNewest,
-      deducedCommit,
-      defaultBranch,
-    })
+    const targetCommitish = chooseCreateCommitish({ tagName, tagExists, isNewest, deducedCommit, defaultBranch })
     if (!tagExists && !isNewest)
       console.warn(`Tag ${tagName} is missing — creating its release at deduced commit ${deducedCommit}`)
 
@@ -132,7 +125,12 @@ async function syncPackage({
     await githubRequest(`/repos/${owner}/${repo}/releases`, {
       token,
       method: 'POST',
-      body: releaseToCreate,
+      body: {
+        tag_name: tagName,
+        target_commitish: targetCommitish,
+        name: releaseToCreate.name,
+        body: releaseToCreate.body,
+      },
       dryRun,
     })
     if (!dryRun) console.log(`Created release ${tagName}`)
@@ -249,7 +247,6 @@ function parseChangelog(changelog: string): ChangelogSections {
 
 type ReleasesToCreate = {
   tag_name: string
-  target_commitish: string
   name: string
   body: string
 }
@@ -317,13 +314,11 @@ function chooseCreateCommitish({
 }
 
 function getReleasePlan({
-  defaultBranch,
   githubReleases,
   changelogSections,
   packageName,
   multiplePackages,
 }: {
-  defaultBranch: string
   githubReleases: Release[]
   changelogSections: ChangelogSections
   packageName: string
@@ -349,7 +344,7 @@ function getReleasePlan({
     expectedTags.add(tagName)
     const existingRelease = releasesByTag.get(tagName)
     if (!existingRelease) {
-      releasesToCreate.push({ tag_name: tagName, target_commitish: defaultBranch, name: tagName, body })
+      releasesToCreate.push({ tag_name: tagName, name: tagName, body })
     } else if (existingRelease.body?.trim() !== body) {
       releasesToUpdate.push({ release_id: existingRelease.id, tag_name: tagName, body })
     }

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -130,6 +130,10 @@ async function syncPackage({
         target_commitish: targetCommitish,
         name: releaseToCreate.name,
         body: releaseToCreate.body,
+        // Only the newest version may be the repo's "Latest". create-release otherwise defaults
+        // make_latest=true, so backfilling an older release while a newer one already exists would
+        // wrongly mark the old one Latest.
+        make_latest: isNewest ? 'true' : 'false',
       },
       dryRun,
     })
@@ -333,11 +337,10 @@ function getReleasePlan({
   const releasesToCreate: ReleasesToCreate[] = []
   const releasesToUpdate: ReleasesToUpdate[] = []
 
-  // changelogSections is newest-first; iterate oldest-first so the newest release is created last.
-  // This matters because create-release defaults to make_latest=true: whichever release is created
-  // last becomes the repo's "Latest". (The releases list itself is ordered by GitHub on tag semver,
-  // not creation order, so backfilled older releases still slot in correctly:
-  // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
+  // changelogSections is newest-first; iterate oldest-first so releases are created (and their
+  // notifications sent) in chronological order. Which release is "Latest" is set explicitly via
+  // make_latest in syncPackage, not inferred from creation order. (GitHub orders the releases list by
+  // tag semver regardless: https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
   for (const versionTag of Object.keys(changelogSections).reverse()) {
     const body = changelogSections[versionTag]
     const tagName = getTagName(versionTag, packageName, multiplePackages)


### PR DESCRIPTION
Follow-up to the second-pass review of the sync-github-releases tooling. Fixes the two real bugs and the one redundancy I found, **one per commit**, on top of #3377.

All 27 unit tests pass, `tsc` clean, Biome clean.

### 🔴 H1 — Guard deletes against a misparsed changelog
A `CHANGELOG.md` that parses to **zero** versions (emptied, corrupted, or its format drifted away from release-me's `## [x.y.z](…)`) made `releasesToDelete` = *every* owned release → a sync would delete them all. Removing `assertChangelog` (in #3377) took away the check that would have caught it. Two guards:
- **Abort** the package when its changelog parses to no versions (non-bypassable).
- **Cap**: refuse to delete more than `MAX_DELETES_WITHOUT_PRUNE` (= 1) releases in a run unless `--prune` is passed — a normal removal is one entry, so a bulk deletion almost always signals a parse failure. Extracted as the pure, tested `assertDeletesAllowed()`. Added a `prune` script + README/`check --prune` docs.

### 🔴 H2 — Set `make_latest` explicitly
`create-release` defaults `make_latest=true`, and the code relied on "newest is created last" to keep the **Latest** badge right. That breaks in a *partial backfill* — when the newest release already exists and only older ones are (re)created, the last-created older release wrongly becomes Latest. Now `make_latest: isNewest ? 'true' : 'false'`, so the badge no longer depends on ordering. (Iterating oldest-first is kept, now only for chronological create/notification order.)

### 🟡 M1 — `syncPackage` owns the create payload
`getReleasePlan` set `target_commitish: defaultBranch` on every create, but `syncPackage` then *always* overwrote it via `chooseCreateCommitish` — dead data, and `defaultBranch` was passed to `getReleasePlan` solely to produce it. Dropped `target_commitish` (and the `defaultBranch` param) from `getReleasePlan`/`ReleasesToCreate`; `syncPackage` now builds the full create payload where the commit is actually resolved (which is also where H2's `make_latest` naturally lives).

### Tests
- `assertDeletesAllowed()` — under cap / over cap (throws) / over cap with `--prune` (ok).
- `parseChangelog()` — non-conforming input → `{}` (the precondition the abort relies on).
- Existing `getReleasePlan` expectations updated for the dropped `target_commitish`/`defaultBranch`.

### Residual (not fixed here — flagging for awareness)
A format drift affecting *only* the single newest entry would delete exactly one release (the latest), which slips under the cap of 1. Catching that precisely needs semver-aware "don't delete anything newer than the changelog's top version"; deferred since it'd add a `semver` dep to this tooling. The empty-changelog abort + bulk cap cover the catastrophic and bulk cases. (The minor L1–L3 from the review — token-error wording, prerelease flag, `remove-all-releases` having no dry-run — are left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m)_