### PR TITLE
sync-github-releases: note git-tag handling in the README

### DIFF
--- a/.github/workflows/sync-github-releases/README.md
+++ b/.github/workflows/sync-github-releases/README.md
@@ -24,6 +24,8 @@ Runs automatically via [`../sync-github-releases.yml`](../sync-github-releases.y
 
 It's safe to run against any current state: older missing releases are created too, and [GitHub orders the list of releases by tag version (not by creation date)](https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257), so they still land in the right place.
 
+**Git tags:** each release is created at its git tag's commit. An existing tag is used as-is. A missing tag is deduced from the `CHANGELOG.md` history for older (backfilled) releases, or fails the sync for the latest release — which must already be tagged, to avoid tagging it at the wrong commit.
+
 ## Scripts
 
 ```bash


### PR DESCRIPTION
Adds a short, high-level note to the `sync-github-releases` README documenting how a release's commit (git tag) is resolved — the behavior implemented in `resolveTargetCommitish()`:

- an **existing** tag is used as-is;
- a **missing** tag is deduced from the `CHANGELOG.md` history for older (backfilled) releases;
- a **missing** tag on the **latest** release **fails the sync** rather than tag the wrong commit (it must already be tagged).

Docs-only; no code change. Placed right after the "safe to run against any current state" paragraph, since that's where backfilling — and therefore tag resolution — is relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nr4trBUbFYVZbgJoLoWXRR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr4trBUbFYVZbgJoLoWXRR)_