### PR TITLE
sync-github-releases: sharper module boundaries (client/env split, per-package module, env→client facade)

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all.ts
+++ b/.github/workflows/sync-github-releases/delete-all.ts
@@ -3,7 +3,8 @@
 
 main()
 
-import { createReleasesClient, getGithubToken, getRepository } from './utils/github.ts'
+import { createReleasesClient } from './utils/github.ts'
+import { getGithubToken, getRepository } from './utils/github-env.ts'
 
 async function main() {
   const { owner, repo } = getRepository()

--- a/.github/workflows/sync-github-releases/delete-all.ts
+++ b/.github/workflows/sync-github-releases/delete-all.ts
@@ -3,12 +3,10 @@
 
 main()
 
-import { createReleasesClient } from './utils/github.ts'
-import { getGithubToken, getRepository } from './utils/github-env.ts'
+import { createReleasesClientFromEnv } from './utils/github-env.ts'
 
 async function main() {
-  const { owner, repo } = getRepository()
-  const client = createReleasesClient({ owner, repo, token: getGithubToken() })
+  const { client, owner, repo } = createReleasesClientFromEnv()
 
   console.log(`Fetching releases for ${owner}/${repo} …`)
   const githubReleases = await client.list()

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -3,14 +3,9 @@
 
 main()
 
-import { readFile } from 'node:fs/promises'
-import path from 'node:path'
-import { applyReleasePlan } from './sync/apply-release-plan.ts'
-import { getReleasePlan } from './sync/release-plan.ts'
-import { getTagScheme } from './sync/tag-scheme.ts'
-import { getReleaseNotesByVersion, type ReleaseNotesByVersion } from './utils/changelog.ts'
+import { syncPackage, type SyncContext } from './sync/sync-package.ts'
 import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
-import { createReleasesClient, type ReleasesClient } from './utils/github.ts'
+import { createReleasesClient } from './utils/github.ts'
 import { getDefaultBranch, getGithubToken, getRepository } from './utils/github-env.ts'
 
 async function main(): Promise<void> {
@@ -32,14 +27,13 @@ async function main(): Promise<void> {
     console.log('No CHANGELOG.md changes detected — nothing to sync.')
     return
   }
-  const hasMultiplePackages = allPackageDirs.length > 1
 
   const { owner, repo } = getRepository()
   const defaultBranch = getDefaultBranch()
   const context: SyncContext = {
     client: createReleasesClient({ owner, repo, token: getGithubToken() }),
     defaultBranch,
-    hasMultiplePackages,
+    hasMultiplePackages: allPackageDirs.length > 1,
     dryRun,
     // The base of the GitHub web (blob) URL each release's CHANGELOG.md footer links back to —
     // github.com is the web host, distinct from the API the client talks to.
@@ -50,44 +44,6 @@ async function main(): Promise<void> {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)
     await syncPackage(packageDir, context)
   }
-}
-
-// The loop-invariant inputs of a sync run, built once and shared across packages. owner/repo aren't
-// here: the client already binds them, and the changelog URL base bakes them in.
-type SyncContext = {
-  client: ReleasesClient
-  defaultBranch: string
-  hasMultiplePackages: boolean
-  dryRun: boolean
-  changelogUrlBase: string
-}
-
-async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
-  // The releases the package's CHANGELOG.md (the source of truth) says should exist …
-  const { packageName, releaseNotesByVersion } = await readPackageReleaseNotes(packageDir, ctx.changelogUrlBase)
-  // … reconciled against the releases currently on GitHub, using this package's tag scheme to match
-  // and name release tags.
-  const githubReleases = await ctx.client.list()
-  const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
-  const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
-  await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
-}
-
-// Read a package's identity (its package.json `name`) and the release notes derived from its
-// CHANGELOG.md — keyed by version, each carrying a footer that links back to the changelog on GitHub.
-async function readPackageReleaseNotes(
-  packageDir: string,
-  changelogUrlBase: string,
-): Promise<{ packageName: string; releaseNotesByVersion: ReleaseNotesByVersion }> {
-  const packageDirPath = path.join(process.cwd(), packageDir)
-  const { name: packageName } = JSON.parse(await readFile(path.join(packageDirPath, 'package.json'), 'utf8')) as {
-    name: string
-  }
-  const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
-
-  // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
-  const changelogUrl = `${changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
-  return { packageName, releaseNotesByVersion: getReleaseNotesByVersion(changelog, changelogUrl) }
 }
 
 // Which package directories to sync, in priority order:

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -10,13 +10,8 @@ import { getReleasePlan } from './sync/release-plan.ts'
 import { getTagScheme } from './sync/tag-scheme.ts'
 import { getReleaseNotesByVersion, type ReleaseNotesByVersion } from './utils/changelog.ts'
 import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
-import {
-  createReleasesClient,
-  getDefaultBranch,
-  getGithubToken,
-  getRepository,
-  type ReleasesClient,
-} from './utils/github.ts'
+import { createReleasesClient, type ReleasesClient } from './utils/github.ts'
+import { getDefaultBranch, getGithubToken, getRepository } from './utils/github-env.ts'
 
 async function main(): Promise<void> {
   // The package.json scripts run from this folder; switch to the repo root so the git commands and

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -5,8 +5,7 @@ main()
 
 import { syncPackage, type SyncContext } from './sync/sync-package.ts'
 import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
-import { createReleasesClient } from './utils/github.ts'
-import { getDefaultBranch, getGithubToken, getRepository } from './utils/github-env.ts'
+import { createReleasesClientFromEnv, getDefaultBranch } from './utils/github-env.ts'
 
 async function main(): Promise<void> {
   // The package.json scripts run from this folder; switch to the repo root so the git commands and
@@ -28,10 +27,10 @@ async function main(): Promise<void> {
     return
   }
 
-  const { owner, repo } = getRepository()
+  const { client, owner, repo } = createReleasesClientFromEnv()
   const defaultBranch = getDefaultBranch()
   const context: SyncContext = {
-    client: createReleasesClient({ owner, repo, token: getGithubToken() }),
+    client,
     defaultBranch,
     hasMultiplePackages: allPackageDirs.length > 1,
     dryRun,

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -1,0 +1,50 @@
+export { syncPackage }
+export type { SyncContext }
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { applyReleasePlan } from './apply-release-plan.ts'
+import { getReleasePlan } from './release-plan.ts'
+import { getTagScheme } from './tag-scheme.ts'
+import { getReleaseNotesByVersion, type ReleaseNotesByVersion } from '../utils/changelog.ts'
+import type { ReleasesClient } from '../utils/github.ts'
+
+// The loop-invariant inputs of a sync run, built once and shared across packages. owner/repo aren't
+// here: the client already binds them, and the changelog URL base bakes them in.
+type SyncContext = {
+  client: ReleasesClient
+  defaultBranch: string
+  hasMultiplePackages: boolean
+  dryRun: boolean
+  changelogUrlBase: string
+}
+
+// Sync one package: derive its expected releases from CHANGELOG.md (the source of truth), reconcile
+// them against the package's existing GitHub Releases into a plan, then apply that plan.
+async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
+  // The releases the package's CHANGELOG.md (the source of truth) says should exist …
+  const { packageName, releaseNotesByVersion } = await readPackageReleaseNotes(packageDir, ctx.changelogUrlBase)
+  // … reconciled against the releases currently on GitHub, using this package's tag scheme to match
+  // and name release tags.
+  const githubReleases = await ctx.client.list()
+  const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
+  const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
+  await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
+}
+
+// Read a package's identity (its package.json `name`) and the release notes derived from its
+// CHANGELOG.md — keyed by version, each carrying a footer that links back to the changelog on GitHub.
+async function readPackageReleaseNotes(
+  packageDir: string,
+  changelogUrlBase: string,
+): Promise<{ packageName: string; releaseNotesByVersion: ReleaseNotesByVersion }> {
+  const packageDirPath = path.join(process.cwd(), packageDir)
+  const { name: packageName } = JSON.parse(await readFile(path.join(packageDirPath, 'package.json'), 'utf8')) as {
+    name: string
+  }
+  const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
+
+  // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
+  const changelogUrl = `${changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
+  return { packageName, releaseNotesByVersion: getReleaseNotesByVersion(changelog, changelogUrl) }
+}

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -1,14 +1,23 @@
-export { getGithubToken }
+export { createReleasesClientFromEnv }
 export { getDefaultBranch }
-export { getRepository }
 
 import assert from 'node:assert'
 import { git } from './git.ts'
+import { createReleasesClient, type ReleasesClient } from './github.ts'
 
 // How a run discovers what to act on, as whom, and against which branch: the repository, the auth
 // token, and the default branch — read from the GitHub Actions environment, with fallbacks for local
 // runs. Kept apart from the API client (github.ts), which is pure transport and shouldn't care where
 // these values come from.
+
+// A GitHub Releases client for the repository this run targets, wired up from the environment. Returns
+// the resolved owner/repo too — callers need them for the web links and log lines that the client
+// (pure transport) doesn't expose.
+function createReleasesClientFromEnv(): { client: ReleasesClient; owner: string; repo: string } {
+  const { owner, repo } = getRepository()
+  const client = createReleasesClient({ owner, repo, token: getGithubToken() })
+  return { client, owner, repo }
+}
 
 function getGithubToken(): string {
   const token = process.env.GITHUB_TOKEN

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -1,0 +1,38 @@
+export { getGithubToken }
+export { getDefaultBranch }
+export { getRepository }
+
+import assert from 'node:assert'
+import { git } from './git.ts'
+
+// How a run discovers what to act on, as whom, and against which branch: the repository, the auth
+// token, and the default branch — read from the GitHub Actions environment, with fallbacks for local
+// runs. Kept apart from the API client (github.ts), which is pure transport and shouldn't care where
+// these values come from.
+
+function getGithubToken(): string {
+  const token = process.env.GITHUB_TOKEN
+  if (!token) {
+    throw new Error('GITHUB_TOKEN must be set — see README.md')
+  }
+  return token
+}
+
+function getDefaultBranch(): string {
+  return process.env.GITHUB_DEFAULT_BRANCH ?? 'main'
+}
+
+function getRepository(): { owner: string; repo: string } {
+  const repository = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
+  const [owner, repo] = repository.split('/')
+  assert(owner && repo, `Invalid GITHUB_REPOSITORY value: ${repository}`)
+  return { owner, repo }
+}
+
+function getRepositoryFromGit(): string {
+  const url = git(['remote', 'get-url', 'origin']).trim()
+  // Handles both https://github.com/owner/repo.git and git@github.com:owner/repo.git
+  const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/)
+  assert(match, `Cannot parse GitHub repository from git remote: ${url}`)
+  return match[1]
+}

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -1,13 +1,8 @@
 export { createReleasesClient }
-export { getGithubToken }
-export { getDefaultBranch }
-export { getRepository }
 export type { Release }
 export type { ReleasesClient }
 
-import assert from 'node:assert'
 import { setTimeout } from 'node:timers/promises'
-import { git } from './git.ts'
 
 // The fields we use of a GitHub Release (https://docs.github.com/en/rest/releases/releases).
 type Release = {
@@ -104,31 +99,4 @@ function createReleasesClient({ owner, repo, token }: { owner: string; repo: str
       return request(`${releasesPath}/${releaseId}`, { method: 'DELETE' })
     },
   }
-}
-
-function getGithubToken(): string {
-  const token = process.env.GITHUB_TOKEN
-  if (!token) {
-    throw new Error('GITHUB_TOKEN must be set — see README.md')
-  }
-  return token
-}
-
-function getDefaultBranch(): string {
-  return process.env.GITHUB_DEFAULT_BRANCH ?? 'main'
-}
-
-function getRepository(): { owner: string; repo: string } {
-  const repository = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
-  const [owner, repo] = repository.split('/')
-  assert(owner && repo, `Invalid GITHUB_REPOSITORY value: ${repository}`)
-  return { owner, repo }
-}
-
-function getRepositoryFromGit(): string {
-  const url = git(['remote', 'get-url', 'origin']).trim()
-  // Handles both https://github.com/owner/repo.git and git@github.com:owner/repo.git
-  const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/)
-  assert(match, `Cannot parse GitHub repository from git remote: ${url}`)
-  return match[1]
 }


### PR DESCRIPTION
Three focused refactors that tighten the abstractions of the `sync-github-releases` tooling. No behavior change — purely structural.

### 1. Split the API client from environment resolution
`utils/github.ts` bundled two concerns: the GitHub Releases API **client** (pure transport) and the resolution of *which* repository / token / default branch to act on (read from the environment). The latter even dragged a `git` import into the transport file. Moved the env getters into `utils/github-env.ts`; `github.ts` is now the client alone, with **zero internal dependencies**.

### 2. Extract the per-package sync into its own module
`sync.ts` mixed two altitudes: the run **driver** (parse CLI, pick packages, build the shared context, loop) and the per-package **algorithm** (read package → list releases → plan → apply). Moved the algorithm — `syncPackage`, `readPackageReleaseNotes`, and the `SyncContext` it consumes — into `sync/sync-package.ts`, alongside the plan/apply/tag-scheme steps it orchestrates. `sync.ts` is now just the driver.

### 3. One env→client facade for both entry points
`sync.ts` and `delete-all.ts` each hand-wired the same `getRepository() + getGithubToken() + createReleasesClient()` sequence. Folded it into `createReleasesClientFromEnv()` in `github-env.ts`, which returns the client plus the resolved `owner`/`repo` callers need for links and logs. `getGithubToken`/`getRepository` are now module-private.

### Result
Cleanly layered, acyclic dependency graph: drivers → algorithm (`sync/`) → utils. Every source file is now ≤102 lines and single-purpose.

### Verification
- ✅ 24 unit tests pass (`vitest`)
- ✅ `tsc --noEmit` clean
- ✅ prettier clean
- ✅ runtime smoke test: both entry points execute end-to-end and fail exactly at the `GITHUB_TOKEN` guard as designed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzWAnK3vELz4jcwXXEByHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzWAnK3vELz4jcwXXEByHQ)_