### PR TITLE
sync-github-releases: don't assume a packages/ monorepo layout

### DIFF
--- a/.github/workflows/sync-github-releases.yml
+++ b/.github/workflows/sync-github-releases.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
     paths:
-      - 'packages/**/CHANGELOG.md'
+      # Any CHANGELOG.md — at the repo root or nested (e.g. packages/vike/CHANGELOG.md).
+      - 'CHANGELOG.md'
+      - '**/CHANGELOG.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -29,6 +29,20 @@ It's safe to run against any current state: older missing releases are created t
 
 A release is tagged from its git tag. The newest version must already be tagged — the sync hard-fails rather than tag the wrong commit — while an older missing tag is recreated at the release commit deduced from the changelog's own history (and hard-fails if it can't be deduced).
 
+## Assumptions
+
+Nothing is hard-coded to this repo — repository, default branch and API URL come from the environment
+(`GITHUB_REPOSITORY`, `GITHUB_DEFAULT_BRANCH`, `GITHUB_API_URL`), so the tooling can be reused as-is in
+any project that follows the same conventions:
+
+- **A package per `CHANGELOG.md`.** A "package" is any directory that has a `CHANGELOG.md` next to a
+  `package.json` — the repo root, `packages/vike`, or any other path.
+- **Changelog format.** Each release is a Markdown heading `## [x.y.z](…)`, as produced by changelog
+  tools like [release-me](https://github.com/brillout/release-me) or release-please. A `…/compare/…`
+  link becomes the release's "Full Changelog" footer.
+- **Tags.** A single package keeps the bare `vX.Y.Z` tag; when several packages share the repo, their
+  tags are namespaced as `<package.json#name>@x.y.z`.
+
 ## Scripts
 
 Run from anywhere in the repo:

--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -7,7 +7,7 @@ and deletes any whose version is no longer in the changelog.
 The source of truth is `CHANGELOG.md` => GitHub Releases are derived from it.
 
 In CI this runs automatically via [`../sync-github-releases.yml`](../sync-github-releases.yml) — on every
-push to `main` that touches a `packages/**/CHANGELOG.md`, and on manual `workflow_dispatch`. The scripts
+push to `main` that touches a `CHANGELOG.md`, and on manual `workflow_dispatch`. The scripts
 below run the same tooling by hand.
 
 ## How it works

--- a/.github/workflows/sync-github-releases/index.ts
+++ b/.github/workflows/sync-github-releases/index.ts
@@ -84,8 +84,10 @@ async function syncPackage({
   const releaseNotesByVersion = parseChangelog(changelog)
 
   // These releases are generated, so point each one back to the changelog it mirrors (the source of
-  // truth) to discourage editing the GitHub Release directly — a sync would overwrite it.
-  const changelogUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${packageDir}/CHANGELOG.md`
+  // truth) to discourage editing the GitHub Release directly — a sync would overwrite it. path.posix.join
+  // keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./` segment.
+  const changelogRepoPath = path.posix.join(packageDir, 'CHANGELOG.md')
+  const changelogUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${changelogRepoPath}`
   for (const versionTag of Object.keys(releaseNotesByVersion)) {
     releaseNotesByVersion[versionTag] = withChangelogFooter(releaseNotesByVersion[versionTag], changelogUrl)
   }

--- a/.github/workflows/sync-github-releases/utils/git.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/git.spec.ts
@@ -13,10 +13,10 @@ describe('toPackageDirs()', () => {
     ).toEqual(['packages/vike', 'packages/create-vike-core'])
   })
 
-  it('ignores CHANGELOG.md files outside packages/ and non-CHANGELOG files', () => {
+  it('maps a CHANGELOG.md to its directory wherever it lives (root, nested) and skips non-CHANGELOG files', () => {
     expect(
       toPackageDirs(['CHANGELOG.md', 'docs/CHANGELOG.md', 'packages/vike/README.md', 'packages/vike/CHANGELOG.md']),
-    ).toEqual(['packages/vike'])
+    ).toEqual(['.', 'docs', 'packages/vike'])
   })
 
   it('returns an empty array when nothing matches', () => {

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -23,9 +23,11 @@ function getRepoRoot(): string {
 }
 
 function toPackageDirs(files: string[]): string[] {
-  // git reports forward-slash paths on every OS, so parse them with path.posix.
+  // A package is any directory containing a CHANGELOG.md, wherever it lives — `packages/vike`, a repo
+  // whose single CHANGELOG.md sits at the repo root (`.`), or any other layout. git reports
+  // forward-slash paths on every OS, so parse them with path.posix.
   const packageDirs = files
-    .filter((file) => file.startsWith('packages/') && path.posix.basename(file) === 'CHANGELOG.md')
+    .filter((file) => path.posix.basename(file) === 'CHANGELOG.md')
     .map((file) => path.posix.dirname(file))
   return [...new Set(packageDirs)]
 }


### PR DESCRIPTION
Follow-up to the reverted #3384. The goal isn't to strip "Vike" mentions (those are legitimate examples in the Vike repo) — it's to make sure the tooling doesn't *assume* it'll only ever run in a Vike-shaped repo, so it can be reused elsewhere.

I audited the whole tool. Almost everything is already project-agnostic: repository, default branch and API URL all come from the environment (`GITHUB_REPOSITORY`, `GITHUB_DEFAULT_BRANCH`, `GITHUB_API_URL`). The **one** real structural coupling was the hard-coded `packages/` monorepo layout — a reused copy would silently sync nothing in a repo with a single root `CHANGELOG.md` or a non-`packages/` monorepo.

Rather than add configuration, the fix is to simply discover `CHANGELOG.md` files wherever they are.

### Commits
1. **Discover CHANGELOG.md anywhere, not just under `packages/`** — `toPackageDirs()` drops the `packages/` prefix filter and treats any directory containing a `CHANGELOG.md` as a package (repo root → `.`). The workflow's push-path filter is widened to the same set (`CHANGELOG.md` + `**/CHANGELOG.md`).
2. **Document the reuse contract** — a short README "Assumptions" section spelling out the conventions a consuming repo must follow (a package per `CHANGELOG.md` + `package.json`, the release-me/release-please changelog format, the `vX.Y.Z` / `name@x.y.z` tag schemes), and noting that repo/branch/API URL come from the environment.
3. **Keep the footer URL clean for a root-level CHANGELOG.md** — when `packageDir` is `.`, build the changelog-footer URL with `path.posix.join` so it doesn't emit a `/./` segment GitHub can't resolve.

### No behavior change for this repo
Vike's only tracked changelog is `packages/vike/CHANGELOG.md`, which is matched identically before and after. All Vike examples in comments, the README and the specs are intentionally kept.

### Verification
- `vitest run --project unit` → 21 passed (incl. the updated `toPackageDirs()` test now expecting `['.', 'docs', 'packages/vike']`)
- `tsc --noEmit` → clean
- `biome check` on the changed `.ts` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m)_