### PR TITLE
sync-github-releases: clean, self-documenting naming

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all-releases.ts
+++ b/.github/workflows/sync-github-releases/delete-all-releases.ts
@@ -2,7 +2,7 @@
 // Run via the `delete-all` package.json script — see README.md
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  await removeAllReleases().catch((err) => {
+  await deleteAllReleases().catch((err) => {
     console.error(err)
     process.exit(1)
   })
@@ -11,7 +11,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 import { fileURLToPath } from 'node:url'
 import { fetchGithubReleases, getGithubToken, getRepository, githubRequest } from './utils/github.ts'
 
-async function removeAllReleases() {
+async function deleteAllReleases() {
   const token = getGithubToken()
 
   const { owner, repo } = getRepository()

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'node:url'
 import { parseChangelog } from './utils/changelog.ts'
 import {
   findReleaseCommit,
-  getPushedChangelogFiles,
+  getPushedFiles,
   getRepoRoot,
   getTrackedChangelogFiles,
   gitTagExists,
@@ -164,7 +164,7 @@ async function syncPackage({
 function getPackageDirsToSync(): string[] {
   // On push, sync only the packages whose CHANGELOG.md changed; otherwise (manual workflow_dispatch
   // or a local run with no <package-dir>) sync every package.
-  const pushedChangelogFiles = getPushedChangelogFiles()
-  if (pushedChangelogFiles) return toPackageDirs(pushedChangelogFiles)
+  const pushedFiles = getPushedFiles()
+  if (pushedFiles) return toPackageDirs(pushedFiles)
   return toPackageDirs(getTrackedChangelogFiles())
 }

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -19,7 +19,7 @@ import {
   gitTagExists,
   toPackageDirs,
 } from './utils/git.ts'
-import { chooseCreateCommitish, getReleasePlan, getTagName, withSourceOfTruth } from './release-plan.ts'
+import { chooseCreateCommitish, getReleasePlan, getReleaseTag, withSourceOfTruth } from './release-plan.ts'
 import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './utils/github.ts'
 
 async function main(): Promise<void> {
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
   const token = getGithubToken()
 
   // When several packages publish to the same repo they share its tag namespace, so releases are
-  // qualified with the package name (see getTagName()). Determined from every tracked CHANGELOG.md,
+  // qualified with the package name (see getReleaseTag()). Determined from every tracked CHANGELOG.md,
   // not just the package(s) being synced now.
   const multiplePackages = toPackageDirs(getTrackedChangelogFiles()).length > 1
 
@@ -102,30 +102,31 @@ async function syncPackage({
   const versionTags = Object.keys(changelogSections)
   const versionByTag = new Map(
     versionTags.map((versionTag) => [
-      getTagName(versionTag, packageJson.name, multiplePackages),
+      getReleaseTag(versionTag, packageJson.name, multiplePackages),
       versionTag.replace(/^v/, ''),
     ]),
   )
-  const newestTag = versionTags.length > 0 ? getTagName(versionTags[0], packageJson.name, multiplePackages) : ''
+  const newestReleaseTag =
+    versionTags.length > 0 ? getReleaseTag(versionTags[0], packageJson.name, multiplePackages) : ''
 
   for (const releaseToCreate of releasesToCreate) {
-    const tagName = releaseToCreate.tag_name
+    const releaseTag = releaseToCreate.tag_name
     // A release needs a tag to point at. When the tag is missing, GitHub would otherwise create it at
     // the default branch's HEAD — the wrong commit for a backfilled release. Deduce the real commit
     // from the changelog's history and tag that instead (or refuse, rather than tag the wrong commit).
-    const tagExists = gitTagExists(tagName)
-    const isNewest = tagName === newestTag
-    const deducedCommit = !tagExists && !isNewest ? findReleaseCommit(versionByTag.get(tagName)!) : null
-    const targetCommitish = chooseCreateCommitish({ tagName, tagExists, isNewest, deducedCommit, defaultBranch })
+    const tagExists = gitTagExists(releaseTag)
+    const isNewest = releaseTag === newestReleaseTag
+    const deducedCommit = !tagExists && !isNewest ? findReleaseCommit(versionByTag.get(releaseTag)!) : null
+    const targetCommitish = chooseCreateCommitish({ releaseTag, tagExists, isNewest, deducedCommit, defaultBranch })
     if (!tagExists && !isNewest)
-      console.warn(`Tag ${tagName} is missing — creating its release at deduced commit ${deducedCommit}`)
+      console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
 
     // https://docs.github.com/en/rest/releases/releases#create-a-release
     await githubRequest(`/repos/${owner}/${repo}/releases`, {
       token,
       method: 'POST',
       body: {
-        tag_name: tagName,
+        tag_name: releaseTag,
         target_commitish: targetCommitish,
         name: releaseToCreate.name,
         body: releaseToCreate.body,
@@ -136,7 +137,7 @@ async function syncPackage({
       },
       dryRun,
     })
-    if (!dryRun) console.log(`Created release ${tagName}`)
+    if (!dryRun) console.log(`Created release ${releaseTag}`)
   }
 
   for (const releaseToUpdate of releasesToUpdate) {

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -19,7 +19,7 @@ import {
   gitTagExists,
   toPackageDirs,
 } from './utils/git.ts'
-import { chooseCreateCommitish, getReleasePlan, getReleaseTag, withSourceOfTruth } from './release-plan.ts'
+import { resolveTargetCommitish, getReleasePlan, getReleaseTag, withChangelogFooter } from './release-plan.ts'
 import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './utils/github.ts'
 
 async function main(): Promise<void> {
@@ -45,11 +45,11 @@ async function main(): Promise<void> {
   // When several packages publish to the same repo they share its tag namespace, so releases are
   // qualified with the package name (see getReleaseTag()). Determined from every tracked CHANGELOG.md,
   // not just the package(s) being synced now.
-  const multiplePackages = toPackageDirs(getTrackedChangelogFiles()).length > 1
+  const hasMultiplePackages = toPackageDirs(getTrackedChangelogFiles()).length > 1
 
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)
-    await syncPackage({ packageDir, owner, repo, defaultBranch, token, dryRun, multiplePackages })
+    await syncPackage({ packageDir, owner, repo, defaultBranch, token, dryRun, hasMultiplePackages })
   }
 }
 
@@ -60,7 +60,7 @@ async function syncPackage({
   defaultBranch,
   token,
   dryRun,
-  multiplePackages,
+  hasMultiplePackages,
 }: {
   packageDir: string
   owner: string
@@ -68,7 +68,7 @@ async function syncPackage({
   defaultBranch: string
   token: string
   dryRun: boolean
-  multiplePackages: boolean
+  hasMultiplePackages: boolean
 }): Promise<void> {
   const require = createRequire(import.meta.url)
 
@@ -79,35 +79,35 @@ async function syncPackage({
   const packageJson = require(packageJsonPath) as { name: string }
 
   const changelog = await readFile(changelogPath, 'utf8')
-  const changelogSections = parseChangelog(changelog)
+  const releaseNotesByVersion = parseChangelog(changelog)
 
   // These releases are generated, so point each one back to the changelog it mirrors (the source of
   // truth) to discourage editing the GitHub Release directly — a sync would overwrite it.
   const changelogUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${packageDir}/CHANGELOG.md`
-  for (const versionTag of Object.keys(changelogSections)) {
-    changelogSections[versionTag] = withSourceOfTruth(changelogSections[versionTag], changelogUrl)
+  for (const versionTag of Object.keys(releaseNotesByVersion)) {
+    releaseNotesByVersion[versionTag] = withChangelogFooter(releaseNotesByVersion[versionTag], changelogUrl)
   }
 
   const githubReleases = await fetchGithubReleases(owner, repo, token)
 
   const { releasesToCreate, releasesToUpdate, releasesToDelete } = getReleasePlan({
     githubReleases,
-    changelogSections,
+    releaseNotesByVersion,
     packageName: packageJson.name,
-    multiplePackages,
+    hasMultiplePackages,
   })
 
-  // changelogSections is keyed by `vX.Y.Z`; map each release tag back to its raw changelog version
+  // releaseNotesByVersion is keyed by `vX.Y.Z`; map each release tag back to its raw changelog version
   // (for the changelog-history lookup) and remember the newest tag (the just-released version).
-  const versionTags = Object.keys(changelogSections)
+  const versionTags = Object.keys(releaseNotesByVersion)
   const versionByTag = new Map(
     versionTags.map((versionTag) => [
-      getReleaseTag(versionTag, packageJson.name, multiplePackages),
+      getReleaseTag(versionTag, packageJson.name, hasMultiplePackages),
       versionTag.replace(/^v/, ''),
     ]),
   )
   const newestReleaseTag =
-    versionTags.length > 0 ? getReleaseTag(versionTags[0], packageJson.name, multiplePackages) : ''
+    versionTags.length > 0 ? getReleaseTag(versionTags[0], packageJson.name, hasMultiplePackages) : ''
 
   for (const releaseToCreate of releasesToCreate) {
     const releaseTag = releaseToCreate.tag_name
@@ -117,7 +117,7 @@ async function syncPackage({
     const tagExists = gitTagExists(releaseTag)
     const isNewest = releaseTag === newestReleaseTag
     const deducedCommit = !tagExists && !isNewest ? findReleaseCommit(versionByTag.get(releaseTag)!) : null
-    const targetCommitish = chooseCreateCommitish({ releaseTag, tagExists, isNewest, deducedCommit, defaultBranch })
+    const targetCommitish = resolveTargetCommitish({ releaseTag, tagExists, isNewest, deducedCommit, defaultBranch })
     if (!tagExists && !isNewest)
       console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
 

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -1,4 +1,4 @@
-// Execute main() only when this file is the entry point (via sync-github-releases.yml or package.json script), not when index.spec.ts imports it.
+// Run main() only when this file is executed directly, not when imported.
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   await main().catch((err) => {
     console.error(err)

--- a/.github/workflows/sync-github-releases/package.json
+++ b/.github/workflows/sync-github-releases/package.json
@@ -8,7 +8,7 @@
     "// check [<package-dir>]: dry-run of `run`, logging changes without writing (needs a contents:read token)": "",
     "check": "pnpm node-ts ./index.ts --dry-run",
     "// delete-all: delete every GitHub Release in the repo — destructive (needs a contents:write token)": "",
-    "delete-all": "pnpm node-ts ./remove-all-releases.ts"
+    "delete-all": "pnpm node-ts ./delete-all-releases.ts"
   },
   "devDependencies": {
     "@types/node": "^24.10.2",

--- a/.github/workflows/sync-github-releases/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/release-plan.spec.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { chooseCreateCommitish, getReleasePlan, getReleaseTag } from './release-plan.ts'
+import { resolveTargetCommitish, getReleasePlan, getReleaseTag } from './release-plan.ts'
 
 describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
     const plan = getReleasePlan({
       packageName: 'vike',
-      multiplePackages: false,
-      changelogSections: {
+      hasMultiplePackages: false,
+      releaseNotesByVersion: {
         'v1.0.1': 'New release notes',
         'v1.0.0': 'Updated old notes',
         'v0.9.0': 'Existing notes',
@@ -39,8 +39,8 @@ describe('getReleasePlan()', () => {
   it('updates the current release instead of creating a duplicate', () => {
     const plan = getReleasePlan({
       packageName: 'vike',
-      multiplePackages: false,
-      changelogSections: {
+      hasMultiplePackages: false,
+      releaseNotesByVersion: {
         'v1.0.1': 'Fresh release notes',
       },
       githubReleases: [{ id: 3, tag_name: 'v1.0.1', body: 'Stale release notes' }],
@@ -56,8 +56,8 @@ describe('getReleasePlan()', () => {
   it('leaves releases we do not own untouched (no spurious update or delete)', () => {
     const plan = getReleasePlan({
       packageName: 'vike',
-      multiplePackages: false,
-      changelogSections: { 'v1.0.0': 'Notes' },
+      hasMultiplePackages: false,
+      releaseNotesByVersion: { 'v1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
         // Not one of our vX.Y.Z tags: must not be updated (no undefined body) nor deleted.
@@ -71,8 +71,8 @@ describe('getReleasePlan()', () => {
   it('deletes a release whose version was removed from the changelog', () => {
     const plan = getReleasePlan({
       packageName: 'vike',
-      multiplePackages: false,
-      changelogSections: { 'v1.0.0': 'Notes' },
+      hasMultiplePackages: false,
+      releaseNotesByVersion: { 'v1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
         // Owned tag, no longer in the changelog → delete.
@@ -90,8 +90,8 @@ describe('getReleasePlan()', () => {
   it('only deletes releases in its own namespace', () => {
     const plan = getReleasePlan({
       packageName: 'create-vike-core',
-      multiplePackages: true,
-      changelogSections: { 'v0.0.1': 'Notes' },
+      hasMultiplePackages: true,
+      releaseNotesByVersion: { 'v0.0.1': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'create-vike-core@0.0.1', body: 'Notes' },
         // Another package's release — not ours to delete.
@@ -105,8 +105,8 @@ describe('getReleasePlan()', () => {
   it('qualifies tags with the package name when several packages share the repo', () => {
     const plan = getReleasePlan({
       packageName: 'create-vike-core',
-      multiplePackages: true,
-      changelogSections: {
+      hasMultiplePackages: true,
+      releaseNotesByVersion: {
         'v0.0.2': 'New notes',
         'v0.0.1': 'Old notes',
       },
@@ -129,29 +129,29 @@ describe('getReleasePlan()', () => {
   })
 })
 
-describe('chooseCreateCommitish()', () => {
+describe('resolveTargetCommitish()', () => {
   const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
 
   it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
-    expect(chooseCreateCommitish({ ...base, tagExists: true, isNewest: false, deducedCommit: null })).toBe('main')
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isNewest: false, deducedCommit: null })).toBe('main')
     // Even for the newest release, an existing tag is fine.
-    expect(chooseCreateCommitish({ ...base, tagExists: true, isNewest: true, deducedCommit: null })).toBe('main')
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isNewest: true, deducedCommit: null })).toBe('main')
   })
 
   it('hard-fails when the newest release has no tag', () => {
-    expect(() => chooseCreateCommitish({ ...base, tagExists: false, isNewest: true, deducedCommit: null })).toThrow(
+    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isNewest: true, deducedCommit: null })).toThrow(
       /latest release must already be tagged/,
     )
   })
 
   it('tags an older release at the deduced commit', () => {
-    expect(chooseCreateCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: 'abc123' })).toBe(
+    expect(resolveTargetCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: 'abc123' })).toBe(
       'abc123',
     )
   })
 
   it('hard-fails when an older release has no tag and no deducible commit', () => {
-    expect(() => chooseCreateCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: null })).toThrow(
+    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: null })).toThrow(
       /couldn't be deduced/,
     )
   })

--- a/.github/workflows/sync-github-releases/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/release-plan.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { chooseCreateCommitish, getReleasePlan, getTagName } from './release-plan.ts'
+import { chooseCreateCommitish, getReleasePlan, getReleaseTag } from './release-plan.ts'
 
 describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
@@ -130,7 +130,7 @@ describe('getReleasePlan()', () => {
 })
 
 describe('chooseCreateCommitish()', () => {
-  const base = { tagName: 'v0.4.0', defaultBranch: 'main' }
+  const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
 
   it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
     expect(chooseCreateCommitish({ ...base, tagExists: true, isNewest: false, deducedCommit: null })).toBe('main')
@@ -157,14 +157,14 @@ describe('chooseCreateCommitish()', () => {
   })
 })
 
-describe('getTagName()', () => {
+describe('getReleaseTag()', () => {
   it('keeps the bare vX.Y.Z tag for a single package', () => {
-    expect(getTagName('v0.4.259', 'vike', false)).toBe('v0.4.259')
-    expect(getTagName('v0.1.0-beta.6', 'vike', false)).toBe('v0.1.0-beta.6')
+    expect(getReleaseTag('v0.4.259', 'vike', false)).toBe('v0.4.259')
+    expect(getReleaseTag('v0.1.0-beta.6', 'vike', false)).toBe('v0.1.0-beta.6')
   })
 
   it('qualifies the tag with the package name when there are several packages', () => {
-    expect(getTagName('v0.0.391', 'create-vike-core', true)).toBe('create-vike-core@0.0.391')
-    expect(getTagName('v0.1.0-beta.6', 'vike', true)).toBe('vike@0.1.0-beta.6')
+    expect(getReleaseTag('v0.0.391', 'create-vike-core', true)).toBe('create-vike-core@0.0.391')
+    expect(getReleaseTag('v0.1.0-beta.6', 'vike', true)).toBe('vike@0.1.0-beta.6')
   })
 })

--- a/.github/workflows/sync-github-releases/release-plan.ts
+++ b/.github/workflows/sync-github-releases/release-plan.ts
@@ -6,17 +6,17 @@ export { chooseCreateCommitish }
 import type { ChangelogSections } from './utils/changelog.ts'
 import type { Release } from './utils/github.ts'
 
-type ReleasesToCreate = {
+type ReleaseToCreate = {
   tag_name: string
   name: string
   body: string
 }
-type ReleasesToUpdate = {
+type ReleaseToUpdate = {
   release_id: number
   tag_name: string
   body: string
 }
-type ReleasesToDelete = {
+type ReleaseToDelete = {
   release_id: number
   tag_name: string
 }
@@ -92,8 +92,8 @@ function getReleasePlan({
   // create and update off the changelog can only ever touch the versions the changelog declares.
   const releasesByTag = new Map(githubReleases.map((release) => [release.tag_name, release]))
   const expectedTags = new Set<string>()
-  const releasesToCreate: ReleasesToCreate[] = []
-  const releasesToUpdate: ReleasesToUpdate[] = []
+  const releasesToCreate: ReleaseToCreate[] = []
+  const releasesToUpdate: ReleaseToUpdate[] = []
 
   // changelogSections is newest-first; iterate oldest-first so releases are created (and their
   // notifications sent) in chronological order. Which release is "Latest" is set explicitly via
@@ -112,7 +112,7 @@ function getReleasePlan({
   }
 
   // Delete this package's releases whose version is no longer in the changelog (the source of truth).
-  const releasesToDelete: ReleasesToDelete[] = githubReleases
+  const releasesToDelete: ReleaseToDelete[] = githubReleases
     .filter(
       (release) => isOwnedTag(release.tag_name, packageName, multiplePackages) && !expectedTags.has(release.tag_name),
     )

--- a/.github/workflows/sync-github-releases/release-plan.ts
+++ b/.github/workflows/sync-github-releases/release-plan.ts
@@ -1,5 +1,5 @@
 export { getReleasePlan }
-export { getTagName }
+export { getReleaseTag }
 export { withSourceOfTruth }
 export { chooseCreateCommitish }
 
@@ -24,17 +24,17 @@ type ReleaseToDelete = {
 // The git tag / GitHub Release tag for a changelog version. A single package keeps the historical
 // bare `vX.Y.Z`. Several packages share the repo's tag namespace, so their tags are qualified with
 // the package name (e.g. `create-vike-core@0.0.391`) to avoid collisions.
-function getTagName(versionTag: string, packageName: string, multiplePackages: boolean): string {
+function getReleaseTag(versionTag: string, packageName: string, multiplePackages: boolean): string {
   if (!multiplePackages) return versionTag
   return `${packageName}@${versionTag.replace(/^v/, '')}`
 }
 
 // Whether a GitHub Release tag belongs to the package being synced — i.e. is a candidate for
-// deletion once its changelog entry is gone. Mirrors getTagName()'s two schemes, so a release of
+// deletion once its changelog entry is gone. Mirrors getReleaseTag()'s two schemes, so a release of
 // another package (or a tag we never created, e.g. `nightly`) is never deleted.
-function isOwnedTag(tagName: string, packageName: string, multiplePackages: boolean): boolean {
-  if (multiplePackages) return tagName.startsWith(`${packageName}@`)
-  return /^v\d+\.\d+\.\d+/.test(tagName)
+function isOwnedTag(releaseTag: string, packageName: string, multiplePackages: boolean): boolean {
+  if (multiplePackages) return releaseTag.startsWith(`${packageName}@`)
+  return /^v\d+\.\d+\.\d+/.test(releaseTag)
 }
 
 // Footer appended to every release body, linking back to the changelog the release is generated from.
@@ -49,13 +49,13 @@ function withSourceOfTruth(body: string, changelogUrl: string): string {
 //  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history,
 //    or hard fail if it couldn't be deduced — never silently tag the wrong commit.
 function chooseCreateCommitish({
-  tagName,
+  releaseTag,
   tagExists,
   isNewest,
   deducedCommit,
   defaultBranch,
 }: {
-  tagName: string
+  releaseTag: string
   tagExists: boolean
   isNewest: boolean
   deducedCommit: string | null
@@ -64,12 +64,12 @@ function chooseCreateCommitish({
   if (tagExists) return defaultBranch
   if (isNewest) {
     throw new Error(
-      `Refusing to create release ${tagName}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
+      `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
     )
   }
   if (!deducedCommit) {
     throw new Error(
-      `Refusing to create release ${tagName}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
+      `Refusing to create release ${releaseTag}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
     )
   }
   return deducedCommit
@@ -101,13 +101,13 @@ function getReleasePlan({
   // tag semver regardless: https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
   for (const versionTag of Object.keys(changelogSections).reverse()) {
     const body = changelogSections[versionTag]
-    const tagName = getTagName(versionTag, packageName, multiplePackages)
-    expectedTags.add(tagName)
-    const existingRelease = releasesByTag.get(tagName)
+    const releaseTag = getReleaseTag(versionTag, packageName, multiplePackages)
+    expectedTags.add(releaseTag)
+    const existingRelease = releasesByTag.get(releaseTag)
     if (!existingRelease) {
-      releasesToCreate.push({ tag_name: tagName, name: tagName, body })
+      releasesToCreate.push({ tag_name: releaseTag, name: releaseTag, body })
     } else if (existingRelease.body?.trim() !== body) {
-      releasesToUpdate.push({ release_id: existingRelease.id, tag_name: tagName, body })
+      releasesToUpdate.push({ release_id: existingRelease.id, tag_name: releaseTag, body })
     }
   }
 

--- a/.github/workflows/sync-github-releases/release-plan.ts
+++ b/.github/workflows/sync-github-releases/release-plan.ts
@@ -21,9 +21,9 @@ type ReleaseToDelete = {
   tag_name: string
 }
 
-// The git tag / GitHub Release tag for a changelog version. A single package keeps the historical
-// bare `vX.Y.Z`. Several packages share the repo's tag namespace, so their tags are qualified with
-// the package name (e.g. `create-vike-core@0.0.391`) to avoid collisions.
+// A single package keeps the historical bare `vX.Y.Z` tag. Several packages share the repo's tag
+// namespace, so their tags are qualified with the package name (e.g. `create-vike-core@0.0.391`) to
+// avoid collisions.
 function getReleaseTag(versionTag: string, packageName: string, hasMultiplePackages: boolean): string {
   if (!hasMultiplePackages) return versionTag
   return `${packageName}@${versionTag.replace(/^v/, '')}`
@@ -37,7 +37,6 @@ function isOwnedTag(releaseTag: string, packageName: string, hasMultiplePackages
   return /^v\d+\.\d+\.\d+/.test(releaseTag)
 }
 
-// Footer appended to every release body, linking back to the changelog the release is generated from.
 function withChangelogFooter(body: string, changelogUrl: string): string {
   return `${body}\n\n_Source of truth: [\`CHANGELOG.md\`](${changelogUrl})._`
 }

--- a/.github/workflows/sync-github-releases/release-plan.ts
+++ b/.github/workflows/sync-github-releases/release-plan.ts
@@ -1,9 +1,9 @@
 export { getReleasePlan }
 export { getReleaseTag }
-export { withSourceOfTruth }
-export { chooseCreateCommitish }
+export { withChangelogFooter }
+export { resolveTargetCommitish }
 
-import type { ChangelogSections } from './utils/changelog.ts'
+import type { ReleaseNotesByVersion } from './utils/changelog.ts'
 import type { Release } from './utils/github.ts'
 
 type ReleaseToCreate = {
@@ -24,21 +24,21 @@ type ReleaseToDelete = {
 // The git tag / GitHub Release tag for a changelog version. A single package keeps the historical
 // bare `vX.Y.Z`. Several packages share the repo's tag namespace, so their tags are qualified with
 // the package name (e.g. `create-vike-core@0.0.391`) to avoid collisions.
-function getReleaseTag(versionTag: string, packageName: string, multiplePackages: boolean): string {
-  if (!multiplePackages) return versionTag
+function getReleaseTag(versionTag: string, packageName: string, hasMultiplePackages: boolean): string {
+  if (!hasMultiplePackages) return versionTag
   return `${packageName}@${versionTag.replace(/^v/, '')}`
 }
 
 // Whether a GitHub Release tag belongs to the package being synced — i.e. is a candidate for
 // deletion once its changelog entry is gone. Mirrors getReleaseTag()'s two schemes, so a release of
 // another package (or a tag we never created, e.g. `nightly`) is never deleted.
-function isOwnedTag(releaseTag: string, packageName: string, multiplePackages: boolean): boolean {
-  if (multiplePackages) return releaseTag.startsWith(`${packageName}@`)
+function isOwnedTag(releaseTag: string, packageName: string, hasMultiplePackages: boolean): boolean {
+  if (hasMultiplePackages) return releaseTag.startsWith(`${packageName}@`)
   return /^v\d+\.\d+\.\d+/.test(releaseTag)
 }
 
 // Footer appended to every release body, linking back to the changelog the release is generated from.
-function withSourceOfTruth(body: string, changelogUrl: string): string {
+function withChangelogFooter(body: string, changelogUrl: string): string {
   return `${body}\n\n_Source of truth: [\`CHANGELOG.md\`](${changelogUrl})._`
 }
 
@@ -48,7 +48,7 @@ function withSourceOfTruth(body: string, changelogUrl: string): string {
 //    tagging it now would point at the default branch's HEAD (the wrong commit).
 //  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history,
 //    or hard fail if it couldn't be deduced — never silently tag the wrong commit.
-function chooseCreateCommitish({
+function resolveTargetCommitish({
   releaseTag,
   tagExists,
   isNewest,
@@ -77,14 +77,14 @@ function chooseCreateCommitish({
 
 function getReleasePlan({
   githubReleases,
-  changelogSections,
+  releaseNotesByVersion,
   packageName,
-  multiplePackages,
+  hasMultiplePackages,
 }: {
   githubReleases: Release[]
-  changelogSections: ChangelogSections
+  releaseNotesByVersion: ReleaseNotesByVersion
   packageName: string
-  multiplePackages: boolean
+  hasMultiplePackages: boolean
 }) {
   // Reconcile from the changelog (the source of truth), not from the GitHub Releases: iterating the
   // releases for updates would try to rewrite any release whose tag isn't in the changelog (e.g. a
@@ -95,13 +95,13 @@ function getReleasePlan({
   const releasesToCreate: ReleaseToCreate[] = []
   const releasesToUpdate: ReleaseToUpdate[] = []
 
-  // changelogSections is newest-first; iterate oldest-first so releases are created (and their
+  // releaseNotesByVersion is newest-first; iterate oldest-first so releases are created (and their
   // notifications sent) in chronological order. Which release is "Latest" is set explicitly via
   // make_latest in syncPackage, not inferred from creation order. (GitHub orders the releases list by
   // tag semver regardless: https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
-  for (const versionTag of Object.keys(changelogSections).reverse()) {
-    const body = changelogSections[versionTag]
-    const releaseTag = getReleaseTag(versionTag, packageName, multiplePackages)
+  for (const versionTag of Object.keys(releaseNotesByVersion).reverse()) {
+    const body = releaseNotesByVersion[versionTag]
+    const releaseTag = getReleaseTag(versionTag, packageName, hasMultiplePackages)
     expectedTags.add(releaseTag)
     const existingRelease = releasesByTag.get(releaseTag)
     if (!existingRelease) {
@@ -114,7 +114,8 @@ function getReleasePlan({
   // Delete this package's releases whose version is no longer in the changelog (the source of truth).
   const releasesToDelete: ReleaseToDelete[] = githubReleases
     .filter(
-      (release) => isOwnedTag(release.tag_name, packageName, multiplePackages) && !expectedTags.has(release.tag_name),
+      (release) =>
+        isOwnedTag(release.tag_name, packageName, hasMultiplePackages) && !expectedTags.has(release.tag_name),
     )
     .map((release) => ({ release_id: release.id, tag_name: release.tag_name }))
 

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -1,11 +1,11 @@
 export { parseChangelog }
 
 // One entry per changelog version: `vX.Y.Z` → release notes (Markdown).
-export type ChangelogSections = Record<string, string>
+export type ReleaseNotesByVersion = Record<string, string>
 
 // Parse a release-me CHANGELOG.md into per-version release notes.
-function parseChangelog(changelog: string): ChangelogSections {
-  const changelogSections: ChangelogSections = {}
+function parseChangelog(changelog: string): ReleaseNotesByVersion {
+  const releaseNotesByVersion: ReleaseNotesByVersion = {}
   // Group 1 is the version; group 2 (optional) is the heading's link. release-me links the version to
   // a `…/compare/…` URL — `## [0.4.257](…/compare/…)` — which we surface as the release's "Full
   // Changelog". (The very first release links to a `…/tree/…` URL instead, which we skip.)
@@ -17,8 +17,8 @@ function parseChangelog(changelog: string): ChangelogSections {
     let notes = changelog.slice(start, end).trim()
     const headingUrl = match[2]
     if (headingUrl?.includes('/compare/')) notes += `\n\n**Full Changelog**: ${headingUrl}`
-    changelogSections[`v${match[1]}`] = notes
+    releaseNotesByVersion[`v${match[1]}`] = notes
   })
 
-  return changelogSections
+  return releaseNotesByVersion
 }

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -1,9 +1,7 @@
 export { parseChangelog }
 
-// One entry per changelog version: `vX.Y.Z` → release notes (Markdown).
 export type ReleaseNotesByVersion = Record<string, string>
 
-// Parse a release-me CHANGELOG.md into per-version release notes.
 function parseChangelog(changelog: string): ReleaseNotesByVersion {
   const releaseNotesByVersion: ReleaseNotesByVersion = {}
   // Group 1 is the version; group 2 (optional) is the heading's link. release-me links the version to

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -2,7 +2,7 @@ export { getRepoRoot }
 export { gitTagExists }
 export { findReleaseCommit }
 export { getTrackedChangelogFiles }
-export { getPushedChangelogFiles }
+export { getPushedFiles }
 export { toPackageDirs }
 
 import { execFileSync } from 'node:child_process'
@@ -21,26 +21,26 @@ function toPackageDirs(files: string[]): string[] {
   return [...new Set(packageDirs)]
 }
 
-function getPushedChangelogFiles(): string[] | null {
+function getPushedFiles(): string[] | null {
   if (process.env.GITHUB_EVENT_NAME !== 'push') return null
-  const beforeSha = getPushBeforeSha()
-  const sha = process.env.GITHUB_SHA
-  if (!beforeSha || !sha) return null
+  const beforeSha = getCommitBeforePush()
+  const headSha = process.env.GITHUB_SHA
+  if (!beforeSha || !headSha) return null
   // execFileSync runs git without a shell, so the interpolated SHAs can't cause injection.
-  const stdout = execFileSync('git', ['diff', '--name-only', beforeSha, sha], { encoding: 'utf8' })
+  const stdout = execFileSync('git', ['diff', '--name-only', beforeSha, headSha], { encoding: 'utf8' })
   return stdout.split('\n').filter(Boolean)
 }
 
-// `before` is the commit the branch pointed at prior to the push. GitHub Actions writes the
+// The commit the branch pointed at before the push (`github.event.before`). GitHub Actions writes the
 // triggering event's payload to the file at GITHUB_EVENT_PATH.
-function getPushBeforeSha(): string | null {
+function getCommitBeforePush(): string | null {
   const eventPath = process.env.GITHUB_EVENT_PATH
   if (!eventPath) return null
   const event = JSON.parse(readFileSync(eventPath, 'utf8')) as { before?: string }
-  const before = event.before
+  const beforeSha = event.before
   // GitHub uses an all-zero SHA when there's no prior commit (e.g. a branch's first push).
-  if (!before || /^0+$/.test(before)) return null
-  return before
+  if (!beforeSha || /^0+$/.test(beforeSha)) return null
+  return beforeSha
 }
 
 function getTrackedChangelogFiles(): string[] {

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -49,9 +49,9 @@ function getTrackedChangelogFiles(): string[] {
   return stdout.split('\n').filter(Boolean)
 }
 
-function gitTagExists(tagName: string): boolean {
+function gitTagExists(releaseTag: string): boolean {
   try {
-    execFileSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${tagName}`], { stdio: 'ignore' })
+    execFileSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${releaseTag}`], { stdio: 'ignore' })
     return true
   } catch {
     return false


### PR DESCRIPTION
A naming pass over the `sync-github-releases` tooling — self-documenting names, fewer comments. One commit per category. 21 sync tests + full repo unit suite (201) green; `tsc` + Biome clean; no behaviour change.

### Renames
| Before | After | Why |
| --- | --- | --- |
| `ReleasesToCreate/Update/Delete` (types) | `ReleaseToCreate/…` | used as `ReleasesToCreate[]` — a plural element type reads as an array of arrays |
| `getPushedChangelogFiles` | `getPushedFiles` | it returns **all** changed files; the changelog filter is in `toPackageDirs` |
| `getPushBeforeSha` | `getCommitBeforePush` | de-pile the nouns; locals `sha`→`headSha`, `before`→`beforeSha` |
| `remove-all-releases.ts` / `removeAllReleases` | `delete-all-releases.ts` / `deleteAllReleases` | match the `delete-all` script and the REST `DELETE` |
| `getTagName` / `tagName` | `getReleaseTag` / `releaseTag` | "name of which tag?" + it collided with `versionTag` (the changelog `vX.Y.Z` key) |
| `withSourceOfTruth` | `withChangelogFooter` | say what it does (append a footer) |
| `chooseCreateCommitish` | `resolveTargetCommitish` | drop the ungrammatical "Create"; name the `target_commitish` it resolves |
| `multiplePackages` | `hasMultiplePackages` | a boolean should read as a question |
| `ChangelogSections` (a `Record`) | `ReleaseNotesByVersion` | reveal key (version) + value (notes), not a "list of sections" |

Then a final commit drops comments the new names made redundant and fixes `index.ts`'s header (it referenced the long-removed `index.spec.ts`).

### Full 0–10 rating of every name (the bits below 10 explained)
The complete table is in my chat message to brillout (it's long). Highlights of what scored low and got fixed: the plural type names (4), `getPushedChangelogFiles` (4, factually wrong), `withSourceOfTruth`/`chooseCreateCommitish` (5), `getTagName`/`tagName`/`ChangelogSections`/`remove-all` (6). Names left as-is with a stated reason include `index.ts` (8, conventional entry point) and `getRepositoryFromGit` (7, returns a slug string while `getRepository` returns an object — left because it's a single-use private helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m)_