### PR TITLE
sync-github-releases: tighter file/function abstractions and DRY cleanups

### DIFF
--- a/.github/workflows/sync-github-releases/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/apply-release-plan.ts
@@ -1,0 +1,53 @@
+export { applyReleasePlan }
+
+import { resolveTargetCommitish, type ReleasePlan, type ReleaseToCreate } from './release-plan.ts'
+import { findReleaseCommit, gitTagExists } from './utils/git.ts'
+import type { ReleasesClient } from './utils/github.ts'
+
+// Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. Under
+// --dry-run the client logs each write instead of performing it, so the per-action confirmations
+// below (which would otherwise claim work that didn't happen) are skipped.
+async function applyReleasePlan(
+  plan: ReleasePlan,
+  client: ReleasesClient,
+  defaultBranch: string,
+  dryRun: boolean,
+): Promise<void> {
+  for (const release of plan.releasesToCreate) {
+    await client.create({
+      tag_name: release.tag_name,
+      name: release.tag_name,
+      body: release.body,
+      target_commitish: resolveCreateTarget(release, defaultBranch),
+      // Only the newest version may be the repo's "Latest". create-release otherwise defaults
+      // make_latest=true, so backfilling an older release while a newer one already exists would
+      // wrongly mark the old one Latest.
+      make_latest: release.isLatest ? 'true' : 'false',
+    })
+    if (!dryRun) console.log(`Created release ${release.tag_name}`)
+  }
+
+  for (const release of plan.releasesToUpdate) {
+    await client.update(release.release_id, release.body)
+    if (!dryRun) console.log(`Updated release ${release.tag_name}`)
+  }
+
+  for (const release of plan.releasesToDelete) {
+    await client.delete(release.release_id)
+    if (!dryRun) console.log(`Deleted release ${release.tag_name}`)
+  }
+}
+
+// The commit a to-be-created release is tagged at. A release needs a tag to point at; when it's
+// missing, GitHub would create it at the default branch's HEAD — the wrong commit for a backfilled
+// (older) release. So deduce the real commit from the changelog history and tag that instead.
+// resolveTargetCommitish() turns these git facts into the commitish, or refuses rather than tag the
+// wrong commit.
+function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): string {
+  const { tag_name: releaseTag, version, isLatest } = release
+  const tagExists = gitTagExists(releaseTag)
+  const deducedCommit = !tagExists && !isLatest ? findReleaseCommit(version) : null
+  if (deducedCommit)
+    console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
+  return resolveTargetCommitish({ releaseTag, tagExists, isLatest, deducedCommit, defaultBranch })
+}

--- a/.github/workflows/sync-github-releases/release-plan.ts
+++ b/.github/workflows/sync-github-releases/release-plan.ts
@@ -1,16 +1,22 @@
 export { getReleasePlan }
 export { getReleaseTag }
 export { resolveTargetCommitish }
+export type { ReleasePlan }
 export type { ReleaseToCreate }
 
 import type { ReleaseNotesByVersion } from './utils/changelog.ts'
 import type { Release } from './utils/github.ts'
 
+type ReleasePlan = {
+  releasesToCreate: ReleaseToCreate[]
+  releasesToUpdate: ReleaseToUpdate[]
+  releasesToDelete: ReleaseToDelete[]
+}
 type ReleaseToCreate = {
   tag_name: string
   body: string
-  // Carried for the apply step (sync.ts): the raw version locates the release commit when its tag is
-  // missing, and isLatest decides the GitHub "Latest" badge.
+  // Carried for the apply step (apply-release-plan.ts): the raw version locates the release commit
+  // when its tag is missing, and isLatest decides the GitHub "Latest" badge.
   version: string
   isLatest: boolean
 }
@@ -83,7 +89,7 @@ function getReleasePlan({
   releaseNotesByVersion: ReleaseNotesByVersion
   packageName: string
   hasMultiplePackages: boolean
-}) {
+}): ReleasePlan {
   // Reconcile from the changelog (the source of truth), not from the GitHub Releases: iterating the
   // releases for updates would try to rewrite any release whose tag isn't in the changelog (e.g. a
   // release of another package, or a manually-created one) with an `undefined` body. Driving both

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -4,7 +4,6 @@
 main()
 
 import { readFile } from 'node:fs/promises'
-import { createRequire } from 'node:module'
 import path from 'node:path'
 import { parseChangelog, withChangelogFooter } from './utils/changelog.ts'
 import {
@@ -71,8 +70,7 @@ async function syncPackage({
   dryRun: boolean
 }): Promise<void> {
   const packageDirPath = path.join(process.cwd(), packageDir)
-  const require = createRequire(import.meta.url)
-  const packageJson = require(path.join(packageDirPath, 'package.json')) as { name: string }
+  const packageJson = JSON.parse(await readFile(path.join(packageDirPath, 'package.json'), 'utf8')) as { name: string }
   const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
 
   // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -32,22 +32,20 @@ async function main(): Promise<void> {
   const args = process.argv.slice(2)
   const dryRun = args.includes('--dry-run')
 
-  const explicitPackageDirs = args.filter((arg) => !arg.startsWith('--'))
-  const packageDirs = explicitPackageDirs.length > 0 ? explicitPackageDirs : getPackageDirsToSync()
-
+  // Every package tracked in the repo — one per CHANGELOG.md. Used both as the default set to sync and
+  // to pick the tag scheme: when several packages share the repo they also share its tag namespace, so
+  // their release tags are qualified with the package name (see getReleaseTag()).
+  const allPackageDirs = toPackageDirs(getTrackedChangelogFiles())
+  const packageDirs = getPackageDirsToSync(args, allPackageDirs)
   if (packageDirs.length === 0) {
     console.log('No CHANGELOG.md changes detected — nothing to sync.')
     return
   }
+  const hasMultiplePackages = allPackageDirs.length > 1
 
   const { owner, repo } = getRepository()
   const defaultBranch = getDefaultBranch()
   const client = createReleasesClient({ owner, repo, token: getGithubToken(), dryRun })
-
-  // When several packages publish to the same repo they share its tag namespace, so releases are
-  // qualified with the package name (see getReleaseTag()). Determined from every tracked CHANGELOG.md,
-  // not just the package(s) being synced now.
-  const hasMultiplePackages = toPackageDirs(getTrackedChangelogFiles()).length > 1
 
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)
@@ -142,10 +140,14 @@ function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): s
   return resolveTargetCommitish({ releaseTag, tagExists, isLatest, deducedCommit, defaultBranch })
 }
 
-function getPackageDirsToSync(): string[] {
-  // On push, sync only the packages whose CHANGELOG.md changed; otherwise (manual workflow_dispatch
-  // or a local run with no <package-dir>) sync every package.
+// Which package directories to sync:
+//  - an explicit <package-dir> argument (anything that isn't a --flag), or
+//  - on push (CI): the packages whose CHANGELOG.md changed, or
+//  - otherwise (manual workflow_dispatch, or a local run with no <package-dir>): every package.
+function getPackageDirsToSync(args: string[], allPackageDirs: string[]): string[] {
+  const explicitPackageDirs = args.filter((arg) => !arg.startsWith('--'))
+  if (explicitPackageDirs.length > 0) return explicitPackageDirs
   const pushedFiles = getPushedFiles()
   if (pushedFiles) return toPackageDirs(pushedFiles)
-  return toPackageDirs(getTrackedChangelogFiles())
+  return allPackageDirs
 }

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -5,16 +5,10 @@ main()
 
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
+import { applyReleasePlan } from './apply-release-plan.ts'
+import { getReleasePlan } from './release-plan.ts'
 import { parseChangelog, withChangelogFooter } from './utils/changelog.ts'
-import {
-  findReleaseCommit,
-  getPushedFiles,
-  getRepoRoot,
-  getTrackedChangelogFiles,
-  gitTagExists,
-  toPackageDirs,
-} from './utils/git.ts'
-import { getReleasePlan, resolveTargetCommitish, type ReleaseToCreate } from './release-plan.ts'
+import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
 import {
   createReleasesClient,
   getDefaultBranch,
@@ -91,51 +85,6 @@ async function syncPackage({
     hasMultiplePackages,
   })
   await applyReleasePlan(plan, client, defaultBranch, dryRun)
-}
-
-async function applyReleasePlan(
-  plan: ReturnType<typeof getReleasePlan>,
-  client: ReleasesClient,
-  defaultBranch: string,
-  dryRun: boolean,
-): Promise<void> {
-  for (const release of plan.releasesToCreate) {
-    await client.create({
-      tag_name: release.tag_name,
-      name: release.tag_name,
-      body: release.body,
-      target_commitish: resolveCreateTarget(release, defaultBranch),
-      // Only the newest version may be the repo's "Latest". create-release otherwise defaults
-      // make_latest=true, so backfilling an older release while a newer one already exists would
-      // wrongly mark the old one Latest.
-      make_latest: release.isLatest ? 'true' : 'false',
-    })
-    if (!dryRun) console.log(`Created release ${release.tag_name}`)
-  }
-
-  for (const release of plan.releasesToUpdate) {
-    await client.update(release.release_id, release.body)
-    if (!dryRun) console.log(`Updated release ${release.tag_name}`)
-  }
-
-  for (const release of plan.releasesToDelete) {
-    await client.delete(release.release_id)
-    if (!dryRun) console.log(`Deleted release ${release.tag_name}`)
-  }
-}
-
-// The commit a to-be-created release is tagged at. A release needs a tag to point at; when it's
-// missing, GitHub would create it at the default branch's HEAD — the wrong commit for a backfilled
-// (older) release. So deduce the real commit from the changelog history and tag that instead.
-// resolveTargetCommitish() turns these git facts into the commitish, or refuses rather than tag the
-// wrong commit.
-function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): string {
-  const { tag_name: releaseTag, version, isLatest } = release
-  const tagExists = gitTagExists(releaseTag)
-  const deducedCommit = !tagExists && !isLatest ? findReleaseCommit(version) : null
-  if (deducedCommit)
-    console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
-  return resolveTargetCommitish({ releaseTag, tagExists, isLatest, deducedCommit, defaultBranch })
 }
 
 // Which package directories to sync:

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -1,3 +1,4 @@
+export { git }
 export { getRepoRoot }
 export { gitTagExists }
 export { findReleaseCommit }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -6,8 +6,8 @@ export type { Release }
 export type { ReleasesClient }
 
 import assert from 'node:assert'
-import { execSync } from 'node:child_process'
 import { setTimeout } from 'node:timers/promises'
+import { git } from './git.ts'
 
 // The fields we use of a GitHub Release (https://docs.github.com/en/rest/releases/releases).
 type Release = {
@@ -141,7 +141,7 @@ function getRepository(): { owner: string; repo: string } {
 }
 
 function getRepositoryFromGit(): string {
-  const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim()
+  const url = git(['remote', 'get-url', 'origin']).trim()
   // Handles both https://github.com/owner/repo.git and git@github.com:owner/repo.git
   const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/)
   assert(match, `Cannot parse GitHub repository from git remote: ${url}`)


### PR DESCRIPTION
A pure-quality refactor of the `sync-github-releases` tool — **no behavior change**, the 21 unit tests stay green (and verified at runtime under Node's `--experimental-strip-types`, plus `tsc` and Biome clean). Each refactor is its own commit.

I started by rating every file, function, and distinct piece of logic, then fixed the lowest-rated ones. Four genuine improvements stood out; I deliberately left a few intrinsic trade-offs alone (see below).

## What changed & why

### 1. Compute the tracked package dirs once (`sync.ts`)
`toPackageDirs(getTrackedChangelogFiles())` was evaluated **twice** per run — once for `hasMultiplePackages`, and again inside `getPackageDirsToSync()` on the no-push path — re-running `git ls-files` and duplicating the mapping. It's now evaluated once as `allPackageDirs`, with both the multi-package check and the default sync set derived from it. Package selection (explicit-arg / push / all) also moves wholly into `getPackageDirsToSync(args, allPackageDirs)` instead of being split between it and `main()`.

### 2. Read `package.json` with `readFile`, not `createRequire` (`sync.ts`)
`syncPackage()` pulled the package name through `createRequire(import.meta.url)` while reading the CHANGELOG.md one line below with `readFile` — two ways to read a file from the same directory. Both now use `readFile` + `JSON.parse`, dropping the `createRequire` import.

### 3. Route `getRepositoryFromGit()` through `git()` (`github.ts`)
`git.ts` already funnels every git call through `git()`/`gitLines()` (`execFileSync`, no shell), but `github.ts` still reached for git on its own via `execSync('git remote get-url origin', …)` — a second invocation style, and the one remaining place using a shell. It now reuses the exported `git(['remote', 'get-url', 'origin'])`, so git invocation lives in exactly one place. (Completes the earlier "DRY git invocations behind git()/gitLines()" pass.)

### 4. Split plan execution into `apply-release-plan.ts`
`sync.ts` carried two abstractions: orchestrating the run, and *executing* a plan against GitHub (`applyReleasePlan` + `resolveCreateTarget`). The latter mirrors `release-plan.ts` — one computes the plan (pure), the other carries it out (I/O). Moving it out leaves `sync.ts` as pure orchestration (151 → 100 lines) and `release-plan.ts` fully pure and unit-tested. `release-plan.ts` now exports a named `ReleasePlan` type in place of the prior `ReturnType<typeof getReleasePlan>`.

## Deliberately left alone
- **`getReleaseTag()` ↔ `isOwnedTag()` mirror** — construct-vs-match is intrinsically two operations (and the match needs a semver guard, not a bare prefix); over-DRYing would reduce clarity. Already co-located and commented.
- **`if (!dryRun) console.log(...)` ×3 in the apply loop** — the explicit form is clearer than a helper, and the dry-run asymmetry is now documented at the top of `apply-release-plan.ts`.

## Verification
- `vitest run` (unit) → **21/21 pass**
- `tsc -p tsconfig.json` → clean
- `biome check` → clean
- Ran the modules through real `node --experimental-strip-types` (the inline `type` imports strip correctly; CI runs `node ./sync.ts` directly), exercising `applyReleasePlan`'s create/update/delete loops and the `getRepository()` git fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DNCkB828iRvSfbxZuMjB1

---
_Generated by [Claude Code](https://claude.ai/code/session_014DNCkB828iRvSfbxZuMjB1)_