### PR TITLE
sync-github-releases: split out the target-commitish decision; one-object applyReleasePlan

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -75,7 +75,7 @@ async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> 
   const githubReleases = await ctx.client.list()
   const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
   const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
-  await applyReleasePlan(plan, ctx.client, ctx.defaultBranch, ctx.dryRun)
+  await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
 }
 
 // Read a package's identity (its package.json `name`) and the release notes derived from its

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
@@ -1,49 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { applyReleasePlan, resolveTargetCommitish } from './apply-release-plan.ts'
+import { applyReleasePlan } from './apply-release-plan.ts'
 import type { ReleasePlan } from './release-plan.ts'
 import type { Release, ReleasesClient } from '../utils/github.ts'
 
-describe('resolveTargetCommitish()', () => {
-  const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
-
-  it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deduceCommit: () => null })).toBe('main')
-    // Even for the latest release, an existing tag is fine.
-    expect(resolveTargetCommitish({ ...base, tagExists: true, isLatest: true, deduceCommit: () => null })).toBe('main')
-  })
-
-  it('hard-fails when the latest release has no tag', () => {
-    expect(() =>
-      resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deduceCommit: () => null }),
-    ).toThrow(/latest release must already be tagged/)
-  })
-
-  it('tags an older release at the deduced commit', () => {
-    expect(resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit: () => 'abc123' })).toBe(
-      'abc123',
-    )
-  })
-
-  it('hard-fails when an older release has no tag and no deducible commit', () => {
-    expect(() =>
-      resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit: () => null }),
-    ).toThrow(/couldn't be deduced/)
-  })
-
-  it('only deduces the commit for a backfilled older release (never when the tag exists or it is latest)', () => {
-    const deduceCommit = vi.fn(() => 'abc123')
-    resolveTargetCommitish({ ...base, tagExists: true, isLatest: false, deduceCommit })
-    expect(() => resolveTargetCommitish({ ...base, tagExists: false, isLatest: true, deduceCommit })).toThrow()
-    expect(deduceCommit).not.toHaveBeenCalled()
-
-    resolveTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit })
-    expect(deduceCommit).toHaveBeenCalledOnce()
-  })
-})
-
 describe('applyReleasePlan()', () => {
-  // No creates in the plan, so resolveCreateTarget() (which shells out to git) isn't exercised here.
-  // The dry-run gate is shared by all three actions via applyWrite(), so update + delete prove it.
+  // No creates in the plan, so resolveTargetCommitish() (which shells out to git) isn't exercised
+  // here. The dry-run gate is shared by all three actions via applyWrite(), so update + delete prove it.
   const plan: ReleasePlan = {
     releasesToCreate: [],
     releasesToUpdate: [{ release_id: 1, tag_name: 'v1.0.0', body: 'Fresh notes' }],

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
@@ -35,7 +35,7 @@ describe('applyReleasePlan()', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
     const { client, calls } = createFakeClient()
 
-    await applyReleasePlan(plan, client, 'main', false)
+    await applyReleasePlan({ plan, client, defaultBranch: 'main', dryRun: false })
 
     expect(calls).toEqual(['update:1', 'delete:2'])
     expect(log.mock.calls.flat()).toEqual(['Updated release v1.0.0', 'Deleted release v0.9.0'])
@@ -46,7 +46,7 @@ describe('applyReleasePlan()', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
     const { client, calls } = createFakeClient()
 
-    await applyReleasePlan(plan, client, 'main', true)
+    await applyReleasePlan({ plan, client, defaultBranch: 'main', dryRun: true })
 
     expect(calls).toEqual([])
     expect(log.mock.calls.flat()).toEqual([

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -1,8 +1,7 @@
 export { applyReleasePlan }
-export { resolveTargetCommitish }
 
-import type { ReleasePlan, ReleaseToCreate } from './release-plan.ts'
-import { findReleaseCommit, gitTagExists } from '../utils/git.ts'
+import type { ReleasePlan } from './release-plan.ts'
+import { resolveTargetCommitish } from './target-commitish.ts'
 import type { ReleasesClient } from '../utils/github.ts'
 
 // Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. The
@@ -17,13 +16,13 @@ async function applyReleasePlan(
   for (const release of plan.releasesToCreate) {
     // Resolve (and validate) the tag's commit before the dry-run gate, so a dry run still surfaces a
     // missing-tag failure or a deduced-commit warning.
-    const target_commitish = resolveCreateTarget(release, defaultBranch)
+    const targetCommitish = resolveTargetCommitish(release, defaultBranch)
     await applyWrite(dryRun, 'create', release.tag_name, () =>
       client.create({
         tag_name: release.tag_name,
         name: release.tag_name,
         body: release.body,
-        target_commitish,
+        target_commitish: targetCommitish,
         // Only the newest version may be the repo's "Latest". create-release otherwise defaults
         // make_latest=true, so backfilling an older release while a newer one already exists would
         // wrongly mark the old one Latest.
@@ -54,56 +53,4 @@ async function applyWrite(
   }
   await write()
   console.log(`${pastTense[action]} release ${releaseTag}`)
-}
-
-// The commit a to-be-created release is tagged at. Gathers the git facts and hands them to
-// resolveTargetCommitish(), which owns the decision; deducing the commit (a full-history changelog
-// search) is passed as a thunk so it runs only for the one case that needs it.
-function resolveCreateTarget(release: ReleaseToCreate, defaultBranch: string): string {
-  const { tag_name: releaseTag, version, isLatest } = release
-  return resolveTargetCommitish({
-    releaseTag,
-    isLatest,
-    tagExists: gitTagExists(releaseTag),
-    deduceCommit: () => {
-      const commit = findReleaseCommit(version)
-      if (commit) console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${commit}`)
-      return commit
-    },
-    defaultBranch,
-  })
-}
-
-// The commit a to-be-created release should be tagged at (its `target_commitish`).
-//  - Tag already exists: GitHub uses it and ignores target_commitish — pass the branch as a no-op.
-//  - Tag missing on the latest release: hard fail. The just-released version must already be tagged;
-//    tagging it now would point at the default branch's HEAD (the wrong commit).
-//  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history
-//    (deduceCommit()), or hard fail if it couldn't be deduced — never silently tag the wrong commit.
-function resolveTargetCommitish({
-  releaseTag,
-  tagExists,
-  isLatest,
-  deduceCommit,
-  defaultBranch,
-}: {
-  releaseTag: string
-  tagExists: boolean
-  isLatest: boolean
-  deduceCommit: () => string | null
-  defaultBranch: string
-}): string {
-  if (tagExists) return defaultBranch
-  if (isLatest) {
-    throw new Error(
-      `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
-    )
-  }
-  const deducedCommit = deduceCommit()
-  if (!deducedCommit) {
-    throw new Error(
-      `Refusing to create release ${releaseTag}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
-    )
-  }
-  return deducedCommit
 }

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -7,12 +7,17 @@ import type { ReleasesClient } from '../utils/github.ts'
 // Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. The
 // --dry-run gate lives here rather than in the client, so the client stays a plain transport and each
 // action is logged the same way whether or not it's actually performed.
-async function applyReleasePlan(
-  plan: ReleasePlan,
-  client: ReleasesClient,
-  defaultBranch: string,
-  dryRun: boolean,
-): Promise<void> {
+async function applyReleasePlan({
+  plan,
+  client,
+  defaultBranch,
+  dryRun,
+}: {
+  plan: ReleasePlan
+  client: ReleasesClient
+  defaultBranch: string
+  dryRun: boolean
+}): Promise<void> {
   for (const release of plan.releasesToCreate) {
     // Resolve (and validate) the tag's commit before the dry-run gate, so a dry run still surfaces a
     // missing-tag failure or a deduced-commit warning.

--- a/.github/workflows/sync-github-releases/sync/target-commitish.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/target-commitish.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { decideTargetCommitish } from './target-commitish.ts'
+
+describe('decideTargetCommitish()', () => {
+  const base = { releaseTag: 'v0.4.0', defaultBranch: 'main' }
+
+  it('uses the default branch when the tag already exists (GitHub ignores it)', () => {
+    expect(decideTargetCommitish({ ...base, tagExists: true, isLatest: false, deduceCommit: () => null })).toBe('main')
+    // Even for the latest release, an existing tag is fine.
+    expect(decideTargetCommitish({ ...base, tagExists: true, isLatest: true, deduceCommit: () => null })).toBe('main')
+  })
+
+  it('hard-fails when the latest release has no tag', () => {
+    expect(() =>
+      decideTargetCommitish({ ...base, tagExists: false, isLatest: true, deduceCommit: () => null }),
+    ).toThrow(/latest release must already be tagged/)
+  })
+
+  it('tags an older release at the deduced commit', () => {
+    expect(decideTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit: () => 'abc123' })).toBe(
+      'abc123',
+    )
+  })
+
+  it('hard-fails when an older release has no tag and no deducible commit', () => {
+    expect(() =>
+      decideTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit: () => null }),
+    ).toThrow(/couldn't be deduced/)
+  })
+
+  it('only deduces the commit for a backfilled older release (never when the tag exists or it is latest)', () => {
+    const deduceCommit = vi.fn(() => 'abc123')
+    decideTargetCommitish({ ...base, tagExists: true, isLatest: false, deduceCommit })
+    expect(() => decideTargetCommitish({ ...base, tagExists: false, isLatest: true, deduceCommit })).toThrow()
+    expect(deduceCommit).not.toHaveBeenCalled()
+
+    decideTargetCommitish({ ...base, tagExists: false, isLatest: false, deduceCommit })
+    expect(deduceCommit).toHaveBeenCalledOnce()
+  })
+})

--- a/.github/workflows/sync-github-releases/sync/target-commitish.ts
+++ b/.github/workflows/sync-github-releases/sync/target-commitish.ts
@@ -1,0 +1,59 @@
+export { resolveTargetCommitish }
+export { decideTargetCommitish }
+
+import type { ReleaseToCreate } from './release-plan.ts'
+import { findReleaseCommit, gitTagExists } from '../utils/git.ts'
+
+// The commit a to-be-created release is tagged at (its GitHub `target_commitish`). Gathers the git
+// facts — does the tag already exist, and if not which commit does the changelog history point at —
+// and hands them to decideTargetCommitish(), which owns the decision. Deducing the commit (a
+// full-history changelog search) is passed as a thunk so it runs only for the one case that needs it.
+function resolveTargetCommitish(release: ReleaseToCreate, defaultBranch: string): string {
+  const { tag_name: releaseTag, version, isLatest } = release
+  return decideTargetCommitish({
+    releaseTag,
+    isLatest,
+    tagExists: gitTagExists(releaseTag),
+    deduceCommit: () => {
+      const commit = findReleaseCommit(version)
+      if (commit) console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${commit}`)
+      return commit
+    },
+    defaultBranch,
+  })
+}
+
+// Decide the `target_commitish` from the given facts (pure — all git access is injected, so this is
+// the part worth unit-testing):
+//  - Tag already exists: GitHub uses it and ignores target_commitish — pass the branch as a no-op.
+//  - Tag missing on the latest release: hard fail. The just-released version must already be tagged;
+//    tagging it now would point at the default branch's HEAD (the wrong commit).
+//  - Tag missing on an older (backfilled) release: tag the commit deduced from the changelog history
+//    (deduceCommit()), or hard fail if it couldn't be deduced — never silently tag the wrong commit.
+function decideTargetCommitish({
+  releaseTag,
+  tagExists,
+  isLatest,
+  deduceCommit,
+  defaultBranch,
+}: {
+  releaseTag: string
+  tagExists: boolean
+  isLatest: boolean
+  deduceCommit: () => string | null
+  defaultBranch: string
+}): string {
+  if (tagExists) return defaultBranch
+  if (isLatest) {
+    throw new Error(
+      `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
+    )
+  }
+  const deducedCommit = deduceCommit()
+  if (!deducedCommit) {
+    throw new Error(
+      `Refusing to create release ${releaseTag}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
+    )
+  }
+  return deducedCommit
+}


### PR DESCRIPTION
Two focused refactors of `sync-github-releases`, each its own commit. Behaviour is unchanged — all 24 unit tests, `tsc`, and Prettier stay green.

I first read every file/function/spec in the module and rated them; the module is already very polished (mostly 8–9), with one clear outlier: `sync/apply-release-plan.ts` carried **two** abstractions and a boolean-trap signature. These two commits address exactly that, without churning the parts that were already good.

### 1. Give the target-commitish decision its own module
`apply-release-plan.ts` mixed *walking the plan* (create → update → delete, dry-run gate, logging) with *deciding which commit a to-be-created release is tagged at* — the trickiest domain logic in the module (it carries the most spec coverage). Moved it to `sync/target-commitish.ts` with its own spec, so each file is one abstraction. Renamed the confusingly-near pair so the two no longer read alike:
- `resolveTargetCommitish` — the impure entry that gathers the git facts (was `resolveCreateTarget`)
- `decideTargetCommitish` — the pure decision over those facts (was `resolveTargetCommitish`)

"resolve" now consistently means *do the git IO*, "decide" means *pure branching over given facts*.

### 2. `applyReleasePlan` takes one options object
The positional signature ended in a boolean trap: `applyReleasePlan(plan, client, 'main', true)` gave no hint that the trailing `true` meant dry-run. Switched to a single options object, matching `getReleasePlan()` and `createReleasesClient()` which already read that way, so every call site names what it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRKwu7EcnnViqrWtCoSUch)_