### PR TITLE
sync-github-releases: sharper changelog parsing and sync.ts abstractions

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -7,7 +7,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { applyReleasePlan } from './sync/apply-release-plan.ts'
 import { getReleasePlan } from './sync/release-plan.ts'
-import { getReleaseNotesByVersion } from './utils/changelog.ts'
+import { getReleaseNotesByVersion, type ReleaseNotesByVersion } from './utils/changelog.ts'
 import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
 import {
   createReleasesClient,
@@ -65,22 +65,34 @@ type SyncContext = {
 }
 
 async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
-  const packageDirPath = path.join(process.cwd(), packageDir)
-  const packageJson = JSON.parse(await readFile(path.join(packageDirPath, 'package.json'), 'utf8')) as { name: string }
-  const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
-
-  // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
-  const changelogUrl = `${ctx.changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
-  const releaseNotesByVersion = getReleaseNotesByVersion(changelog, changelogUrl)
-
+  // The releases the package's CHANGELOG.md (the source of truth) says should exist …
+  const { packageName, releaseNotesByVersion } = await readPackageReleaseNotes(packageDir, ctx.changelogUrlBase)
+  // … reconciled against the releases currently on GitHub.
   const githubReleases = await ctx.client.list()
   const plan = getReleasePlan({
     githubReleases,
     releaseNotesByVersion,
-    packageName: packageJson.name,
+    packageName,
     hasMultiplePackages: ctx.hasMultiplePackages,
   })
   await applyReleasePlan(plan, ctx.client, ctx.defaultBranch, ctx.dryRun)
+}
+
+// Read a package's identity (its package.json `name`) and the release notes derived from its
+// CHANGELOG.md — keyed by version, each carrying a footer that links back to the changelog on GitHub.
+async function readPackageReleaseNotes(
+  packageDir: string,
+  changelogUrlBase: string,
+): Promise<{ packageName: string; releaseNotesByVersion: ReleaseNotesByVersion }> {
+  const packageDirPath = path.join(process.cwd(), packageDir)
+  const { name: packageName } = JSON.parse(await readFile(path.join(packageDirPath, 'package.json'), 'utf8')) as {
+    name: string
+  }
+  const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
+
+  // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
+  const changelogUrl = `${changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
+  return { packageName, releaseNotesByVersion: getReleaseNotesByVersion(changelog, changelogUrl) }
 }
 
 // Which package directories to sync:

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -22,14 +22,16 @@ async function main(): Promise<void> {
   // package-dir paths below resolve against it.
   process.chdir(getRepoRoot())
 
+  // CLI args: an optional `--dry-run` flag, plus any number of explicit <package-dir> positionals.
   const args = process.argv.slice(2)
   const dryRun = args.includes('--dry-run')
+  const explicitPackageDirs = args.filter((arg) => !arg.startsWith('--'))
 
   // Every package tracked in the repo — one per CHANGELOG.md. Used both as the default set to sync and
   // to pick the tag scheme: when several packages share the repo they also share its tag namespace, so
   // their release tags are qualified with the package name (see getTagScheme()).
   const allPackageDirs = toPackageDirs(getTrackedChangelogFiles())
-  const packageDirs = getPackageDirsToSync(args, allPackageDirs)
+  const packageDirs = getPackageDirsToSync(explicitPackageDirs, allPackageDirs)
   if (packageDirs.length === 0) {
     console.log('No CHANGELOG.md changes detected — nothing to sync.')
     return
@@ -95,12 +97,11 @@ async function readPackageReleaseNotes(
   return { packageName, releaseNotesByVersion: getReleaseNotesByVersion(changelog, changelogUrl) }
 }
 
-// Which package directories to sync:
-//  - an explicit <package-dir> argument (anything that isn't a --flag), or
+// Which package directories to sync, in priority order:
+//  - the explicit <package-dir> arguments, if any, or
 //  - on push (CI): the packages whose CHANGELOG.md changed, or
 //  - otherwise (manual workflow_dispatch, or a local run with no <package-dir>): every package.
-function getPackageDirsToSync(args: string[], allPackageDirs: string[]): string[] {
-  const explicitPackageDirs = args.filter((arg) => !arg.startsWith('--'))
+function getPackageDirsToSync(explicitPackageDirs: string[], allPackageDirs: string[]): string[] {
   if (explicitPackageDirs.length > 0) return explicitPackageDirs
   const pushedFiles = getPushedFiles()
   if (pushedFiles) return toPackageDirs(pushedFiles)

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -6,22 +6,22 @@ export type ReleaseNotesByVersion = Record<string, string>
 // Parse a CHANGELOG.md into release notes keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`),
 // newest first. Decorating a version into its git tag is getTagScheme()'s job, not ours.
 function parseChangelog(changelog: string): ReleaseNotesByVersion {
-  const releaseNotesByVersion: ReleaseNotesByVersion = {}
-  // Group 1 is the version; group 2 (optional) is the heading's link. release-me links the version to
-  // a `…/compare/…` URL — `## [0.4.257](…/compare/…)` — which we surface as the release's "Full
+  // Each heading captures the version and, optionally, its link. release-me links the version to a
+  // `…/compare/…` URL — `## [0.4.257](…/compare/…)` — which we surface as the release's "Full
   // Changelog". (The very first release links to a `…/tree/…` URL instead, which we skip.)
   const matches = [...changelog.matchAll(/^##? \[(\d+\.\d+\.\d+[^\]]*)\](?:\(([^)]+)\))?/gm)]
 
-  matches.forEach((match, index) => {
-    const start = changelog.indexOf('\n', match.index)
-    const end = matches[index + 1]?.index ?? changelog.length
-    let notes = changelog.slice(start, end).trim()
-    const headingUrl = match[2]
-    if (headingUrl?.includes('/compare/')) notes += `\n\n**Full Changelog**: ${headingUrl}`
-    releaseNotesByVersion[match[1]] = notes
-  })
-
-  return releaseNotesByVersion
+  return Object.fromEntries(
+    matches.map((match, index) => {
+      const [, version, headingUrl] = match
+      // A version's notes run from the end of its heading line to the start of the next heading.
+      const notesStart = changelog.indexOf('\n', match.index)
+      const notesEnd = matches[index + 1]?.index ?? changelog.length
+      let notes = changelog.slice(notesStart, notesEnd).trim()
+      if (headingUrl?.includes('/compare/')) notes += `\n\n**Full Changelog**: ${headingUrl}`
+      return [version, notes]
+    }),
+  )
 }
 
 // The release notes we publish for each changelog version: the parsed entry plus a footer linking back


### PR DESCRIPTION
A focused refactor pass over the `sync-github-releases` tool, on top of #3391. Three independent, behavior-preserving commits, each scrutinized against "is this a sensible abstraction?" and "is this DRY / can it be simpler?".

The tool was already in very good shape, so this is surgical — no churn, no API changes. Two files touched (`sync.ts`, `utils/changelog.ts`), +41/−28.

## Commits

1. **`parse the changelog as a functional mapping`** — `parseChangelog()` built its result by mutating an object inside a `forEach` and read capture groups positionally (`match[1]`/`match[2]`, decoded by a comment). Rewritten as `Object.fromEntries(matches.map(...))` with named destructuring (`[, version, headingUrl]`), matching the functional style already used by `getReleaseNotesByVersion()` and the rest of the file. The now-redundant "Group 1/2" comment is dropped.

2. **`read a package's desired releases in one step`** — `syncPackage()` interleaved low-level file I/O (reading `package.json`/`CHANGELOG.md`, building the changelog URL) with the reconcile-and-apply orchestration. The I/O moves into a new `readPackageReleaseNotes()`, leaving `syncPackage()` a plain narrative: derive the desired releases from the changelog, list the actual ones on GitHub, plan the diff, apply it.

3. **`separate CLI parsing from package selection`** — `getPackageDirsToSync()` took raw `argv` and filtered out `--flags` itself, mixing CLI syntax with selection policy. The explicit `<package-dir>` positionals are now parsed in `main()` next to `--dry-run`; `getPackageDirsToSync()` expresses only the precedence (explicit > pushed > all).

## Verification

- `biome check` — clean (12 files)
- `tsc --noEmit` — clean
- unit tests — 24/24 pass

No test changes were needed: all three commits are behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTd4LKrER7QCtGh5caQMeK)_