### PR TITLE
sync-github-releases: document design decisions in the README

### DIFF
--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -54,3 +54,20 @@ GITHUB_TOKEN=<token> pnpm run sync:check
 # Synchronize the releases of packages/vike
 GITHUB_TOKEN=<token> pnpm run sync -- packages/vike
 ```
+
+## Decisions
+
+Notable design choices and the reasoning behind them:
+
+- **`CHANGELOG.md` is the source of truth.** The plan is reconciled from the changelog, not from the existing GitHub Releases — so a release the changelog doesn't mention (another package's, or a hand-made one) is never rewritten or deleted. Each generated release links back to its `CHANGELOG.md`.
+- **The tag scheme follows the package count.** A lone package keeps the historical bare `vX.Y.Z` tag; several packages sharing the repo get namespaced `<package.json#name>@x.y.z` tags to avoid collisions. The count comes from every tracked `CHANGELOG.md`, not just the package being synced.
+- **Deletes stay in their own namespace.** A version removed from the changelog deletes its release only when the tag belongs to the synced package — never another package's or a hand-made release.
+- **Missing git tags: hard-fail the newest, deduce the rest.** Tagging the newest release now would point at the default branch's HEAD (the wrong commit), so it hard-fails; an older missing tag is recreated at the commit deduced from the changelog's history, or hard-fails rather than guess.
+- **"Latest" is set explicitly.** Only the newest version is created with `make_latest=true`; releases are created oldest-first (so notifications arrive in order) and GitHub sorts the list by tag semver regardless.
+- **Only writes are throttled** — a delay sits between write requests for GitHub's secondary rate limit, but never before the first and never for reads, so a single new release waits not at all.
+- **On `push`, only changed packages sync** (selected from the push diff); a manual run, or one with no `<package-dir>`, syncs every package.
+- **Project-agnostic, not Vike-stripped.** Repository, default branch and API URL come from the environment, so the tool can be dropped into another repo; Vike stays as the running example, since the goal was to drop the *assumption* of Vike-only use, not the name.
+- **`CHANGELOG.md` is discovered anywhere**, not only under `packages/` — any directory containing one is a package (the repo root included). Discovery was chosen over a configurable path: simpler, and it covers single-package and other layouts.
+- **Names mirror commands** — the scripts and their entry files share a name with what they do: `sync`/`sync.ts`, `sync:check`, `delete-all`/`delete-all.ts`.
+- **Entry points don't guard against import.** `sync.ts` and `delete-all.ts` just call `main()`; nothing imports them, so the old "run only if not imported" guard protected a case that never happens.
+- **TypeScript runs directly** via Node's type stripping (no build step), with explicit `.ts` import extensions — hence the Node ≥ 22.6 requirement.


### PR DESCRIPTION
Adds a `## Decisions` section to the README, capturing the rationale behind the tool's behavior so the "why" isn't lost. One tight bullet per decision (12 total), covering what we worked through:

- `CHANGELOG.md` as the single source of truth (reconcile from the changelog, not the existing releases)
- the package-count tag scheme (`vX.Y.Z` vs `<name>@x.y.z`) and namespaced deletes
- missing-tag handling (hard-fail the newest, deduce older ones)
- explicit `make_latest` + oldest-first creation
- write-only throttling
- push-diff package selection
- project-agnostic config (and *why* "Vike" stays as the example rather than being stripped)
- `CHANGELOG.md` discovery anywhere (vs a configurable path)
- names mirroring commands, no import guard, and direct TypeScript execution

README-only change, placed after Scripts/Examples so the practical usage stays up top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVrLp5MnSy76cK4bQZH6m)_