### PR TITLE
sync-github-releases: a ReleasesClient, and let the plan own version + tag

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all.ts
+++ b/.github/workflows/sync-github-releases/delete-all.ts
@@ -3,21 +3,19 @@
 
 main()
 
-import { deleteRelease, fetchGithubReleases, getGithubToken, getRepository } from './utils/github.ts'
+import { createReleasesClient, getGithubToken, getRepository } from './utils/github.ts'
 
 async function main() {
-  const token = getGithubToken()
-
   const { owner, repo } = getRepository()
-  console.log(`Fetching releases for ${owner}/${repo} …`)
+  const client = createReleasesClient({ owner, repo, token: getGithubToken() })
 
-  const githubReleases = await fetchGithubReleases(owner, repo, token)
+  console.log(`Fetching releases for ${owner}/${repo} …`)
+  const githubReleases = await client.list()
 
   console.log(`Starting delete of ${githubReleases.length} releases …`)
-
   for (const release of githubReleases) {
     console.log(`Deleting release ${release.tag_name} (ID: ${release.id}) …`)
-    await deleteRelease(owner, repo, token, release.id)
+    await client.delete(release.id)
   }
 
   console.log(`Deleted ${githubReleases.length} releases.`)

--- a/.github/workflows/sync-github-releases/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/release-plan.spec.ts
@@ -7,10 +7,10 @@ describe('getReleasePlan()', () => {
       packageName: 'vike',
       hasMultiplePackages: false,
       releaseNotesByVersion: {
-        'v1.0.1': 'New release notes',
-        'v1.0.0': 'Updated old notes',
-        'v0.9.0': 'Existing notes',
-        'v0.8.0': 'Missing past notes',
+        '1.0.1': 'New release notes',
+        '1.0.0': 'Updated old notes',
+        '0.9.0': 'Existing notes',
+        '0.8.0': 'Missing past notes',
       },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Outdated old notes' },
@@ -19,17 +19,10 @@ describe('getReleasePlan()', () => {
     })
 
     expect(plan).toEqual({
+      // Oldest-first, and only the newest version is flagged isLatest.
       releasesToCreate: [
-        {
-          tag_name: 'v0.8.0',
-          name: 'v0.8.0',
-          body: 'Missing past notes',
-        },
-        {
-          tag_name: 'v1.0.1',
-          name: 'v1.0.1',
-          body: 'New release notes',
-        },
+        { tag_name: 'v0.8.0', body: 'Missing past notes', version: '0.8.0', isLatest: false },
+        { tag_name: 'v1.0.1', body: 'New release notes', version: '1.0.1', isLatest: true },
       ],
       releasesToUpdate: [{ release_id: 1, tag_name: 'v1.0.0', body: 'Updated old notes' }],
       releasesToDelete: [],
@@ -41,7 +34,7 @@ describe('getReleasePlan()', () => {
       packageName: 'vike',
       hasMultiplePackages: false,
       releaseNotesByVersion: {
-        'v1.0.1': 'Fresh release notes',
+        '1.0.1': 'Fresh release notes',
       },
       githubReleases: [{ id: 3, tag_name: 'v1.0.1', body: 'Stale release notes' }],
     })
@@ -57,7 +50,7 @@ describe('getReleasePlan()', () => {
     const plan = getReleasePlan({
       packageName: 'vike',
       hasMultiplePackages: false,
-      releaseNotesByVersion: { 'v1.0.0': 'Notes' },
+      releaseNotesByVersion: { '1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
         // Not one of our vX.Y.Z tags: must not be updated (no undefined body) nor deleted.
@@ -72,7 +65,7 @@ describe('getReleasePlan()', () => {
     const plan = getReleasePlan({
       packageName: 'vike',
       hasMultiplePackages: false,
-      releaseNotesByVersion: { 'v1.0.0': 'Notes' },
+      releaseNotesByVersion: { '1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
         // Owned tag, no longer in the changelog → delete.
@@ -91,7 +84,7 @@ describe('getReleasePlan()', () => {
     const plan = getReleasePlan({
       packageName: 'create-vike-core',
       hasMultiplePackages: true,
-      releaseNotesByVersion: { 'v0.0.1': 'Notes' },
+      releaseNotesByVersion: { '0.0.1': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'create-vike-core@0.0.1', body: 'Notes' },
         // Another package's release — not ours to delete.
@@ -107,8 +100,8 @@ describe('getReleasePlan()', () => {
       packageName: 'create-vike-core',
       hasMultiplePackages: true,
       releaseNotesByVersion: {
-        'v0.0.2': 'New notes',
-        'v0.0.1': 'Old notes',
+        '0.0.2': 'New notes',
+        '0.0.1': 'Old notes',
       },
       // The existing release is matched by its namespaced tag — no duplicate is created for it, and
       // it isn't confused with another package's bare `v0.0.1` release.
@@ -116,13 +109,7 @@ describe('getReleasePlan()', () => {
     })
 
     expect(plan).toEqual({
-      releasesToCreate: [
-        {
-          tag_name: 'create-vike-core@0.0.2',
-          name: 'create-vike-core@0.0.2',
-          body: 'New notes',
-        },
-      ],
+      releasesToCreate: [{ tag_name: 'create-vike-core@0.0.2', body: 'New notes', version: '0.0.2', isLatest: true }],
       releasesToUpdate: [],
       releasesToDelete: [],
     })
@@ -133,25 +120,25 @@ describe('resolveTargetCommitish()', () => {
   const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
 
   it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isNewest: false, deducedCommit: null })).toBe('main')
-    // Even for the newest release, an existing tag is fine.
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isNewest: true, deducedCommit: null })).toBe('main')
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deducedCommit: null })).toBe('main')
+    // Even for the latest release, an existing tag is fine.
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: true, deducedCommit: null })).toBe('main')
   })
 
-  it('hard-fails when the newest release has no tag', () => {
-    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isNewest: true, deducedCommit: null })).toThrow(
+  it('hard-fails when the latest release has no tag', () => {
+    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deducedCommit: null })).toThrow(
       /latest release must already be tagged/,
     )
   })
 
   it('tags an older release at the deduced commit', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: 'abc123' })).toBe(
+    expect(resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: 'abc123' })).toBe(
       'abc123',
     )
   })
 
   it('hard-fails when an older release has no tag and no deducible commit', () => {
-    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isNewest: false, deducedCommit: null })).toThrow(
+    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: null })).toThrow(
       /couldn't be deduced/,
     )
   })
@@ -159,12 +146,12 @@ describe('resolveTargetCommitish()', () => {
 
 describe('getReleaseTag()', () => {
   it('keeps the bare vX.Y.Z tag for a single package', () => {
-    expect(getReleaseTag('v0.4.259', 'vike', false)).toBe('v0.4.259')
-    expect(getReleaseTag('v0.1.0-beta.6', 'vike', false)).toBe('v0.1.0-beta.6')
+    expect(getReleaseTag('0.4.259', 'vike', false)).toBe('v0.4.259')
+    expect(getReleaseTag('0.1.0-beta.6', 'vike', false)).toBe('v0.1.0-beta.6')
   })
 
   it('qualifies the tag with the package name when there are several packages', () => {
-    expect(getReleaseTag('v0.0.391', 'create-vike-core', true)).toBe('create-vike-core@0.0.391')
-    expect(getReleaseTag('v0.1.0-beta.6', 'vike', true)).toBe('vike@0.1.0-beta.6')
+    expect(getReleaseTag('0.0.391', 'create-vike-core', true)).toBe('create-vike-core@0.0.391')
+    expect(getReleaseTag('0.1.0-beta.6', 'vike', true)).toBe('vike@0.1.0-beta.6')
   })
 })

--- a/.github/workflows/sync-github-releases/release-plan.ts
+++ b/.github/workflows/sync-github-releases/release-plan.ts
@@ -1,15 +1,18 @@
 export { getReleasePlan }
 export { getReleaseTag }
-export { withChangelogFooter }
 export { resolveTargetCommitish }
+export type { ReleaseToCreate }
 
 import type { ReleaseNotesByVersion } from './utils/changelog.ts'
 import type { Release } from './utils/github.ts'
 
 type ReleaseToCreate = {
   tag_name: string
-  name: string
   body: string
+  // Carried for the apply step (sync.ts): the raw version locates the release commit when its tag is
+  // missing, and isLatest decides the GitHub "Latest" badge.
+  version: string
+  isLatest: boolean
 }
 type ReleaseToUpdate = {
   release_id: number
@@ -21,12 +24,12 @@ type ReleaseToDelete = {
   tag_name: string
 }
 
-// A single package keeps the historical bare `vX.Y.Z` tag. Several packages share the repo's tag
-// namespace, so their tags are qualified with the package name (e.g. `create-vike-core@0.0.391`) to
-// avoid collisions.
-function getReleaseTag(versionTag: string, packageName: string, hasMultiplePackages: boolean): string {
-  if (!hasMultiplePackages) return versionTag
-  return `${packageName}@${versionTag.replace(/^v/, '')}`
+// A version's git tag. A single package keeps the historical bare `vX.Y.Z` tag. Several packages share
+// the repo's tag namespace, so their tags are qualified with the package name (e.g.
+// `create-vike-core@0.0.391`) to avoid collisions.
+function getReleaseTag(version: string, packageName: string, hasMultiplePackages: boolean): string {
+  if (hasMultiplePackages) return `${packageName}@${version}`
+  return `v${version}`
 }
 
 // Whether a GitHub Release tag belongs to the package being synced — i.e. is a candidate for
@@ -37,31 +40,27 @@ function isOwnedTag(releaseTag: string, packageName: string, hasMultiplePackages
   return /^v\d+\.\d+\.\d+/.test(releaseTag)
 }
 
-function withChangelogFooter(body: string, changelogUrl: string): string {
-  return `${body}\n\n_Source of truth: [\`CHANGELOG.md\`](${changelogUrl})._`
-}
-
 // The commit a to-be-created release should be tagged at (its `target_commitish`).
 //  - Tag already exists: GitHub uses it and ignores target_commitish — pass the branch as a no-op.
-//  - Tag missing on the newest release: hard fail. The just-released version must already be tagged;
+//  - Tag missing on the latest release: hard fail. The just-released version must already be tagged;
 //    tagging it now would point at the default branch's HEAD (the wrong commit).
 //  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history,
 //    or hard fail if it couldn't be deduced — never silently tag the wrong commit.
 function resolveTargetCommitish({
   releaseTag,
   tagExists,
-  isNewest,
+  isLatest,
   deducedCommit,
   defaultBranch,
 }: {
   releaseTag: string
   tagExists: boolean
-  isNewest: boolean
+  isLatest: boolean
   deducedCommit: string | null
   defaultBranch: string
 }): string {
   if (tagExists) return defaultBranch
-  if (isNewest) {
+  if (isLatest) {
     throw new Error(
       `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
     )
@@ -94,17 +93,22 @@ function getReleasePlan({
   const releasesToCreate: ReleaseToCreate[] = []
   const releasesToUpdate: ReleaseToUpdate[] = []
 
-  // releaseNotesByVersion is newest-first; iterate oldest-first so releases are created (and their
-  // notifications sent) in chronological order. Which release is "Latest" is set explicitly via
-  // make_latest in syncPackage, not inferred from creation order. (GitHub orders the releases list by
-  // tag semver regardless: https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
-  for (const versionTag of Object.keys(releaseNotesByVersion).reverse()) {
-    const body = releaseNotesByVersion[versionTag]
-    const releaseTag = getReleaseTag(versionTag, packageName, hasMultiplePackages)
+  // releaseNotesByVersion is newest-first; the newest version is the one eligible to be the repo's
+  // "Latest". Capture it before reversing.
+  const versions = Object.keys(releaseNotesByVersion)
+  const latestVersion = versions[0]
+
+  // Iterate oldest-first so releases are created (and their notifications sent) in chronological
+  // order. Which release is "Latest" is set explicitly (isLatest), not inferred from creation order.
+  // (GitHub orders the releases list by tag semver regardless:
+  // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
+  for (const version of [...versions].reverse()) {
+    const body = releaseNotesByVersion[version]
+    const releaseTag = getReleaseTag(version, packageName, hasMultiplePackages)
     expectedTags.add(releaseTag)
     const existingRelease = releasesByTag.get(releaseTag)
     if (!existingRelease) {
-      releasesToCreate.push({ tag_name: releaseTag, name: releaseTag, body })
+      releasesToCreate.push({ tag_name: releaseTag, body, version, isLatest: version === latestVersion })
     } else if (existingRelease.body?.trim() !== body) {
       releasesToUpdate.push({ release_id: existingRelease.id, tag_name: releaseTag, body })
     }

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -6,7 +6,7 @@ main()
 import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import path from 'node:path'
-import { parseChangelog } from './utils/changelog.ts'
+import { parseChangelog, withChangelogFooter } from './utils/changelog.ts'
 import {
   findReleaseCommit,
   getPushedFiles,
@@ -15,15 +15,13 @@ import {
   gitTagExists,
   toPackageDirs,
 } from './utils/git.ts'
-import { resolveTargetCommitish, getReleasePlan, getReleaseTag, withChangelogFooter } from './release-plan.ts'
+import { getReleasePlan, resolveTargetCommitish, type ReleaseToCreate } from './release-plan.ts'
 import {
-  createRelease,
-  deleteRelease,
-  fetchGithubReleases,
+  createReleasesClient,
   getDefaultBranch,
   getGithubToken,
   getRepository,
-  updateReleaseBody,
+  type ReleasesClient,
 } from './utils/github.ts'
 
 async function main(): Promise<void> {
@@ -44,7 +42,7 @@ async function main(): Promise<void> {
 
   const { owner, repo } = getRepository()
   const defaultBranch = getDefaultBranch()
-  const token = getGithubToken()
+  const client = createReleasesClient({ owner, repo, token: getGithubToken(), dryRun })
 
   // When several packages publish to the same repo they share its tag namespace, so releases are
   // qualified with the package name (see getReleaseTag()). Determined from every tracked CHANGELOG.md,
@@ -53,105 +51,94 @@ async function main(): Promise<void> {
 
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)
-    await syncPackage({ packageDir, owner, repo, defaultBranch, token, dryRun, hasMultiplePackages })
+    await syncPackage({ packageDir, client, owner, repo, defaultBranch, hasMultiplePackages, dryRun })
   }
 }
 
 async function syncPackage({
   packageDir,
+  client,
   owner,
   repo,
   defaultBranch,
-  token,
-  dryRun,
   hasMultiplePackages,
+  dryRun,
 }: {
   packageDir: string
+  client: ReleasesClient
   owner: string
   repo: string
   defaultBranch: string
-  token: string
-  dryRun: boolean
   hasMultiplePackages: boolean
+  dryRun: boolean
 }): Promise<void> {
-  const require = createRequire(import.meta.url)
-
   const packageDirPath = path.join(process.cwd(), packageDir)
-  const packageJsonPath = path.join(packageDirPath, 'package.json')
-  const changelogPath = path.join(packageDirPath, 'CHANGELOG.md')
+  const require = createRequire(import.meta.url)
+  const packageJson = require(path.join(packageDirPath, 'package.json')) as { name: string }
+  const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
 
-  const packageJson = require(packageJsonPath) as { name: string }
-
-  const changelog = await readFile(changelogPath, 'utf8')
-  const releaseNotesByVersion = parseChangelog(changelog)
-
-  // These releases are generated, so point each one back to the changelog it mirrors (the source of
-  // truth) to discourage editing the GitHub Release directly — a sync would overwrite it. path.posix.join
-  // keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./` segment.
+  // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
   const changelogRepoPath = path.posix.join(packageDir, 'CHANGELOG.md')
   const changelogUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${changelogRepoPath}`
-  for (const versionTag of Object.keys(releaseNotesByVersion)) {
-    releaseNotesByVersion[versionTag] = withChangelogFooter(releaseNotesByVersion[versionTag], changelogUrl)
-  }
+  const releaseNotesByVersion = Object.fromEntries(
+    Object.entries(parseChangelog(changelog)).map(([version, notes]) => [
+      version,
+      withChangelogFooter(notes, changelogUrl),
+    ]),
+  )
 
-  const githubReleases = await fetchGithubReleases(owner, repo, token)
-
-  const { releasesToCreate, releasesToUpdate, releasesToDelete } = getReleasePlan({
+  const githubReleases = await client.list()
+  const plan = getReleasePlan({
     githubReleases,
     releaseNotesByVersion,
     packageName: packageJson.name,
     hasMultiplePackages,
   })
+  await applyReleasePlan(plan, client, defaultBranch, dryRun)
+}
 
-  // releaseNotesByVersion is keyed by `vX.Y.Z`; map each release tag back to its raw changelog version
-  // (for the changelog-history lookup) and remember the newest tag (the just-released version).
-  const versionTags = Object.keys(releaseNotesByVersion)
-  const releaseTagOf = (versionTag: string) => getReleaseTag(versionTag, packageJson.name, hasMultiplePackages)
-  const versionByTag = new Map(
-    versionTags.map((versionTag) => [releaseTagOf(versionTag), versionTag.replace(/^v/, '')]),
-  )
-  const newestReleaseTag = versionTags.length > 0 ? releaseTagOf(versionTags[0]) : ''
-
-  for (const releaseToCreate of releasesToCreate) {
-    const releaseTag = releaseToCreate.tag_name
-    // A release needs a tag to point at. When the tag is missing, GitHub would otherwise create it at
-    // the default branch's HEAD — the wrong commit for a backfilled release. Deduce the real commit
-    // from the changelog's history and tag that instead (or refuse, rather than tag the wrong commit).
-    const tagExists = gitTagExists(releaseTag)
-    const isNewest = releaseTag === newestReleaseTag
-    const deducedCommit = !tagExists && !isNewest ? findReleaseCommit(versionByTag.get(releaseTag)!) : null
-    const targetCommitish = resolveTargetCommitish({ releaseTag, tagExists, isNewest, deducedCommit, defaultBranch })
-    if (!tagExists && !isNewest)
-      console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
-
-    await createRelease(
-      owner,
-      repo,
-      token,
-      {
-        tag_name: releaseTag,
-        target_commitish: targetCommitish,
-        name: releaseToCreate.name,
-        body: releaseToCreate.body,
-        // Only the newest version may be the repo's "Latest". create-release otherwise defaults
-        // make_latest=true, so backfilling an older release while a newer one already exists would
-        // wrongly mark the old one Latest.
-        make_latest: isNewest ? 'true' : 'false',
-      },
-      dryRun,
-    )
-    if (!dryRun) console.log(`Created release ${releaseTag}`)
+async function applyReleasePlan(
+  plan: ReturnType<typeof getReleasePlan>,
+  client: ReleasesClient,
+  defaultBranch: string,
+  dryRun: boolean,
+): Promise<void> {
+  for (const release of plan.releasesToCreate) {
+    await client.create({
+      tag_name: release.tag_name,
+      name: release.tag_name,
+      body: release.body,
+      target_commitish: resolveCreateTarget(release, defaultBranch),
+      // Only the newest version may be the repo's "Latest". create-release otherwise defaults
+      // make_latest=true, so backfilling an older release while a newer one already exists would
+      // wrongly mark the old one Latest.
+      make_latest: release.isLatest ? 'true' : 'false',
+    })
+    if (!dryRun) console.log(`Created release ${release.tag_name}`)
   }
 
-  for (const releaseToUpdate of releasesToUpdate) {
-    await updateReleaseBody(owner, repo, token, releaseToUpdate.release_id, releaseToUpdate.body, dryRun)
-    if (!dryRun) console.log(`Updated release ${releaseToUpdate.tag_name}`)
+  for (const release of plan.releasesToUpdate) {
+    await client.update(release.release_id, release.body)
+    if (!dryRun) console.log(`Updated release ${release.tag_name}`)
   }
 
-  for (const releaseToDelete of releasesToDelete) {
-    await deleteRelease(owner, repo, token, releaseToDelete.release_id, dryRun)
-    if (!dryRun) console.log(`Deleted release ${releaseToDelete.tag_name}`)
+  for (const release of plan.releasesToDelete) {
+    await client.delete(release.release_id)
+    if (!dryRun) console.log(`Deleted release ${release.tag_name}`)
   }
+}
+
+// The commit a to-be-created release is tagged at. A release needs a tag to point at; when it's
+// missing, GitHub would create it at the default branch's HEAD — the wrong commit for a backfilled
+// (older) release. So deduce the real commit from the changelog history and tag that instead.
+// resolveTargetCommitish() turns these git facts into the commitish, or refuses rather than mis-tag.
+function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): string {
+  const { tag_name: releaseTag, version, isLatest } = release
+  const tagExists = gitTagExists(releaseTag)
+  const deducedCommit = !tagExists && !isLatest ? findReleaseCommit(version) : null
+  if (deducedCommit)
+    console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
+  return resolveTargetCommitish({ releaseTag, tagExists, isLatest, deducedCommit, defaultBranch })
 }
 
 function getPackageDirsToSync(): string[] {

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -131,7 +131,8 @@ async function applyReleasePlan(
 // The commit a to-be-created release is tagged at. A release needs a tag to point at; when it's
 // missing, GitHub would create it at the default branch's HEAD — the wrong commit for a backfilled
 // (older) release. So deduce the real commit from the changelog history and tag that instead.
-// resolveTargetCommitish() turns these git facts into the commitish, or refuses rather than mis-tag.
+// resolveTargetCommitish() turns these git facts into the commitish, or refuses rather than tag the
+// wrong commit.
 function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): string {
   const { tag_name: releaseTag, version, isLatest } = release
   const tagExists = gitTagExists(releaseTag)

--- a/.github/workflows/sync-github-releases/utils/changelog.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.spec.ts
@@ -24,52 +24,52 @@ describe('parseChangelog()', () => {
 
     expect(parseChangelog(changelog)).toEqual({
       // Compare link surfaced as a "Full Changelog" footer.
-      'v1.0.1':
+      '1.0.1':
         '### Features\n\n* Added release automation.\n\n**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.1',
       // Non-`/compare/` link → no footer.
-      'v1.0.0': '### Bug Fixes\n\n* Fixed old release notes.',
+      '1.0.0': '### Bug Fixes\n\n* Fixed old release notes.',
     })
   })
 
   it('parses oldest Vike entries (single # headings, pre-release versions)', () => {
     const changelogSections = parseChangelog(readFixture('changelog-vike.md'))
     expect(Object.keys(changelogSections)).toEqual([
-      'v0.1.0-beta.10',
-      'v0.1.0-beta.9',
-      'v0.1.0-beta.8',
-      'v0.1.0-beta.7',
-      'v0.1.0-beta.6',
+      '0.1.0-beta.10',
+      '0.1.0-beta.9',
+      '0.1.0-beta.8',
+      '0.1.0-beta.7',
+      '0.1.0-beta.6',
     ])
-    expect(changelogSections['v0.1.0-beta.10']).toContain('### Features')
-    expect(changelogSections['v0.1.0-beta.8']).toContain('### BREAKING CHANGES')
-    expect(changelogSections['v0.1.0-beta.6']).toContain('Initial public release')
+    expect(changelogSections['0.1.0-beta.10']).toContain('### Features')
+    expect(changelogSections['0.1.0-beta.8']).toContain('### BREAKING CHANGES')
+    expect(changelogSections['0.1.0-beta.6']).toContain('Initial public release')
   })
 
   it('parses oldest Telefunc entries (trailing non-versioned sections)', () => {
     const changelogSections = parseChangelog(readFixture('changelog-telefunc.md'))
-    expect(Object.keys(changelogSections)).toEqual(['v0.1.2', 'v0.1.1'])
-    expect(changelogSections['v0.1.2']).toContain('improve TelefunctionError type')
-    expect(changelogSections['v0.1.1']).toContain('isomorphic imports')
+    expect(Object.keys(changelogSections)).toEqual(['0.1.2', '0.1.1'])
+    expect(changelogSections['0.1.2']).toContain('improve TelefunctionError type')
+    expect(changelogSections['0.1.1']).toContain('isomorphic imports')
   })
 
   it('parses oldest vike-vue entries (no-link headings, dash bullets)', () => {
     const changelogSections = parseChangelog(readFixture('changelog-vike-vue.md'))
-    expect(Object.keys(changelogSections)).toEqual(['v0.2.3', 'v0.2.2', 'v0.2.1', 'v0.2.0', 'v0.1.1'])
-    expect(changelogSections['v0.2.1']).toContain('Fix peer dependency')
-    expect(changelogSections['v0.2.0']).toContain('Add `Head` config option')
+    expect(Object.keys(changelogSections)).toEqual(['0.2.3', '0.2.2', '0.2.1', '0.2.0', '0.1.1'])
+    expect(changelogSections['0.2.1']).toContain('Fix peer dependency')
+    expect(changelogSections['0.2.0']).toContain('Add `Head` config option')
   })
 
   it('parses oldest vike-solid entries (single # headings, mixed formats)', () => {
     const changelogSections = parseChangelog(readFixture('changelog-vike-solid.md'))
-    expect(Object.keys(changelogSections)).toEqual(['v0.7.2', 'v0.7.1', 'v0.7.0', 'v0.6.2', 'v0.6.1'])
-    expect(changelogSections['v0.7.0']).toContain('### BREAKING CHANGES')
-    expect(changelogSections['v0.6.1']).toContain('MIGRATION.md')
+    expect(Object.keys(changelogSections)).toEqual(['0.7.2', '0.7.1', '0.7.0', '0.6.2', '0.6.1'])
+    expect(changelogSections['0.7.0']).toContain('### BREAKING CHANGES')
+    expect(changelogSections['0.6.1']).toContain('MIGRATION.md')
   })
 
   it('parses oldest vike-react entries (no-link initial version)', () => {
     const changelogSections = parseChangelog(readFixture('changelog-vike-react.md'))
-    expect(Object.keys(changelogSections)).toEqual(['v0.1.6', 'v0.1.5', 'v0.1.4', 'v0.1.3', 'v0.1.2', 'v0.1.1'])
-    expect(changelogSections['v0.1.6']).toContain("fix 'vike-react' type")
-    expect(changelogSections['v0.1.1']).toContain('fix ESM import paths')
+    expect(Object.keys(changelogSections)).toEqual(['0.1.6', '0.1.5', '0.1.4', '0.1.3', '0.1.2', '0.1.1'])
+    expect(changelogSections['0.1.6']).toContain("fix 'vike-react' type")
+    expect(changelogSections['0.1.1']).toContain('fix ESM import paths')
   })
 })

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -1,7 +1,10 @@
 export { parseChangelog }
+export { withChangelogFooter }
 
 export type ReleaseNotesByVersion = Record<string, string>
 
+// Parse a CHANGELOG.md into release notes keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`),
+// newest first. Decorating a version into its git tag is getReleaseTag()'s job, not ours.
 function parseChangelog(changelog: string): ReleaseNotesByVersion {
   const releaseNotesByVersion: ReleaseNotesByVersion = {}
   // Group 1 is the version; group 2 (optional) is the heading's link. release-me links the version to
@@ -15,8 +18,14 @@ function parseChangelog(changelog: string): ReleaseNotesByVersion {
     let notes = changelog.slice(start, end).trim()
     const headingUrl = match[2]
     if (headingUrl?.includes('/compare/')) notes += `\n\n**Full Changelog**: ${headingUrl}`
-    releaseNotesByVersion[`v${match[1]}`] = notes
+    releaseNotesByVersion[match[1]] = notes
   })
 
   return releaseNotesByVersion
+}
+
+// These releases are generated, so point each one back to the CHANGELOG.md it mirrors (the source of
+// truth) to discourage editing the GitHub Release directly — a sync would overwrite it.
+function withChangelogFooter(body: string, changelogUrl: string): string {
+  return `${body}\n\n_Source of truth: [\`CHANGELOG.md\`](${changelogUrl})._`
 }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -1,17 +1,16 @@
-export { fetchGithubReleases }
-export { createRelease }
-export { updateReleaseBody }
-export { deleteRelease }
+export { createReleasesClient }
 export { getGithubToken }
 export { getDefaultBranch }
 export { getRepository }
+export type { Release }
+export type { ReleasesClient }
 
 import assert from 'node:assert'
 import { execSync } from 'node:child_process'
 import { setTimeout } from 'node:timers/promises'
 
 // The fields we use of a GitHub Release (https://docs.github.com/en/rest/releases/releases).
-export type Release = {
+type Release = {
   id: number
   tag_name: string
   body: string | null
@@ -25,128 +24,101 @@ type NewRelease = {
   make_latest: 'true' | 'false'
 }
 
+// A client for one repository's GitHub Releases. It binds the owner/repo/token (and --dry-run) once,
+// so callers just say what to do — not where, nor as whom.
+type ReleasesClient = {
+  list(): Promise<Release[]>
+  create(release: NewRelease): Promise<void>
+  update(releaseId: number, body: string): Promise<void>
+  delete(releaseId: number): Promise<void>
+}
+
 const API_URL = process.env.GITHUB_API_URL ?? 'https://api.github.com'
-const REPOSITORY = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
-const DEFAULT_BRANCH = process.env.GITHUB_DEFAULT_BRANCH ?? 'main'
 // Pause between write requests so bursts (e.g. backfilling many releases) stay under GitHub's
 // secondary rate limit — its burst/concurrency limit, separate from the hourly primary quota.
 // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 const RATE_LIMIT_DELAY_MS = 500
-// Writes performed so far, to delay only *between* them (not before the first, nor after reads).
-let writeCount = 0
 
-function releasesPath(owner: string, repo: string): string {
-  return `/repos/${owner}/${repo}/releases`
-}
+function createReleasesClient({
+  owner,
+  repo,
+  token,
+  dryRun = false,
+}: {
+  owner: string
+  repo: string
+  token: string
+  dryRun?: boolean
+}): ReleasesClient {
+  const releasesPath = `/repos/${owner}/${repo}/releases`
+  // Writes performed so far, to delay only *between* them (not before the first, nor after reads).
+  let writeCount = 0
 
-async function fetchGithubReleases(owner: string, repo: string, token: string): Promise<Release[]> {
-  const githubReleases: Release[] = []
-  let page = 1
-  const perPage = 100
+  async function request<T = void>(
+    pathname: string,
+    { body, method = 'GET' }: { body?: unknown; method?: 'GET' | 'PATCH' | 'POST' | 'DELETE' } = {},
+  ): Promise<T> {
+    if (dryRun && method !== 'GET') {
+      console.log(`[dry-run] ${method} ${pathname}`)
+      if (body !== undefined) console.log(JSON.stringify(body, null, 2))
+      return undefined as T
+    }
 
-  while (true) {
-    // https://docs.github.com/en/rest/releases/releases#list-releases
-    const releaseList = await githubRequest<Release[]>(
-      `${releasesPath(owner, repo)}?per_page=${perPage}&page=${page}`,
-      {
-        token,
+    // Throttle between writes only: reads aren't the rate-limit concern, and a lone write — the common
+    // case of a single new release — shouldn't wait at all. So a backfill of N writes pays N-1 delays,
+    // while one write pays none.
+    if (method !== 'GET') {
+      if (writeCount > 0) await setTimeout(RATE_LIMIT_DELAY_MS)
+      writeCount++
+    }
+
+    const response = await fetch(new URL(pathname, API_URL), {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'sync-github-releases-workflow',
+        'X-GitHub-Api-Version': '2022-11-28',
       },
-    )
+      body: body ? JSON.stringify(body) : undefined,
+    })
 
-    if (releaseList.length === 0) break
+    if (!response.ok) {
+      const errorBody = await response.text()
+      throw new Error(
+        `GitHub API request failed (${method} ${pathname}): ${response.status} ${response.statusText}\n${errorBody}`,
+      )
+    }
 
-    githubReleases.push(...releaseList)
-
-    if (releaseList.length < perPage) break
-
-    page++
+    return response.status === 204 ? (undefined as T) : ((await response.json()) as T)
   }
 
-  return githubReleases
-}
-
-async function createRelease(
-  owner: string,
-  repo: string,
-  token: string,
-  release: NewRelease,
-  dryRun = false,
-): Promise<void> {
-  // https://docs.github.com/en/rest/releases/releases#create-a-release
-  await githubRequest(releasesPath(owner, repo), { token, method: 'POST', body: release, dryRun })
-}
-
-async function updateReleaseBody(
-  owner: string,
-  repo: string,
-  token: string,
-  releaseId: number,
-  body: string,
-  dryRun = false,
-): Promise<void> {
-  // https://docs.github.com/en/rest/releases/releases#update-a-release
-  await githubRequest(`${releasesPath(owner, repo)}/${releaseId}`, { token, method: 'PATCH', body: { body }, dryRun })
-}
-
-async function deleteRelease(
-  owner: string,
-  repo: string,
-  token: string,
-  releaseId: number,
-  dryRun = false,
-): Promise<void> {
-  // https://docs.github.com/en/rest/releases/releases#delete-a-release
-  await githubRequest(`${releasesPath(owner, repo)}/${releaseId}`, { token, method: 'DELETE', dryRun })
-}
-
-async function githubRequest<T = void>(
-  pathname: string,
-  {
-    body,
-    method = 'GET',
-    token,
-    dryRun = false,
-  }: {
-    body?: unknown
-    method?: 'GET' | 'PATCH' | 'POST' | 'DELETE'
-    token: string
-    dryRun?: boolean
-  },
-): Promise<T> {
-  if (dryRun && method !== 'GET') {
-    console.log(`[dry-run] ${method} ${pathname}`)
-    if (body !== undefined) console.log(JSON.stringify(body, null, 2))
-    return undefined as T
-  }
-
-  // Throttle between writes only: reads aren't the rate-limit concern, and a lone write — the common
-  // case of a single new release — shouldn't wait at all. So a backfill of N writes pays N-1 delays,
-  // while one write pays none.
-  if (method !== 'GET') {
-    if (writeCount > 0) await setTimeout(RATE_LIMIT_DELAY_MS)
-    writeCount++
-  }
-
-  const response = await fetch(new URL(pathname, API_URL), {
-    method,
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'sync-github-releases-workflow',
-      'X-GitHub-Api-Version': '2022-11-28',
+  return {
+    // https://docs.github.com/en/rest/releases/releases#list-releases
+    async list(): Promise<Release[]> {
+      const releases: Release[] = []
+      const perPage = 100
+      // Keep paging until a short (or empty) page signals the end.
+      for (let page = 1; ; page++) {
+        const pageReleases = await request<Release[]>(`${releasesPath}?per_page=${perPage}&page=${page}`)
+        releases.push(...pageReleases)
+        if (pageReleases.length < perPage) return releases
+      }
     },
-    body: body ? JSON.stringify(body) : undefined,
-  })
-
-  if (!response.ok) {
-    const errorBody = await response.text()
-    throw new Error(
-      `GitHub API request failed (${method} ${pathname}): ${response.status} ${response.statusText}\n${errorBody}`,
-    )
+    // https://docs.github.com/en/rest/releases/releases#create-a-release
+    create(release: NewRelease): Promise<void> {
+      return request(releasesPath, { method: 'POST', body: release })
+    },
+    // https://docs.github.com/en/rest/releases/releases#update-a-release
+    update(releaseId: number, body: string): Promise<void> {
+      return request(`${releasesPath}/${releaseId}`, { method: 'PATCH', body: { body } })
+    },
+    // https://docs.github.com/en/rest/releases/releases#delete-a-release
+    delete(releaseId: number): Promise<void> {
+      return request(`${releasesPath}/${releaseId}`, { method: 'DELETE' })
+    },
   }
-
-  return response.status === 204 ? (undefined as T) : ((await response.json()) as T)
 }
 
 function getGithubToken(): string {
@@ -158,12 +130,13 @@ function getGithubToken(): string {
 }
 
 function getDefaultBranch(): string {
-  return DEFAULT_BRANCH
+  return process.env.GITHUB_DEFAULT_BRANCH ?? 'main'
 }
 
 function getRepository(): { owner: string; repo: string } {
-  const [owner, repo] = REPOSITORY.split('/')
-  assert(owner && repo, `Invalid GITHUB_REPOSITORY value: ${REPOSITORY}`)
+  const repository = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
+  const [owner, repo] = repository.split('/')
+  assert(owner && repo, `Invalid GITHUB_REPOSITORY value: ${repository}`)
   return { owner, repo }
 }
 


### PR DESCRIPTION
A pure-quality refactor of the `sync-github-releases` tool — no behavior change, the 21 unit tests stay green (and verified end-to-end under Node's `--experimental-strip-types`, plus `tsc` and Prettier clean). Net **−42 lines** despite *adding* the client abstraction and richer plan data.

## What changed & why

### 1. A `ReleasesClient` instead of threading `(owner, repo, token)` everywhere
Every GitHub helper repeated the same `(owner, repo, token, …)` prefix, and both entry scripts threaded it through. `createReleasesClient({ owner, repo, token, dryRun })` binds identity once and exposes `list` / `create` / `update` / `delete` that read as intent. The secondary-rate-limit counter becomes closure state rather than a module-level global, and `getRepository()` is computed lazily so importing `github.ts` no longer shells out to `git`.

### 2. `getReleaseTag()` is now the *sole* authority on tag format
`parseChangelog()` keyed notes by a manufactured `v`-prefixed string (`v0.4.257`) that downstream code kept stripping back off (`replace(/^v/, '')`, in two places). Keys are now the **raw version** the changelog actually contains (`0.4.257`); `getReleaseTag()` is the only place that decorates a version into a tag (`v0.4.257` or `create-vike-core@0.4.257`).

### 3. The plan carries what applying it needs
`getReleasePlan()` now attaches `version` and `isLatest` to each create. `syncPackage()` no longer rebuilds the tag→version `Map` and "newest tag" the plan already knew, and the create loop's `target_commitish` logic — previously a triple-repeated `!tagExists && !isNewest` smeared across three files — collapses into a single `resolveCreateTarget()`. `syncPackage()` reads as a clean pipeline: *load → parse + footer → fetch → plan → apply*.

### 4. Smaller cleanups
- Move `withChangelogFooter()` next to the parser it decorates, and append footers **without mutating** the parsed record.
- Drop the redundant `name` field from the plan (it was always equal to `tag_name`).
- Unify the `isNewest`/`isLatest` naming on the single concept (the GitHub "Latest" badge).
- Collapse the list-pagination loop's two redundant break conditions into one.

## Verification
- `vitest run` → **21/21 pass**
- `tsc --noEmit` → clean
- `prettier --check` → clean
- Ran the modules through real `node --experimental-strip-types` to confirm the inline `type` imports strip correctly at runtime (CI runs `node ./sync.ts` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XckNfvJgEeiE4vca3fQnsx

---
_Generated by [Claude Code](https://claude.ai/code/session_01XckNfvJgEeiE4vca3fQnsx)_