### PR TITLE
sync-github-releases: DRY + tighter abstraction pass

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -3,7 +3,7 @@
 
 main()
 
-import { syncPackage, type SyncContext } from './sync/sync-package.ts'
+import { createSyncContext, syncPackage } from './sync/sync-package.ts'
 import { getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
 import { createReleasesClientFromEnv, getDefaultBranch, getPushedFiles } from './utils/github-env.ts'
 
@@ -28,16 +28,14 @@ async function main(): Promise<void> {
   }
 
   const { client, owner, repo } = createReleasesClientFromEnv()
-  const defaultBranch = getDefaultBranch()
-  const context: SyncContext = {
+  const context = createSyncContext({
     client,
-    defaultBranch,
+    owner,
+    repo,
+    defaultBranch: getDefaultBranch(),
     hasMultiplePackages: allPackageDirs.length > 1,
     dryRun,
-    // The base of the GitHub web (blob) URL each release's CHANGELOG.md footer links back to —
-    // github.com is the web host, distinct from the API the client talks to.
-    changelogUrlBase: `https://github.com/${owner}/${repo}/blob/${defaultBranch}`,
-  }
+  })
 
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -1,4 +1,5 @@
 export { syncPackage }
+export { createSyncContext }
 export type { SyncContext }
 
 import { readFile } from 'node:fs/promises'
@@ -17,6 +18,34 @@ type SyncContext = {
   hasMultiplePackages: boolean
   dryRun: boolean
   changelogUrlBase: string
+}
+
+// Assemble the context from a run's resolved facts. Co-located with SyncContext so its one derived
+// field — the base of the GitHub web (blob) URL each release's CHANGELOG.md footer links back to — is
+// built where the type lives, not in the entry script. github.com is the web host, distinct from the
+// API the client talks to.
+function createSyncContext({
+  client,
+  owner,
+  repo,
+  defaultBranch,
+  hasMultiplePackages,
+  dryRun,
+}: {
+  client: ReleasesClient
+  owner: string
+  repo: string
+  defaultBranch: string
+  hasMultiplePackages: boolean
+  dryRun: boolean
+}): SyncContext {
+  return {
+    client,
+    defaultBranch,
+    hasMultiplePackages,
+    dryRun,
+    changelogUrlBase: `https://github.com/${owner}/${repo}/blob/${defaultBranch}`,
+  }
 }
 
 // Sync one package: derive its expected releases from CHANGELOG.md (the source of truth), reconcile

--- a/.github/workflows/sync-github-releases/sync/target-commitish.ts
+++ b/.github/workflows/sync-github-releases/sync/target-commitish.ts
@@ -44,16 +44,16 @@ function decideTargetCommitish({
   defaultBranch: string
 }): string {
   if (tagExists) return defaultBranch
+  // Both refusals open the same way; only the reason they can't proceed differs.
+  const refusal = `Refusing to create release ${releaseTag}: its git tag is missing`
   if (isLatest) {
     throw new Error(
-      `Refusing to create release ${releaseTag}: its git tag is missing. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
+      `${refusal}. The latest release must already be tagged — creating it now would tag the wrong commit (the default branch's HEAD).`,
     )
   }
   const deducedCommit = deduceCommit()
   if (!deducedCommit) {
-    throw new Error(
-      `Refusing to create release ${releaseTag}: its git tag is missing and its release commit couldn't be deduced from the changelog history.`,
-    )
+    throw new Error(`${refusal} and its release commit couldn't be deduced from the changelog history.`)
   }
   return deducedCommit
 }

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -13,6 +13,9 @@ export { toPackageDirs }
 import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 
+// Matches any CHANGELOG.md at any depth — git pathspecs aren't anchored to the repo root.
+const CHANGELOG_PATHSPEC = '*CHANGELOG.md'
+
 function git(args: string[]): string {
   return execFileSync('git', args, { encoding: 'utf8' })
 }
@@ -37,8 +40,7 @@ function toPackageDirs(files: string[]): string[] {
 }
 
 function getTrackedChangelogFiles(): string[] {
-  // `*CHANGELOG.md` matches at any depth — git pathspecs aren't anchored to the repo root.
-  return gitLines(['ls-files', '--', '*CHANGELOG.md'])
+  return gitLines(['ls-files', '--', CHANGELOG_PATHSPEC])
 }
 
 function gitTagExists(releaseTag: string): boolean {
@@ -55,5 +57,5 @@ function gitTagExists(releaseTag: string): boolean {
 // its tag belongs. Pickaxe (`-S`, a literal-string search) the changelog history for the heading's
 // link opener `[<version>](`; the oldest commit that changed its count is the one that added it.
 function findReleaseCommit(version: string): string | null {
-  return gitLines(['log', '--reverse', '--format=%H', `-S[${version}](`, '--', '*CHANGELOG.md'])[0] ?? null
+  return gitLines(['log', '--reverse', '--format=%H', `-S[${version}](`, '--', CHANGELOG_PATHSPEC])[0] ?? null
 }

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -40,9 +40,10 @@ function getDefaultBranch(): string {
 }
 
 function getRepository(): { owner: string; repo: string } {
+  // Either source can be malformed, so keep the message source-neutral (it isn't always GITHUB_REPOSITORY).
   const repository = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
   const [owner, repo] = repository.split('/')
-  assert(owner && repo, `Invalid GITHUB_REPOSITORY value: ${repository}`)
+  assert(owner && repo, `Cannot parse owner/repo from repository: ${repository}`)
   return { owner, repo }
 }
 


### PR DESCRIPTION
A focused scrutiny pass over `.github/workflows/sync-github-releases/`. The module was already in good shape, so these are surgical, each in its own commit. All 24 unit tests pass, `tsc` is clean, and the changed files are Prettier-clean (3.8.3, the pinned version).

### Commits

1. **name the repeated `*CHANGELOG.md` git pathspec** — the same pathspec was spelled out verbatim in `getTrackedChangelogFiles()` and `findReleaseCommit()`. Lifted to a `CHANGELOG_PATHSPEC` constant so the two `git` invocations can't drift, and moved the "matches at any depth" note onto the constant it explains.

2. **source-neutral repository-parse error** — `getRepository()` resolves owner/repo from `GITHUB_REPOSITORY` *or*, failing that, the git remote, but its assert message blamed `GITHUB_REPOSITORY` unconditionally — misleading when the value actually came from a malformed git remote. Reworded source-neutrally, matching `getRepositoryFromGit()`'s own message.

3. **DRY the missing-tag refusal message** — both refusals in `decideTargetCommitish()` opened with the identical `Refusing to create release <tag>: its git tag is missing` stem. Bound it once so each throw states only how it differs (the latest-release hard stop vs. the un-deducible older commit).

4. **give `SyncContext` its own constructor** — the type is declared in `sync-package.ts` but was assembled inline in the `sync.ts` entry point, which had to spell out the GitHub web (blob) URL the changelog footers link back to. Moved that into a `createSyncContext()` factory beside the type, so the one derived field is built where the type lives and `main()` reads as a flat sequence of steps with no URL plumbing.

### Verification

- `vitest run` → 24 passed
- `tsc --noEmit` → clean
- end-to-end smoke run of `sync.ts --dry-run` exercises the changed `git ls-files` pathspec and `getRepository()` paths; the new error message was confirmed against a malformed `GITHUB_REPOSITORY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbFYoELL8Y8yzZMNDBgjdz)_