### PR TITLE
sync-github-releases: sharpen the env/git/transport boundaries

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -4,8 +4,8 @@
 main()
 
 import { syncPackage, type SyncContext } from './sync/sync-package.ts'
-import { getPushedFiles, getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
-import { createReleasesClientFromEnv, getDefaultBranch } from './utils/github-env.ts'
+import { getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
+import { createReleasesClientFromEnv, getDefaultBranch, getPushedFiles } from './utils/github-env.ts'
 
 async function main(): Promise<void> {
   // The package.json scripts run from this folder; switch to the repo root so the git commands and

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -22,9 +22,11 @@ type SyncContext = {
 // Sync one package: derive its expected releases from CHANGELOG.md (the source of truth), reconcile
 // them against the package's existing GitHub Releases into a plan, then apply that plan.
 async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
-  // The releases the package's CHANGELOG.md (the source of truth) says should exist …
-  const { packageName, releaseNotesByVersion } = await readPackageReleaseNotes(packageDir, ctx.changelogUrlBase)
-  // … reconciled against the releases currently on GitHub, using this package's tag scheme to match
+  // What the package's files on disk say: its npm name (to name and match its release tags) and the
+  // releases its CHANGELOG.md (the source of truth) says should exist.
+  const packageName = await readPackageName(packageDir)
+  const releaseNotesByVersion = await readReleaseNotes(packageDir, ctx.changelogUrlBase)
+  // Reconcile those against the releases currently on GitHub, using this package's tag scheme to match
   // and name release tags.
   const githubReleases = await ctx.client.list()
   const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
@@ -32,19 +34,17 @@ async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> 
   await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
 }
 
-// Read a package's identity (its package.json `name`) and the release notes derived from its
-// CHANGELOG.md — keyed by version, each carrying a footer that links back to the changelog on GitHub.
-async function readPackageReleaseNotes(
-  packageDir: string,
-  changelogUrlBase: string,
-): Promise<{ packageName: string; releaseNotesByVersion: ReleaseNotesByVersion }> {
-  const packageDirPath = path.join(process.cwd(), packageDir)
-  const { name: packageName } = JSON.parse(await readFile(path.join(packageDirPath, 'package.json'), 'utf8')) as {
-    name: string
-  }
-  const changelog = await readFile(path.join(packageDirPath, 'CHANGELOG.md'), 'utf8')
+// A package's npm name (its package.json `name`) — used to name and recognize its release tags.
+async function readPackageName(packageDir: string): Promise<string> {
+  const { name } = JSON.parse(await readFile(path.resolve(packageDir, 'package.json'), 'utf8')) as { name: string }
+  return name
+}
 
+// The release notes derived from a package's CHANGELOG.md (the source of truth), keyed by version,
+// each carrying a footer that links back to the changelog on GitHub.
+async function readReleaseNotes(packageDir: string, changelogUrlBase: string): Promise<ReleaseNotesByVersion> {
+  const changelog = await readFile(path.resolve(packageDir, 'CHANGELOG.md'), 'utf8')
   // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
   const changelogUrl = `${changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
-  return { packageName, releaseNotesByVersion: getReleaseNotesByVersion(changelog, changelogUrl) }
+  return getReleaseNotesByVersion(changelog, changelogUrl)
 }

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -1,13 +1,16 @@
+// Local git plumbing — runs the `git` CLI and shapes its output (e.g. turning its file lists into
+// package dirs). Knows nothing of the GitHub Actions environment (github-env.ts) nor the GitHub API
+// (github.ts).
+
 export { git }
+export { gitLines }
 export { getRepoRoot }
 export { gitTagExists }
 export { findReleaseCommit }
 export { getTrackedChangelogFiles }
-export { getPushedFiles }
 export { toPackageDirs }
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 function git(args: string[]): string {
@@ -31,27 +34,6 @@ function toPackageDirs(files: string[]): string[] {
     .filter((file) => path.posix.basename(file) === 'CHANGELOG.md')
     .map((file) => path.posix.dirname(file))
   return [...new Set(packageDirs)]
-}
-
-function getPushedFiles(): string[] | null {
-  if (process.env.GITHUB_EVENT_NAME !== 'push') return null
-  const beforeSha = getCommitBeforePush()
-  const headSha = process.env.GITHUB_SHA
-  if (!beforeSha || !headSha) return null
-  // The SHAs are passed as argv (git() uses no shell), so they can't cause injection.
-  return gitLines(['diff', '--name-only', beforeSha, headSha])
-}
-
-// The commit the branch pointed at before the push (`github.event.before`). GitHub Actions writes the
-// triggering event's payload to the file at GITHUB_EVENT_PATH.
-function getCommitBeforePush(): string | null {
-  const eventPath = process.env.GITHUB_EVENT_PATH
-  if (!eventPath) return null
-  const event = JSON.parse(readFileSync(eventPath, 'utf8')) as { before?: string }
-  const beforeSha = event.before
-  // GitHub uses an all-zero SHA when there's no prior commit (e.g. a branch's first push).
-  if (!beforeSha || /^0+$/.test(beforeSha)) return null
-  return beforeSha
 }
 
 function getTrackedChangelogFiles(): string[] {

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -17,7 +17,7 @@ import { createReleasesClient, type ReleasesClient } from './github.ts'
 // (pure transport) doesn't expose.
 function createReleasesClientFromEnv(): { client: ReleasesClient; owner: string; repo: string } {
   const { owner, repo } = getRepository()
-  const client = createReleasesClient({ owner, repo, token: getGithubToken() })
+  const client = createReleasesClient({ owner, repo, token: getGithubToken(), apiUrl: getApiUrl() })
   return { client, owner, repo }
 }
 
@@ -27,6 +27,12 @@ function getGithubToken(): string {
     throw new Error('GITHUB_TOKEN must be set — see README.md')
   }
   return token
+}
+
+// The GitHub REST API base URL. GITHUB_API_URL is provided on GitHub Actions (and points at the right
+// host on GitHub Enterprise); fall back to the public API for local runs.
+function getApiUrl(): string {
+  return process.env.GITHUB_API_URL ?? 'https://api.github.com'
 }
 
 function getDefaultBranch(): string {

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -1,14 +1,16 @@
 export { createReleasesClientFromEnv }
 export { getDefaultBranch }
+export { getPushedFiles }
 
 import assert from 'node:assert'
-import { git } from './git.ts'
+import { readFileSync } from 'node:fs'
+import { git, gitLines } from './git.ts'
 import { createReleasesClient, type ReleasesClient } from './github.ts'
 
 // How a run discovers what to act on, as whom, and against which branch: the repository, the auth
-// token, and the default branch — read from the GitHub Actions environment, with fallbacks for local
-// runs. Kept apart from the API client (github.ts), which is pure transport and shouldn't care where
-// these values come from.
+// token, the default branch, and — on a push — which files changed. All read from the GitHub Actions
+// environment, with fallbacks for local runs. Kept apart from the API client (github.ts), which is
+// pure transport and shouldn't care where these values come from.
 
 // A GitHub Releases client for the repository this run targets, wired up from the environment. Returns
 // the resolved owner/repo too — callers need them for the web links and log lines that the client
@@ -44,4 +46,27 @@ function getRepositoryFromGit(): string {
   const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/)
   assert(match, `Cannot parse GitHub repository from git remote: ${url}`)
   return match[1]
+}
+
+// The files the triggering push changed, or null when this isn't a push (manual workflow_dispatch, or
+// a local run) — the caller then falls back to syncing every package.
+function getPushedFiles(): string[] | null {
+  if (process.env.GITHUB_EVENT_NAME !== 'push') return null
+  const beforeSha = getCommitBeforePush()
+  const headSha = process.env.GITHUB_SHA
+  if (!beforeSha || !headSha) return null
+  // The SHAs are passed as argv (git() uses no shell), so they can't cause injection.
+  return gitLines(['diff', '--name-only', beforeSha, headSha])
+}
+
+// The commit the branch pointed at before the push (`github.event.before`). GitHub Actions writes the
+// triggering event's payload to the file at GITHUB_EVENT_PATH.
+function getCommitBeforePush(): string | null {
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  if (!eventPath) return null
+  const event = JSON.parse(readFileSync(eventPath, 'utf8')) as { before?: string }
+  const beforeSha = event.before
+  // GitHub uses an all-zero SHA when there's no prior commit (e.g. a branch's first push).
+  if (!beforeSha || /^0+$/.test(beforeSha)) return null
+  return beforeSha
 }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -19,9 +19,9 @@ type NewRelease = {
   make_latest: 'true' | 'false'
 }
 
-// A client for one repository's GitHub Releases. It binds the owner/repo/token once, so callers just
-// say what to do — not where, nor as whom. It's a plain transport: skipping writes under --dry-run is
-// the apply step's job (see applyReleasePlan()).
+// A client for one repository's GitHub Releases. It binds the owner/repo/token and API base URL once,
+// so callers just say what to do — not where, nor as whom. It's a plain transport: skipping writes
+// under --dry-run is the apply step's job (see applyReleasePlan()).
 type ReleasesClient = {
   list(): Promise<Release[]>
   create(release: NewRelease): Promise<void>
@@ -29,13 +29,17 @@ type ReleasesClient = {
   delete(releaseId: number): Promise<void>
 }
 
-const API_URL = process.env.GITHUB_API_URL ?? 'https://api.github.com'
 // Pause between write requests so bursts (e.g. backfilling many releases) stay under GitHub's
 // secondary rate limit — its burst/concurrency limit, separate from the hourly primary quota.
 // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 const RATE_LIMIT_DELAY_MS = 500
 
-function createReleasesClient({ owner, repo, token }: { owner: string; repo: string; token: string }): ReleasesClient {
+function createReleasesClient({
+  owner,
+  repo,
+  token,
+  apiUrl,
+}: { owner: string; repo: string; token: string; apiUrl: string }): ReleasesClient {
   const releasesPath = `/repos/${owner}/${repo}/releases`
   // Writes performed so far, to delay only *between* them (not before the first, nor after reads).
   let writeCount = 0
@@ -52,7 +56,7 @@ function createReleasesClient({ owner, repo, token }: { owner: string; repo: str
       writeCount++
     }
 
-    const response = await fetch(new URL(pathname, API_URL), {
+    const response = await fetch(new URL(pathname, apiUrl), {
       method,
       headers: {
         Accept: 'application/vnd.github+json',


### PR DESCRIPTION
Three small, behavior-preserving refactors of the `sync-github-releases` tool. The headline is one cross-cutting cleanup: **`github-env.ts` should own every read of the GitHub Actions environment**, leaving `git.ts` as pure local-git plumbing and `github.ts` as pure transport. Before this, `process.env.GITHUB_*` was read in three modules; now it's read in one.

### 1. `github-env` owns the push-event environment reads
`getPushedFiles()` / `getCommitBeforePush()` read `GITHUB_EVENT_NAME`, `GITHUB_SHA`, `GITHUB_EVENT_PATH` — they belong next to the other `GITHUB_*` reads, not in `git.ts`. Moving them leaves every remaining `git.ts` function shelling git directly (or shaping its output), with no environment knowledge. `gitLines()` is now exported for the moved diff call.

### 2. `github-env` owns the API base URL; `github.ts` is pure transport
`github.ts` documents itself as a plain transport, yet read `GITHUB_API_URL` at module scope — the last env coupling left over from splitting the client from environment resolution. The base URL is now resolved in `github-env.ts` (alongside repo/token/branch) and passed in, exactly like the repo and token. `github.ts` now touches no `process.env` at all.

### 3. Split the per-package disk reads into single-purpose readers
`readPackageReleaseNotes()` did two unrelated jobs under a name that advertised one: it read the package.json `name` (feeds the tag scheme) and the CHANGELOG.md notes (feed the plan). Split into `readPackageName()` and `readReleaseNotes()`, each named for the single value it returns, so `syncPackage()` reads as a plain sequence of its inputs. Along the way `path.resolve(packageDir, file)` replaces `path.join(process.cwd(), packageDir, file)` — identical result, no intermediate path or explicit `process.cwd()`.

### Verification
- `tsc --noEmit` clean
- `biome check` clean
- 24/24 unit tests pass (unchanged)
- Runtime smoke-checked the full module graph loads, the moved `getPushedFiles()` returns `null` off-CI as before, the client still constructs from env, and the new `path.resolve` reads resolve byte-identically to the old paths against the real repo.

No behavior change — purely module boundaries, naming, and DRYing of the env reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1WvPSyKmcFJH6TA3eDkMP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1WvPSyKmcFJH6TA3eDkMP)_