### PR TITLE
sync-github-releases: DRY up git calls, the releases client, and the entry guard

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all-releases.ts
+++ b/.github/workflows/sync-github-releases/delete-all-releases.ts
@@ -9,7 +9,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 }
 
 import { fileURLToPath } from 'node:url'
-import { fetchGithubReleases, getGithubToken, getRepository, githubRequest } from './utils/github.ts'
+import { deleteRelease, fetchGithubReleases, getGithubToken, getRepository } from './utils/github.ts'
 
 async function deleteAllReleases() {
   const token = getGithubToken()
@@ -23,12 +23,7 @@ async function deleteAllReleases() {
 
   for (const release of githubReleases) {
     console.log(`Deleting release ${release.tag_name} (ID: ${release.id}) …`)
-
-    // https://docs.github.com/en/rest/releases/releases#delete-a-release
-    await githubRequest(`/repos/${owner}/${repo}/releases/${release.id}`, {
-      method: 'DELETE',
-      token,
-    })
+    await deleteRelease(owner, repo, token, release.id)
   }
 
   console.log(`Deleted ${githubReleases.length} releases.`)

--- a/.github/workflows/sync-github-releases/delete-all-releases.ts
+++ b/.github/workflows/sync-github-releases/delete-all-releases.ts
@@ -1,15 +1,10 @@
 // Deletes every GitHub Release.
 // Run via the `delete-all` package.json script — see README.md
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  await deleteAllReleases().catch((err) => {
-    console.error(err)
-    process.exit(1)
-  })
-}
-
-import { fileURLToPath } from 'node:url'
 import { deleteRelease, fetchGithubReleases, getGithubToken, getRepository } from './utils/github.ts'
+import { runAsMain } from './utils/run-as-main.ts'
+
+runAsMain(import.meta.url, deleteAllReleases)
 
 async function deleteAllReleases() {
   const token = getGithubToken()

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -20,7 +20,15 @@ import {
   toPackageDirs,
 } from './utils/git.ts'
 import { resolveTargetCommitish, getReleasePlan, getReleaseTag, withChangelogFooter } from './release-plan.ts'
-import { fetchGithubReleases, getDefaultBranch, getGithubToken, getRepository, githubRequest } from './utils/github.ts'
+import {
+  createRelease,
+  deleteRelease,
+  fetchGithubReleases,
+  getDefaultBranch,
+  getGithubToken,
+  getRepository,
+  updateReleaseBody,
+} from './utils/github.ts'
 
 async function main(): Promise<void> {
   // The package.json scripts run from this folder; switch to the repo root so the git commands and
@@ -121,11 +129,11 @@ async function syncPackage({
     if (!tagExists && !isNewest)
       console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
 
-    // https://docs.github.com/en/rest/releases/releases#create-a-release
-    await githubRequest(`/repos/${owner}/${repo}/releases`, {
+    await createRelease(
+      owner,
+      repo,
       token,
-      method: 'POST',
-      body: {
+      {
         tag_name: releaseTag,
         target_commitish: targetCommitish,
         name: releaseToCreate.name,
@@ -136,28 +144,17 @@ async function syncPackage({
         make_latest: isNewest ? 'true' : 'false',
       },
       dryRun,
-    })
+    )
     if (!dryRun) console.log(`Created release ${releaseTag}`)
   }
 
   for (const releaseToUpdate of releasesToUpdate) {
-    // https://docs.github.com/en/rest/releases/releases#update-a-release
-    await githubRequest(`/repos/${owner}/${repo}/releases/${releaseToUpdate.release_id}`, {
-      token,
-      method: 'PATCH',
-      body: { body: releaseToUpdate.body },
-      dryRun,
-    })
+    await updateReleaseBody(owner, repo, token, releaseToUpdate.release_id, releaseToUpdate.body, dryRun)
     if (!dryRun) console.log(`Updated release ${releaseToUpdate.tag_name}`)
   }
 
   for (const releaseToDelete of releasesToDelete) {
-    // https://docs.github.com/en/rest/releases/releases#delete-a-release
-    await githubRequest(`/repos/${owner}/${repo}/releases/${releaseToDelete.release_id}`, {
-      token,
-      method: 'DELETE',
-      dryRun,
-    })
+    await deleteRelease(owner, repo, token, releaseToDelete.release_id, dryRun)
     if (!dryRun) console.log(`Deleted release ${releaseToDelete.tag_name}`)
   }
 }

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -1,15 +1,6 @@
-// Run main() only when this file is executed directly, not when imported.
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  await main().catch((err) => {
-    console.error(err)
-    process.exit(1)
-  })
-}
-
 import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { parseChangelog } from './utils/changelog.ts'
 import {
   findReleaseCommit,
@@ -29,6 +20,9 @@ import {
   getRepository,
   updateReleaseBody,
 } from './utils/github.ts'
+import { runAsMain } from './utils/run-as-main.ts'
+
+runAsMain(import.meta.url, main)
 
 async function main(): Promise<void> {
   // The package.json scripts run from this folder; switch to the repo root so the git commands and

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -102,14 +102,11 @@ async function syncPackage({
   // releaseNotesByVersion is keyed by `vX.Y.Z`; map each release tag back to its raw changelog version
   // (for the changelog-history lookup) and remember the newest tag (the just-released version).
   const versionTags = Object.keys(releaseNotesByVersion)
+  const releaseTagOf = (versionTag: string) => getReleaseTag(versionTag, packageJson.name, hasMultiplePackages)
   const versionByTag = new Map(
-    versionTags.map((versionTag) => [
-      getReleaseTag(versionTag, packageJson.name, hasMultiplePackages),
-      versionTag.replace(/^v/, ''),
-    ]),
+    versionTags.map((versionTag) => [releaseTagOf(versionTag), versionTag.replace(/^v/, '')]),
   )
-  const newestReleaseTag =
-    versionTags.length > 0 ? getReleaseTag(versionTags[0], packageJson.name, hasMultiplePackages) : ''
+  const newestReleaseTag = versionTags.length > 0 ? releaseTagOf(versionTags[0]) : ''
 
   for (const releaseToCreate of releasesToCreate) {
     const releaseTag = releaseToCreate.tag_name

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -9,8 +9,17 @@ import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf8' })
+}
+
+// git stdout as lines, dropping the trailing blank left by the final newline.
+function gitLines(args: string[]): string[] {
+  return git(args).split('\n').filter(Boolean)
+}
+
 function getRepoRoot(): string {
-  return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
+  return git(['rev-parse', '--show-toplevel']).trim()
 }
 
 function toPackageDirs(files: string[]): string[] {
@@ -26,9 +35,8 @@ function getPushedFiles(): string[] | null {
   const beforeSha = getCommitBeforePush()
   const headSha = process.env.GITHUB_SHA
   if (!beforeSha || !headSha) return null
-  // execFileSync runs git without a shell, so the interpolated SHAs can't cause injection.
-  const stdout = execFileSync('git', ['diff', '--name-only', beforeSha, headSha], { encoding: 'utf8' })
-  return stdout.split('\n').filter(Boolean)
+  // The SHAs are passed as argv (git() uses no shell), so they can't cause injection.
+  return gitLines(['diff', '--name-only', beforeSha, headSha])
 }
 
 // The commit the branch pointed at before the push (`github.event.before`). GitHub Actions writes the
@@ -45,13 +53,13 @@ function getCommitBeforePush(): string | null {
 
 function getTrackedChangelogFiles(): string[] {
   // `*CHANGELOG.md` matches at any depth — git pathspecs aren't anchored to the repo root.
-  const stdout = execFileSync('git', ['ls-files', '--', '*CHANGELOG.md'], { encoding: 'utf8' })
-  return stdout.split('\n').filter(Boolean)
+  return gitLines(['ls-files', '--', '*CHANGELOG.md'])
 }
 
 function gitTagExists(releaseTag: string): boolean {
+  // `rev-parse --verify` exits non-zero (so git() throws) when the tag is missing.
   try {
-    execFileSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${releaseTag}`], { stdio: 'ignore' })
+    git(['rev-parse', '-q', '--verify', `refs/tags/${releaseTag}`])
     return true
   } catch {
     return false
@@ -62,8 +70,5 @@ function gitTagExists(releaseTag: string): boolean {
 // its tag belongs. Pickaxe (`-S`, a literal-string search) the changelog history for the heading's
 // link opener `[<version>](`; the oldest commit that changed its count is the one that added it.
 function findReleaseCommit(version: string): string | null {
-  const stdout = execFileSync('git', ['log', '--reverse', '--format=%H', `-S[${version}](`, '--', '*CHANGELOG.md'], {
-    encoding: 'utf8',
-  })
-  return stdout.split('\n').filter(Boolean)[0] ?? null
+  return gitLines(['log', '--reverse', '--format=%H', `-S[${version}](`, '--', '*CHANGELOG.md'])[0] ?? null
 }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -1,5 +1,7 @@
 export { fetchGithubReleases }
-export { githubRequest }
+export { createRelease }
+export { updateReleaseBody }
+export { deleteRelease }
 export { getGithubToken }
 export { getDefaultBranch }
 export { getRepository }
@@ -15,6 +17,14 @@ export type Release = {
   body: string | null
 }
 
+type NewRelease = {
+  tag_name: string
+  target_commitish: string
+  name: string
+  body: string
+  make_latest: 'true' | 'false'
+}
+
 const API_URL = process.env.GITHUB_API_URL ?? 'https://api.github.com'
 const REPOSITORY = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
 const DEFAULT_BRANCH = process.env.GITHUB_DEFAULT_BRANCH ?? 'main'
@@ -25,6 +35,10 @@ const RATE_LIMIT_DELAY_MS = 500
 // Writes performed so far, to delay only *between* them (not before the first, nor after reads).
 let writeCount = 0
 
+function releasesPath(owner: string, repo: string): string {
+  return `/repos/${owner}/${repo}/releases`
+}
+
 async function fetchGithubReleases(owner: string, repo: string, token: string): Promise<Release[]> {
   const githubReleases: Release[] = []
   let page = 1
@@ -33,8 +47,10 @@ async function fetchGithubReleases(owner: string, repo: string, token: string): 
   while (true) {
     // https://docs.github.com/en/rest/releases/releases#list-releases
     const releaseList = await githubRequest<Release[]>(
-      `/repos/${owner}/${repo}/releases?per_page=${perPage}&page=${page}`,
-      { token },
+      `${releasesPath(owner, repo)}?per_page=${perPage}&page=${page}`,
+      {
+        token,
+      },
     )
 
     if (releaseList.length === 0) break
@@ -47,6 +63,40 @@ async function fetchGithubReleases(owner: string, repo: string, token: string): 
   }
 
   return githubReleases
+}
+
+async function createRelease(
+  owner: string,
+  repo: string,
+  token: string,
+  release: NewRelease,
+  dryRun = false,
+): Promise<void> {
+  // https://docs.github.com/en/rest/releases/releases#create-a-release
+  await githubRequest(releasesPath(owner, repo), { token, method: 'POST', body: release, dryRun })
+}
+
+async function updateReleaseBody(
+  owner: string,
+  repo: string,
+  token: string,
+  releaseId: number,
+  body: string,
+  dryRun = false,
+): Promise<void> {
+  // https://docs.github.com/en/rest/releases/releases#update-a-release
+  await githubRequest(`${releasesPath(owner, repo)}/${releaseId}`, { token, method: 'PATCH', body: { body }, dryRun })
+}
+
+async function deleteRelease(
+  owner: string,
+  repo: string,
+  token: string,
+  releaseId: number,
+  dryRun = false,
+): Promise<void> {
+  // https://docs.github.com/en/rest/releases/releases#delete-a-release
+  await githubRequest(`${releasesPath(owner, repo)}/${releaseId}`, { token, method: 'DELETE', dryRun })
 }
 
 async function githubRequest<T = void>(

--- a/.github/workflows/sync-github-releases/utils/run-as-main.ts
+++ b/.github/workflows/sync-github-releases/utils/run-as-main.ts
@@ -1,0 +1,13 @@
+export { runAsMain }
+
+import { fileURLToPath } from 'node:url'
+
+// Run fn — exiting non-zero if it rejects — only when its module is executed directly, not imported.
+// The caller passes its own import.meta.url so the check compares against the caller, not this file.
+function runAsMain(moduleUrl: string, fn: () => Promise<void>): void {
+  if (process.argv[1] !== fileURLToPath(moduleUrl)) return
+  fn().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
A DRY pass over the `sync-github-releases` tooling — one commit per repetition removed. 21 sync tests + full repo unit suite (201) green; `tsc` + Biome clean; no behaviour change.

### What was repeated → what it became
1. **`git.ts`** — `execFileSync('git', …, {encoding:'utf8'})` ×5 and `.split('\n').filter(Boolean)` ×3 → `git(args)` + `gitLines(args)`. `gitTagExists` reuses `git()` too (a missing tag makes `rev-parse --verify` throw, which is exactly the boolean it wants).
2. **`github.ts`** — `/repos/${owner}/${repo}/releases` + method + doc-link were rebuilt at every call site, and the `DELETE` request existed in **both** `index.ts` and `delete-all-releases.ts`. Now the client owns `createRelease` / `updateReleaseBody` / `deleteRelease` (sharing `releasesPath()`); `index.ts` and `delete-all` just state intent, and `githubRequest` is private to `github.ts`.
3. **entry guard** — the identical `if (process.argv[1] === fileURLToPath(import.meta.url)) { …catch…exit(1) }` in `index.ts` and `delete-all-releases.ts` → `runAsMain(import.meta.url, fn)`.
4. **`index.ts`** — `getReleaseTag(vt, packageJson.name, hasMultiplePackages)` called twice with the same trailing args → a bound local `releaseTagOf(vt)`.

### Repetition I deliberately left (with reasons)
- The three `Created/Updated/Deleted release …` logs and their `for … { await op(); if (!dryRun) log }` loops *look* alike but each is a distinct operation + message; a generic "apply" helper would hide intent, not clarify it.
- `getGithubToken()` + `getRepository()` setup appears in `main` and `deleteAllReleases` — it's two ordinary calls, not a pattern worth extracting.
- `process.env.X ?? default` (×3 in `github.ts`) reads three *different* env vars — not duplication.

Net: `index.ts` shrinks (~56→fewer lines, the loops are one-liners), the GitHub REST details live in one cohesive client, and `git.ts` has no `execFileSync` boilerplate left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m)_