### PR TITLE
sync-github-releases: separate the tag scheme from the release plan

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -6,7 +6,8 @@ main()
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { applyReleasePlan } from './sync/apply-release-plan.ts'
-import { getReleasePlan, getTagScheme } from './sync/release-plan.ts'
+import { getReleasePlan } from './sync/release-plan.ts'
+import { getTagScheme } from './sync/tag-scheme.ts'
 import { getReleaseNotesByVersion, type ReleaseNotesByVersion } from './utils/changelog.ts'
 import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
 import {

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -6,7 +6,7 @@ main()
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { applyReleasePlan } from './sync/apply-release-plan.ts'
-import { getReleasePlan } from './sync/release-plan.ts'
+import { getReleasePlan, getTagScheme } from './sync/release-plan.ts'
 import { getReleaseNotesByVersion, type ReleaseNotesByVersion } from './utils/changelog.ts'
 import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
 import {
@@ -69,14 +69,11 @@ type SyncContext = {
 async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
   // The releases the package's CHANGELOG.md (the source of truth) says should exist …
   const { packageName, releaseNotesByVersion } = await readPackageReleaseNotes(packageDir, ctx.changelogUrlBase)
-  // … reconciled against the releases currently on GitHub.
+  // … reconciled against the releases currently on GitHub, using this package's tag scheme to match
+  // and name release tags.
   const githubReleases = await ctx.client.list()
-  const plan = getReleasePlan({
-    githubReleases,
-    releaseNotesByVersion,
-    packageName,
-    hasMultiplePackages: ctx.hasMultiplePackages,
-  })
+  const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
+  const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
   await applyReleasePlan(plan, ctx.client, ctx.defaultBranch, ctx.dryRun)
 }
 

--- a/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
@@ -4,8 +4,7 @@ import { getReleasePlan, getTagScheme } from './release-plan.ts'
 describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
     const plan = getReleasePlan({
-      packageName: 'vike',
-      hasMultiplePackages: false,
+      tagScheme: getTagScheme('vike', false),
       releaseNotesByVersion: {
         '1.0.1': 'New release notes',
         '1.0.0': 'Updated old notes',
@@ -31,8 +30,7 @@ describe('getReleasePlan()', () => {
 
   it('updates the current release instead of creating a duplicate', () => {
     const plan = getReleasePlan({
-      packageName: 'vike',
-      hasMultiplePackages: false,
+      tagScheme: getTagScheme('vike', false),
       releaseNotesByVersion: {
         '1.0.1': 'Fresh release notes',
       },
@@ -48,8 +46,7 @@ describe('getReleasePlan()', () => {
 
   it('leaves releases we do not own untouched (no spurious update or delete)', () => {
     const plan = getReleasePlan({
-      packageName: 'vike',
-      hasMultiplePackages: false,
+      tagScheme: getTagScheme('vike', false),
       releaseNotesByVersion: { '1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
@@ -63,8 +60,7 @@ describe('getReleasePlan()', () => {
 
   it('deletes a release whose version was removed from the changelog', () => {
     const plan = getReleasePlan({
-      packageName: 'vike',
-      hasMultiplePackages: false,
+      tagScheme: getTagScheme('vike', false),
       releaseNotesByVersion: { '1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
@@ -82,8 +78,7 @@ describe('getReleasePlan()', () => {
 
   it('only deletes releases in its own namespace', () => {
     const plan = getReleasePlan({
-      packageName: 'create-vike-core',
-      hasMultiplePackages: true,
+      tagScheme: getTagScheme('create-vike-core', true),
       releaseNotesByVersion: { '0.0.1': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'create-vike-core@0.0.1', body: 'Notes' },
@@ -97,8 +92,7 @@ describe('getReleasePlan()', () => {
 
   it('qualifies tags with the package name when several packages share the repo', () => {
     const plan = getReleasePlan({
-      packageName: 'create-vike-core',
-      hasMultiplePackages: true,
+      tagScheme: getTagScheme('create-vike-core', true),
       releaseNotesByVersion: {
         '0.0.2': 'New notes',
         '0.0.1': 'Old notes',

--- a/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { getReleasePlan, getTagScheme } from './release-plan.ts'
+import { getReleasePlan } from './release-plan.ts'
+import { getTagScheme } from './tag-scheme.ts'
 
 describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
@@ -107,25 +108,5 @@ describe('getReleasePlan()', () => {
       releasesToUpdate: [],
       releasesToDelete: [],
     })
-  })
-})
-
-describe('getTagScheme()', () => {
-  it('keeps the bare vX.Y.Z tag for a single package, and owns only such tags', () => {
-    const scheme = getTagScheme('vike', false)
-    expect(scheme.build('0.4.259')).toBe('v0.4.259')
-    expect(scheme.build('0.1.0-beta.6')).toBe('v0.1.0-beta.6')
-    expect(scheme.owns('v0.4.259')).toBe(true)
-    // A tag we never create — left untouched.
-    expect(scheme.owns('nightly')).toBe(false)
-  })
-
-  it('qualifies the tag with the package name when there are several packages, and owns only its own', () => {
-    const scheme = getTagScheme('create-vike-core', true)
-    expect(scheme.build('0.0.391')).toBe('create-vike-core@0.0.391')
-    expect(scheme.build('0.1.0-beta.6')).toBe('create-vike-core@0.1.0-beta.6')
-    expect(scheme.owns('create-vike-core@0.0.391')).toBe(true)
-    // Another package's release — not ours.
-    expect(scheme.owns('vike@0.4.0')).toBe(false)
   })
 })

--- a/.github/workflows/sync-github-releases/sync/release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.ts
@@ -1,10 +1,10 @@
 export { getReleasePlan }
-export { getTagScheme }
 export type { ReleasePlan }
 export type { ReleaseToCreate }
 
 import type { ReleaseNotesByVersion } from '../utils/changelog.ts'
 import type { Release } from '../utils/github.ts'
+import type { TagScheme } from './tag-scheme.ts'
 
 type ReleasePlan = {
   releasesToCreate: ReleaseToCreate[]
@@ -27,32 +27,6 @@ type ReleaseToUpdate = {
 type ReleaseToDelete = {
   release_id: number
   tag_name: string
-}
-
-// A package's release-tag scheme, defined in one place so building a tag and recognizing one can't
-// drift apart. `build` turns a version into its tag; `owns` reports whether a release tag is this
-// package's — i.e. a candidate for deletion once its changelog entry is gone, never another package's
-// release nor a tag we don't create (e.g. `nightly`).
-//
-// A single package keeps the historical bare `vX.Y.Z` tag. Several packages share the repo's tag
-// namespace, so their tags are qualified with the package name (e.g. `create-vike-core@0.0.391`) to
-// avoid collisions.
-type TagScheme = {
-  build(version: string): string
-  owns(releaseTag: string): boolean
-}
-function getTagScheme(packageName: string, hasMultiplePackages: boolean): TagScheme {
-  if (hasMultiplePackages) {
-    const prefix = `${packageName}@`
-    return {
-      build: (version) => `${prefix}${version}`,
-      owns: (releaseTag) => releaseTag.startsWith(prefix),
-    }
-  }
-  return {
-    build: (version) => `v${version}`,
-    owns: (releaseTag) => /^v\d+\.\d+\.\d+/.test(releaseTag),
-  }
 }
 
 function getReleasePlan({

--- a/.github/workflows/sync-github-releases/sync/release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.ts
@@ -58,16 +58,12 @@ function getTagScheme(packageName: string, hasMultiplePackages: boolean): TagSch
 function getReleasePlan({
   githubReleases,
   releaseNotesByVersion,
-  packageName,
-  hasMultiplePackages,
+  tagScheme,
 }: {
   githubReleases: Release[]
   releaseNotesByVersion: ReleaseNotesByVersion
-  packageName: string
-  hasMultiplePackages: boolean
+  tagScheme: TagScheme
 }): ReleasePlan {
-  const tagScheme = getTagScheme(packageName, hasMultiplePackages)
-
   // Reconcile from the changelog (the source of truth), not from the GitHub Releases: iterating the
   // releases for updates would try to rewrite any release whose tag isn't in the changelog (e.g. a
   // release of another package, or a manually-created one) with an `undefined` body. Driving both

--- a/.github/workflows/sync-github-releases/sync/tag-scheme.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/tag-scheme.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { getTagScheme } from './tag-scheme.ts'
+
+describe('getTagScheme()', () => {
+  it('keeps the bare vX.Y.Z tag for a single package, and owns only such tags', () => {
+    const scheme = getTagScheme('vike', false)
+    expect(scheme.build('0.4.259')).toBe('v0.4.259')
+    expect(scheme.build('0.1.0-beta.6')).toBe('v0.1.0-beta.6')
+    expect(scheme.owns('v0.4.259')).toBe(true)
+    // A tag we never create — left untouched.
+    expect(scheme.owns('nightly')).toBe(false)
+  })
+
+  it('qualifies the tag with the package name when there are several packages, and owns only its own', () => {
+    const scheme = getTagScheme('create-vike-core', true)
+    expect(scheme.build('0.0.391')).toBe('create-vike-core@0.0.391')
+    expect(scheme.build('0.1.0-beta.6')).toBe('create-vike-core@0.1.0-beta.6')
+    expect(scheme.owns('create-vike-core@0.0.391')).toBe(true)
+    // Another package's release — not ours.
+    expect(scheme.owns('vike@0.4.0')).toBe(false)
+  })
+})

--- a/.github/workflows/sync-github-releases/sync/tag-scheme.ts
+++ b/.github/workflows/sync-github-releases/sync/tag-scheme.ts
@@ -1,0 +1,28 @@
+export { getTagScheme }
+export type { TagScheme }
+
+// A package's release-tag scheme, defined in one place so building a tag and recognizing one can't
+// drift apart. `build` turns a version into its tag; `owns` reports whether a release tag is this
+// package's — i.e. a candidate for deletion once its changelog entry is gone, never another package's
+// release nor a tag we don't create (e.g. `nightly`).
+//
+// A single package keeps the historical bare `vX.Y.Z` tag. Several packages share the repo's tag
+// namespace, so their tags are qualified with the package name (e.g. `create-vike-core@0.0.391`) to
+// avoid collisions.
+type TagScheme = {
+  build(version: string): string
+  owns(releaseTag: string): boolean
+}
+function getTagScheme(packageName: string, hasMultiplePackages: boolean): TagScheme {
+  if (hasMultiplePackages) {
+    const prefix = `${packageName}@`
+    return {
+      build: (version) => `${prefix}${version}`,
+      owns: (releaseTag) => releaseTag.startsWith(prefix),
+    }
+  }
+  return {
+    build: (version) => `v${version}`,
+    owns: (releaseTag) => /^v\d+\.\d+\.\d+/.test(releaseTag),
+  }
+}


### PR DESCRIPTION
Two small, surgical refactors of `sync-github-releases`, each its own commit. No behavior change — the 24 unit tests, `tsc`, Prettier and Biome all stay green.

The reconciliation module (`sync/release-plan.ts`) carried **two** abstractions: how a package *names/recognizes* its release tags (`getTagScheme` — `build`/`owns`), and how it *reconciles* releases against the changelog (`getReleasePlan`). On top of that, `getReleasePlan` re-derived the scheme itself from `packageName` + `hasMultiplePackages`, conflating the two.

**1. `getReleasePlan` receives a tag scheme, not package metadata**
Instead of taking `packageName` + `hasMultiplePackages` only to build a `TagScheme` internally, it now accepts the already-built `tagScheme`. Its inputs are exactly what it reconciles with: the existing releases, the desired notes, and the scheme that matches/names their tags. `syncPackage()` builds the scheme — it owns the per-package facts. (Mirrors the recent "hand the function what it needs" moves: the CLI-parse split and `SyncContext`.)

**2. Give the tag scheme its own module**
Now that the scheme is injected and has a second consumer (`syncPackage`), `getTagScheme` + the `TagScheme` type (and their tests) move out of `release-plan.ts` into `sync/tag-scheme.ts`. Each file is now one abstraction: `tag-scheme.ts` owns tag naming/ownership, `release-plan.ts` owns reconciliation.

Net `-7` lines; `release-plan.ts` drops from ~107 to ~71 lines and reads as a single-purpose reconciler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nr4trBUbFYVZbgJoLoWXRR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr4trBUbFYVZbgJoLoWXRR)_