### PR TITLE
sync-github-releases: sharper module boundaries and DRY cleanups

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -38,48 +38,49 @@ async function main(): Promise<void> {
 
   const { owner, repo } = getRepository()
   const defaultBranch = getDefaultBranch()
-  const client = createReleasesClient({ owner, repo, token: getGithubToken() })
+  const context: SyncContext = {
+    client: createReleasesClient({ owner, repo, token: getGithubToken() }),
+    defaultBranch,
+    hasMultiplePackages,
+    dryRun,
+    // The base of the GitHub web (blob) URL each release's CHANGELOG.md footer links back to —
+    // github.com is the web host, distinct from the API the client talks to.
+    changelogUrlBase: `https://github.com/${owner}/${repo}/blob/${defaultBranch}`,
+  }
 
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)
-    await syncPackage({ packageDir, client, owner, repo, defaultBranch, hasMultiplePackages, dryRun })
+    await syncPackage(packageDir, context)
   }
 }
 
-async function syncPackage({
-  packageDir,
-  client,
-  owner,
-  repo,
-  defaultBranch,
-  hasMultiplePackages,
-  dryRun,
-}: {
-  packageDir: string
+// The loop-invariant inputs of a sync run, built once and shared across packages. owner/repo aren't
+// here: the client already binds them, and the changelog URL base bakes them in.
+type SyncContext = {
   client: ReleasesClient
-  owner: string
-  repo: string
   defaultBranch: string
   hasMultiplePackages: boolean
   dryRun: boolean
-}): Promise<void> {
+  changelogUrlBase: string
+}
+
+async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
   const packageDirPath = path.join(process.cwd(), packageDir)
   const packageJson = JSON.parse(await readFile(path.join(packageDirPath, 'package.json'), 'utf8')) as { name: string }
   const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
 
   // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
-  const changelogRepoPath = path.posix.join(packageDir, 'CHANGELOG.md')
-  const changelogUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${changelogRepoPath}`
+  const changelogUrl = `${ctx.changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
   const releaseNotesByVersion = getReleaseNotesByVersion(changelog, changelogUrl)
 
-  const githubReleases = await client.list()
+  const githubReleases = await ctx.client.list()
   const plan = getReleasePlan({
     githubReleases,
     releaseNotesByVersion,
     packageName: packageJson.name,
-    hasMultiplePackages,
+    hasMultiplePackages: ctx.hasMultiplePackages,
   })
-  await applyReleasePlan(plan, client, defaultBranch, dryRun)
+  await applyReleasePlan(plan, ctx.client, ctx.defaultBranch, ctx.dryRun)
 }
 
 // Which package directories to sync:

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
 
   // Every package tracked in the repo — one per CHANGELOG.md. Used both as the default set to sync and
   // to pick the tag scheme: when several packages share the repo they also share its tag namespace, so
-  // their release tags are qualified with the package name (see getReleaseTag()).
+  // their release tags are qualified with the package name (see getTagScheme()).
   const allPackageDirs = toPackageDirs(getTrackedChangelogFiles())
   const packageDirs = getPackageDirsToSync(args, allPackageDirs)
   if (packageDirs.length === 0) {

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -7,7 +7,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { applyReleasePlan } from './sync/apply-release-plan.ts'
 import { getReleasePlan } from './sync/release-plan.ts'
-import { parseChangelog, withChangelogFooter } from './utils/changelog.ts'
+import { getReleaseNotesByVersion } from './utils/changelog.ts'
 import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
 import {
   createReleasesClient,
@@ -70,12 +70,7 @@ async function syncPackage({
   // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
   const changelogRepoPath = path.posix.join(packageDir, 'CHANGELOG.md')
   const changelogUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${changelogRepoPath}`
-  const releaseNotesByVersion = Object.fromEntries(
-    Object.entries(parseChangelog(changelog)).map(([version, notes]) => [
-      version,
-      withChangelogFooter(notes, changelogUrl),
-    ]),
-  )
+  const releaseNotesByVersion = getReleaseNotesByVersion(changelog, changelogUrl)
 
   const githubReleases = await client.list()
   const plan = getReleasePlan({

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
 
   const { owner, repo } = getRepository()
   const defaultBranch = getDefaultBranch()
-  const client = createReleasesClient({ owner, repo, token: getGithubToken(), dryRun })
+  const client = createReleasesClient({ owner, repo, token: getGithubToken() })
 
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyReleasePlan, resolveTargetCommitish } from './apply-release-plan.ts'
+import type { ReleasePlan } from './release-plan.ts'
+import type { Release, ReleasesClient } from '../utils/github.ts'
+
+describe('resolveTargetCommitish()', () => {
+  const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
+
+  it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deducedCommit: null })).toBe('main')
+    // Even for the latest release, an existing tag is fine.
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: true, deducedCommit: null })).toBe('main')
+  })
+
+  it('hard-fails when the latest release has no tag', () => {
+    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deducedCommit: null })).toThrow(
+      /latest release must already be tagged/,
+    )
+  })
+
+  it('tags an older release at the deduced commit', () => {
+    expect(resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: 'abc123' })).toBe(
+      'abc123',
+    )
+  })
+
+  it('hard-fails when an older release has no tag and no deducible commit', () => {
+    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: null })).toThrow(
+      /couldn't be deduced/,
+    )
+  })
+})
+
+describe('applyReleasePlan()', () => {
+  // No creates in the plan, so resolveCreateTarget() (which shells out to git) isn't exercised here.
+  // The dry-run gate is shared by all three actions via applyWrite(), so update + delete prove it.
+  const plan: ReleasePlan = {
+    releasesToCreate: [],
+    releasesToUpdate: [{ release_id: 1, tag_name: 'v1.0.0', body: 'Fresh notes' }],
+    releasesToDelete: [{ release_id: 2, tag_name: 'v0.9.0' }],
+  }
+
+  function createFakeClient(): { client: ReleasesClient; calls: string[] } {
+    const calls: string[] = []
+    const client: ReleasesClient = {
+      async list() {
+        return [] as Release[]
+      },
+      async create() {
+        calls.push('create')
+      },
+      async update(releaseId) {
+        calls.push(`update:${releaseId}`)
+      },
+      async delete(releaseId) {
+        calls.push(`delete:${releaseId}`)
+      },
+    }
+    return { client, calls }
+  }
+
+  it('performs each write and logs it', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const { client, calls } = createFakeClient()
+
+    await applyReleasePlan(plan, client, 'main', false)
+
+    expect(calls).toEqual(['update:1', 'delete:2'])
+    expect(log.mock.calls.flat()).toEqual(['Updated release v1.0.0', 'Deleted release v0.9.0'])
+    log.mockRestore()
+  })
+
+  it('under --dry-run, announces every action but performs no write', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const { client, calls } = createFakeClient()
+
+    await applyReleasePlan(plan, client, 'main', true)
+
+    expect(calls).toEqual([])
+    expect(log.mock.calls.flat()).toEqual([
+      '[dry-run] Would update release v1.0.0',
+      '[dry-run] Would delete release v0.9.0',
+    ])
+    log.mockRestore()
+  })
+})

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
@@ -7,27 +7,37 @@ describe('resolveTargetCommitish()', () => {
   const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
 
   it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deducedCommit: null })).toBe('main')
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deduceCommit: () => null })).toBe('main')
     // Even for the latest release, an existing tag is fine.
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: true, deducedCommit: null })).toBe('main')
+    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: true, deduceCommit: () => null })).toBe('main')
   })
 
   it('hard-fails when the latest release has no tag', () => {
-    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deducedCommit: null })).toThrow(
-      /latest release must already be tagged/,
-    )
+    expect(() =>
+      resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deduceCommit: () => null }),
+    ).toThrow(/latest release must already be tagged/)
   })
 
   it('tags an older release at the deduced commit', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: 'abc123' })).toBe(
+    expect(resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit: () => 'abc123' })).toBe(
       'abc123',
     )
   })
 
   it('hard-fails when an older release has no tag and no deducible commit', () => {
-    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: null })).toThrow(
-      /couldn't be deduced/,
-    )
+    expect(() =>
+      resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit: () => null }),
+    ).toThrow(/couldn't be deduced/)
+  })
+
+  it('only deduces the commit for a backfilled older release (never when the tag exists or it is latest)', () => {
+    const deduceCommit = vi.fn(() => 'abc123')
+    resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deduceCommit })
+    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deduceCommit })).toThrow()
+    expect(deduceCommit).not.toHaveBeenCalled()
+
+    resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit })
+    expect(deduceCommit).toHaveBeenCalledOnce()
   })
 })
 

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -4,9 +4,9 @@ import { resolveTargetCommitish, type ReleasePlan, type ReleaseToCreate } from '
 import { findReleaseCommit, gitTagExists } from '../utils/git.ts'
 import type { ReleasesClient } from '../utils/github.ts'
 
-// Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. Under
-// --dry-run the client logs each write instead of performing it, so the per-action confirmations
-// below (which would otherwise claim work that didn't happen) are skipped.
+// Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. The
+// --dry-run gate lives here rather than in the client, so the client stays a plain transport and each
+// action is logged the same way whether or not it's actually performed.
 async function applyReleasePlan(
   plan: ReleasePlan,
   client: ReleasesClient,
@@ -14,28 +14,45 @@ async function applyReleasePlan(
   dryRun: boolean,
 ): Promise<void> {
   for (const release of plan.releasesToCreate) {
-    await client.create({
-      tag_name: release.tag_name,
-      name: release.tag_name,
-      body: release.body,
-      target_commitish: resolveCreateTarget(release, defaultBranch),
-      // Only the newest version may be the repo's "Latest". create-release otherwise defaults
-      // make_latest=true, so backfilling an older release while a newer one already exists would
-      // wrongly mark the old one Latest.
-      make_latest: release.isLatest ? 'true' : 'false',
-    })
-    if (!dryRun) console.log(`Created release ${release.tag_name}`)
+    // Resolve (and validate) the tag's commit before the dry-run gate, so a dry run still surfaces a
+    // missing-tag failure or a deduced-commit warning.
+    const target_commitish = resolveCreateTarget(release, defaultBranch)
+    await applyWrite(dryRun, 'create', release.tag_name, () =>
+      client.create({
+        tag_name: release.tag_name,
+        name: release.tag_name,
+        body: release.body,
+        target_commitish,
+        // Only the newest version may be the repo's "Latest". create-release otherwise defaults
+        // make_latest=true, so backfilling an older release while a newer one already exists would
+        // wrongly mark the old one Latest.
+        make_latest: release.isLatest ? 'true' : 'false',
+      }),
+    )
   }
 
-  for (const release of plan.releasesToUpdate) {
-    await client.update(release.release_id, release.body)
-    if (!dryRun) console.log(`Updated release ${release.tag_name}`)
-  }
+  for (const release of plan.releasesToUpdate)
+    await applyWrite(dryRun, 'update', release.tag_name, () => client.update(release.release_id, release.body))
 
-  for (const release of plan.releasesToDelete) {
-    await client.delete(release.release_id)
-    if (!dryRun) console.log(`Deleted release ${release.tag_name}`)
+  for (const release of plan.releasesToDelete)
+    await applyWrite(dryRun, 'delete', release.tag_name, () => client.delete(release.release_id))
+}
+
+// Perform one write against GitHub — or, under --dry-run, just announce it. Centralizing the gate here
+// keeps create/update/delete from each repeating the dry-run branch, and logs every action once.
+const pastTense = { create: 'Created', update: 'Updated', delete: 'Deleted' } as const
+async function applyWrite(
+  dryRun: boolean,
+  action: keyof typeof pastTense,
+  releaseTag: string,
+  write: () => Promise<void>,
+): Promise<void> {
+  if (dryRun) {
+    console.log(`[dry-run] Would ${action} release ${releaseTag}`)
+    return
   }
+  await write()
+  console.log(`${pastTense[action]} release ${releaseTag}`)
 }
 
 // The commit a to-be-created release is tagged at. A release needs a tag to point at; when it's

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -1,6 +1,7 @@
 export { applyReleasePlan }
+export { resolveTargetCommitish }
 
-import { resolveTargetCommitish, type ReleasePlan, type ReleaseToCreate } from './release-plan.ts'
+import type { ReleasePlan, ReleaseToCreate } from './release-plan.ts'
 import { findReleaseCommit, gitTagExists } from '../utils/git.ts'
 import type { ReleasesClient } from '../utils/github.ts'
 
@@ -67,4 +68,37 @@ function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): s
   if (deducedCommit)
     console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
   return resolveTargetCommitish({ releaseTag, tagExists, isLatest, deducedCommit, defaultBranch })
+}
+
+// The commit a to-be-created release should be tagged at (its `target_commitish`).
+//  - Tag already exists: GitHub uses it and ignores target_commitish — pass the branch as a no-op.
+//  - Tag missing on the latest release: hard fail. The just-released version must already be tagged;
+//    tagging it now would point at the default branch's HEAD (the wrong commit).
+//  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history,
+//    or hard fail if it couldn't be deduced — never silently tag the wrong commit.
+function resolveTargetCommitish({
+  releaseTag,
+  tagExists,
+  isLatest,
+  deducedCommit,
+  defaultBranch,
+}: {
+  releaseTag: string
+  tagExists: boolean
+  isLatest: boolean
+  deducedCommit: string | null
+  defaultBranch: string
+}): string {
+  if (tagExists) return defaultBranch
+  if (isLatest) {
+    throw new Error(
+      `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
+    )
+  }
+  if (!deducedCommit) {
+    throw new Error(
+      `Refusing to create release ${releaseTag}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
+    )
+  }
+  return deducedCommit
 }

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -56,37 +56,41 @@ async function applyWrite(
   console.log(`${pastTense[action]} release ${releaseTag}`)
 }
 
-// The commit a to-be-created release is tagged at. A release needs a tag to point at; when it's
-// missing, GitHub would create it at the default branch's HEAD — the wrong commit for a backfilled
-// (older) release. So deduce the real commit from the changelog history and tag that instead.
-// resolveTargetCommitish() turns these git facts into the commitish, or refuses rather than tag the
-// wrong commit.
+// The commit a to-be-created release is tagged at. Gathers the git facts and hands them to
+// resolveTargetCommitish(), which owns the decision; deducing the commit (a full-history changelog
+// search) is passed as a thunk so it runs only for the one case that needs it.
 function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): string {
   const { tag_name: releaseTag, version, isLatest } = release
-  const tagExists = gitTagExists(releaseTag)
-  const deducedCommit = !tagExists && !isLatest ? findReleaseCommit(version) : null
-  if (deducedCommit)
-    console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${deducedCommit}`)
-  return resolveTargetCommitish({ releaseTag, tagExists, isLatest, deducedCommit, defaultBranch })
+  return resolveTargetCommitish({
+    releaseTag,
+    isLatest,
+    tagExists: gitTagExists(releaseTag),
+    deduceCommit: () => {
+      const commit = findReleaseCommit(version)
+      if (commit) console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${commit}`)
+      return commit
+    },
+    defaultBranch,
+  })
 }
 
 // The commit a to-be-created release should be tagged at (its `target_commitish`).
 //  - Tag already exists: GitHub uses it and ignores target_commitish — pass the branch as a no-op.
 //  - Tag missing on the latest release: hard fail. The just-released version must already be tagged;
 //    tagging it now would point at the default branch's HEAD (the wrong commit).
-//  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history,
-//    or hard fail if it couldn't be deduced — never silently tag the wrong commit.
+//  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history
+//    (deduceCommit()), or hard fail if it couldn't be deduced — never silently tag the wrong commit.
 function resolveTargetCommitish({
   releaseTag,
   tagExists,
   isLatest,
-  deducedCommit,
+  deduceCommit,
   defaultBranch,
 }: {
   releaseTag: string
   tagExists: boolean
   isLatest: boolean
-  deducedCommit: string | null
+  deduceCommit: () => string | null
   defaultBranch: string
 }): string {
   if (tagExists) return defaultBranch
@@ -95,6 +99,7 @@ function resolveTargetCommitish({
       `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
     )
   }
+  const deducedCommit = deduceCommit()
   if (!deducedCommit) {
     throw new Error(
       `Refusing to create release ${releaseTag}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,

--- a/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveTargetCommitish, getReleasePlan, getReleaseTag } from './release-plan.ts'
+import { resolveTargetCommitish, getReleasePlan, getTagScheme } from './release-plan.ts'
 
 describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
@@ -144,14 +144,22 @@ describe('resolveTargetCommitish()', () => {
   })
 })
 
-describe('getReleaseTag()', () => {
-  it('keeps the bare vX.Y.Z tag for a single package', () => {
-    expect(getReleaseTag('0.4.259', 'vike', false)).toBe('v0.4.259')
-    expect(getReleaseTag('0.1.0-beta.6', 'vike', false)).toBe('v0.1.0-beta.6')
+describe('getTagScheme()', () => {
+  it('keeps the bare vX.Y.Z tag for a single package, and owns only such tags', () => {
+    const scheme = getTagScheme('vike', false)
+    expect(scheme.build('0.4.259')).toBe('v0.4.259')
+    expect(scheme.build('0.1.0-beta.6')).toBe('v0.1.0-beta.6')
+    expect(scheme.owns('v0.4.259')).toBe(true)
+    // A tag we never create — left untouched.
+    expect(scheme.owns('nightly')).toBe(false)
   })
 
-  it('qualifies the tag with the package name when there are several packages', () => {
-    expect(getReleaseTag('0.0.391', 'create-vike-core', true)).toBe('create-vike-core@0.0.391')
-    expect(getReleaseTag('0.1.0-beta.6', 'vike', true)).toBe('vike@0.1.0-beta.6')
+  it('qualifies the tag with the package name when there are several packages, and owns only its own', () => {
+    const scheme = getTagScheme('create-vike-core', true)
+    expect(scheme.build('0.0.391')).toBe('create-vike-core@0.0.391')
+    expect(scheme.build('0.1.0-beta.6')).toBe('create-vike-core@0.1.0-beta.6')
+    expect(scheme.owns('create-vike-core@0.0.391')).toBe(true)
+    // Another package's release — not ours.
+    expect(scheme.owns('vike@0.4.0')).toBe(false)
   })
 })

--- a/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveTargetCommitish, getReleasePlan, getTagScheme } from './release-plan.ts'
+import { getReleasePlan, getTagScheme } from './release-plan.ts'
 
 describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
@@ -113,34 +113,6 @@ describe('getReleasePlan()', () => {
       releasesToUpdate: [],
       releasesToDelete: [],
     })
-  })
-})
-
-describe('resolveTargetCommitish()', () => {
-  const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
-
-  it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deducedCommit: null })).toBe('main')
-    // Even for the latest release, an existing tag is fine.
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: true, deducedCommit: null })).toBe('main')
-  })
-
-  it('hard-fails when the latest release has no tag', () => {
-    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deducedCommit: null })).toThrow(
-      /latest release must already be tagged/,
-    )
-  })
-
-  it('tags an older release at the deduced commit', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: 'abc123' })).toBe(
-      'abc123',
-    )
-  })
-
-  it('hard-fails when an older release has no tag and no deducible commit', () => {
-    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deducedCommit: null })).toThrow(
-      /couldn't be deduced/,
-    )
   })
 })
 

--- a/.github/workflows/sync-github-releases/sync/release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.ts
@@ -1,5 +1,5 @@
 export { getReleasePlan }
-export { getReleaseTag }
+export { getTagScheme }
 export { resolveTargetCommitish }
 export type { ReleasePlan }
 export type { ReleaseToCreate }
@@ -30,20 +30,30 @@ type ReleaseToDelete = {
   tag_name: string
 }
 
-// A version's git tag. A single package keeps the historical bare `vX.Y.Z` tag. Several packages share
-// the repo's tag namespace, so their tags are qualified with the package name (e.g.
-// `create-vike-core@0.0.391`) to avoid collisions.
-function getReleaseTag(version: string, packageName: string, hasMultiplePackages: boolean): string {
-  if (hasMultiplePackages) return `${packageName}@${version}`
-  return `v${version}`
+// A package's release-tag scheme, defined in one place so building a tag and recognizing one can't
+// drift apart. `build` turns a version into its tag; `owns` reports whether a release tag is this
+// package's — i.e. a candidate for deletion once its changelog entry is gone, never another package's
+// release nor a tag we don't create (e.g. `nightly`).
+//
+// A single package keeps the historical bare `vX.Y.Z` tag. Several packages share the repo's tag
+// namespace, so their tags are qualified with the package name (e.g. `create-vike-core@0.0.391`) to
+// avoid collisions.
+type TagScheme = {
+  build(version: string): string
+  owns(releaseTag: string): boolean
 }
-
-// Whether a GitHub Release tag belongs to the package being synced — i.e. is a candidate for
-// deletion once its changelog entry is gone. Mirrors getReleaseTag()'s two schemes, so a release of
-// another package (or a tag we never created, e.g. `nightly`) is never deleted.
-function isOwnedTag(releaseTag: string, packageName: string, hasMultiplePackages: boolean): boolean {
-  if (hasMultiplePackages) return releaseTag.startsWith(`${packageName}@`)
-  return /^v\d+\.\d+\.\d+/.test(releaseTag)
+function getTagScheme(packageName: string, hasMultiplePackages: boolean): TagScheme {
+  if (hasMultiplePackages) {
+    const prefix = `${packageName}@`
+    return {
+      build: (version) => `${prefix}${version}`,
+      owns: (releaseTag) => releaseTag.startsWith(prefix),
+    }
+  }
+  return {
+    build: (version) => `v${version}`,
+    owns: (releaseTag) => /^v\d+\.\d+\.\d+/.test(releaseTag),
+  }
 }
 
 // The commit a to-be-created release should be tagged at (its `target_commitish`).
@@ -90,6 +100,8 @@ function getReleasePlan({
   packageName: string
   hasMultiplePackages: boolean
 }): ReleasePlan {
+  const tagScheme = getTagScheme(packageName, hasMultiplePackages)
+
   // Reconcile from the changelog (the source of truth), not from the GitHub Releases: iterating the
   // releases for updates would try to rewrite any release whose tag isn't in the changelog (e.g. a
   // release of another package, or a manually-created one) with an `undefined` body. Driving both
@@ -110,7 +122,7 @@ function getReleasePlan({
   // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
   for (const version of [...versions].reverse()) {
     const body = releaseNotesByVersion[version]
-    const releaseTag = getReleaseTag(version, packageName, hasMultiplePackages)
+    const releaseTag = tagScheme.build(version)
     expectedTags.add(releaseTag)
     const existingRelease = releasesByTag.get(releaseTag)
     if (!existingRelease) {
@@ -122,10 +134,7 @@ function getReleasePlan({
 
   // Delete this package's releases whose version is no longer in the changelog (the source of truth).
   const releasesToDelete: ReleaseToDelete[] = githubReleases
-    .filter(
-      (release) =>
-        isOwnedTag(release.tag_name, packageName, hasMultiplePackages) && !expectedTags.has(release.tag_name),
-    )
+    .filter((release) => tagScheme.owns(release.tag_name) && !expectedTags.has(release.tag_name))
     .map((release) => ({ release_id: release.id, tag_name: release.tag_name }))
 
   return { releasesToCreate, releasesToUpdate, releasesToDelete }

--- a/.github/workflows/sync-github-releases/sync/release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.ts
@@ -1,6 +1,5 @@
 export { getReleasePlan }
 export { getTagScheme }
-export { resolveTargetCommitish }
 export type { ReleasePlan }
 export type { ReleaseToCreate }
 
@@ -54,39 +53,6 @@ function getTagScheme(packageName: string, hasMultiplePackages: boolean): TagSch
     build: (version) => `v${version}`,
     owns: (releaseTag) => /^v\d+\.\d+\.\d+/.test(releaseTag),
   }
-}
-
-// The commit a to-be-created release should be tagged at (its `target_commitish`).
-//  - Tag already exists: GitHub uses it and ignores target_commitish — pass the branch as a no-op.
-//  - Tag missing on the latest release: hard fail. The just-released version must already be tagged;
-//    tagging it now would point at the default branch's HEAD (the wrong commit).
-//  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history,
-//    or hard fail if it couldn't be deduced — never silently tag the wrong commit.
-function resolveTargetCommitish({
-  releaseTag,
-  tagExists,
-  isLatest,
-  deducedCommit,
-  defaultBranch,
-}: {
-  releaseTag: string
-  tagExists: boolean
-  isLatest: boolean
-  deducedCommit: string | null
-  defaultBranch: string
-}): string {
-  if (tagExists) return defaultBranch
-  if (isLatest) {
-    throw new Error(
-      `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
-    )
-  }
-  if (!deducedCommit) {
-    throw new Error(
-      `Refusing to create release ${releaseTag}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
-    )
-  }
-  return deducedCommit
 }
 
 function getReleasePlan({

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -1,5 +1,5 @@
 export { parseChangelog }
-export { withChangelogFooter }
+export { getReleaseNotesByVersion }
 
 export type ReleaseNotesByVersion = Record<string, string>
 
@@ -22,6 +22,17 @@ function parseChangelog(changelog: string): ReleaseNotesByVersion {
   })
 
   return releaseNotesByVersion
+}
+
+// The release notes we publish for each changelog version: the parsed entry plus a footer linking back
+// to its CHANGELOG.md.
+function getReleaseNotesByVersion(changelog: string, changelogUrl: string): ReleaseNotesByVersion {
+  return Object.fromEntries(
+    Object.entries(parseChangelog(changelog)).map(([version, notes]) => [
+      version,
+      withChangelogFooter(notes, changelogUrl),
+    ]),
+  )
 }
 
 // These releases are generated, so point each one back to the CHANGELOG.md it mirrors (the source of

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -4,7 +4,7 @@ export { getReleaseNotesByVersion }
 export type ReleaseNotesByVersion = Record<string, string>
 
 // Parse a CHANGELOG.md into release notes keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`),
-// newest first. Decorating a version into its git tag is getReleaseTag()'s job, not ours.
+// newest first. Decorating a version into its git tag is getTagScheme()'s job, not ours.
 function parseChangelog(changelog: string): ReleaseNotesByVersion {
   const releaseNotesByVersion: ReleaseNotesByVersion = {}
   // Group 1 is the version; group 2 (optional) is the heading's link. release-me links the version to

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -40,15 +40,7 @@ const API_URL = process.env.GITHUB_API_URL ?? 'https://api.github.com'
 // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 const RATE_LIMIT_DELAY_MS = 500
 
-function createReleasesClient({
-  owner,
-  repo,
-  token,
-}: {
-  owner: string
-  repo: string
-  token: string
-}): ReleasesClient {
+function createReleasesClient({ owner, repo, token }: { owner: string; repo: string; token: string }): ReleasesClient {
   const releasesPath = `/repos/${owner}/${repo}/releases`
   // Writes performed so far, to delay only *between* them (not before the first, nor after reads).
   let writeCount = 0

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -109,7 +109,7 @@ function createReleasesClient({ owner, repo, token }: { owner: string; repo: str
 function getGithubToken(): string {
   const token = process.env.GITHUB_TOKEN
   if (!token) {
-    throw new Error('GITHUB_TOKEN must be set or use --dry-run — see README.md')
+    throw new Error('GITHUB_TOKEN must be set — see README.md')
   }
   return token
 }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -24,8 +24,9 @@ type NewRelease = {
   make_latest: 'true' | 'false'
 }
 
-// A client for one repository's GitHub Releases. It binds the owner/repo/token (and --dry-run) once,
-// so callers just say what to do — not where, nor as whom.
+// A client for one repository's GitHub Releases. It binds the owner/repo/token once, so callers just
+// say what to do — not where, nor as whom. It's a plain transport: skipping writes under --dry-run is
+// the apply step's job (see applyReleasePlan()).
 type ReleasesClient = {
   list(): Promise<Release[]>
   create(release: NewRelease): Promise<void>
@@ -43,12 +44,10 @@ function createReleasesClient({
   owner,
   repo,
   token,
-  dryRun = false,
 }: {
   owner: string
   repo: string
   token: string
-  dryRun?: boolean
 }): ReleasesClient {
   const releasesPath = `/repos/${owner}/${repo}/releases`
   // Writes performed so far, to delay only *between* them (not before the first, nor after reads).
@@ -58,12 +57,6 @@ function createReleasesClient({
     pathname: string,
     { body, method = 'GET' }: { body?: unknown; method?: 'GET' | 'PATCH' | 'POST' | 'DELETE' } = {},
   ): Promise<T> {
-    if (dryRun && method !== 'GET') {
-      console.log(`[dry-run] ${method} ${pathname}`)
-      if (body !== undefined) console.log(JSON.stringify(body, null, 2))
-      return undefined as T
-    }
-
     // Throttle between writes only: reads aren't the rate-limit concern, and a lone write — the common
     // case of a single new release — shouldn't wait at all. So a backfill of N writes pays N-1 delays,
     // while one write pays none.


### PR DESCRIPTION
Continues the abstraction/DRY work (#3389, #3390). Eight focused commits, one refactor each. No behavior change except a corrected error message (last commit).

## Pinnacle architectural split

- **Build release notes in `changelog.ts`** — `sync.ts` hand-rolled the parse→footer composition by importing both `parseChangelog` and `withChangelogFooter` and mapping the entries. Moved into `getReleaseNotesByVersion()`, so all "changelog → published notes" logic lives in one place; `withChangelogFooter` is now a private detail.
- **Own the dry-run gate in the apply step** — dry-run was split: the client logged `[dry-run] POST …` + a JSON body, while `applyReleasePlan` separately gated its confirmation lines on `dryRun` (two log styles, the flag threaded through both). The releases client is now a plain transport; `applyReleasePlan` owns the gate and logs every action one consistent way via a single `applyWrite()` helper.
- **Move commitish resolution into the apply module** — `resolveTargetCommitish()` decides where a to-be-created release gets tagged: an execution concern of the apply step, not part of computing the plan. Moved next to its sole caller, and its unit tests relocated into a new `apply-release-plan.spec.ts` that also covers `applyReleasePlan`'s dry-run gate (via a fake client). `release-plan.ts` is now purely "compute the plan".
- **Pass a `SyncContext`** — `syncPackage()` took seven parameters, including `owner`/`repo` that the client already binds (they flowed through a second path only to build the footer URL). Bundled the loop-invariants into a `SyncContext` built once in `main()`, baking owner/repo/branch into a precomputed `changelogUrlBase`. Now `syncPackage(packageDir, ctx)`.

## Simplify / DRY

- **One tag scheme** — `getReleaseTag` (build a tag) and `isOwnedTag` (recognize the package's tags) independently encoded the same two schemes, repeating the `${packageName}@` prefix and the `v` convention, and had to be kept mirror-images by hand. Replaced with `getTagScheme()` returning a `{ build, owns }` pair, so each scheme is defined once.
- **`resolveTargetCommitish` owns the whole decision** — the precedence (tag exists → branch; latest & untagged → fail; older & untagged → deduce/fail) was encoded twice: once as `resolveCreateTarget`'s `!tagExists && !isLatest` guard, again as the function's branches. A lazy `deduceCommit` thunk lets the pure function own the full decision while the expensive full-history git search still runs only for the one branch that needs it.

## Correctness

- **`GITHUB_TOKEN` error message** — said *"must be set or use --dry-run"*, implying `--dry-run` avoids needing a token. It doesn't: `getGithubToken()` is called unconditionally, and the README documents that every script — `sync:check` included (`contents: read`) — needs one. Dropped the misleading alternative.

## Verification

- `vitest run` (unit) → **24/24 pass** (was 21; +3 from new apply-module coverage)
- `tsc -p tsconfig.json` → clean
- `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrzYeLeDnRXH3FZVEcboUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrzYeLeDnRXH3FZVEcboUF)_