### PR TITLE
Remove explanatory comments from sync workflow scripts

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -12,7 +12,6 @@ async function main(): Promise<void> {
   // package-dir paths below resolve against it.
   process.chdir(getRepoRoot())
 
-  // CLI args: an optional `--dry-run` flag, plus any number of explicit <package-dir> positionals.
   const args = process.argv.slice(2)
   const dryRun = args.includes('--dry-run')
   const explicitPackageDirs = args.filter((arg) => !arg.startsWith('--'))

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -20,10 +20,6 @@ type SyncContext = {
   changelogUrlBase: string
 }
 
-// Assemble the context from a run's resolved facts. Co-located with SyncContext so its one derived
-// field — the base of the GitHub web (blob) URL each release's CHANGELOG.md footer links back to — is
-// built where the type lives, not in the entry script. github.com is the web host, distinct from the
-// API the client talks to.
 function createSyncContext({
   client,
   owner,
@@ -51,26 +47,19 @@ function createSyncContext({
 // Sync one package: derive its expected releases from CHANGELOG.md (the source of truth), reconcile
 // them against the package's existing GitHub Releases into a plan, then apply that plan.
 async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
-  // What the package's files on disk say: its npm name (to name and match its release tags) and the
-  // releases its CHANGELOG.md (the source of truth) says should exist.
   const packageName = await readPackageName(packageDir)
   const releaseNotesByVersion = await readReleaseNotes(packageDir, ctx.changelogUrlBase)
-  // Reconcile those against the releases currently on GitHub, using this package's tag scheme to match
-  // and name release tags.
   const githubReleases = await ctx.client.list()
   const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
   const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
   await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
 }
 
-// A package's npm name (its package.json `name`) — used to name and recognize its release tags.
 async function readPackageName(packageDir: string): Promise<string> {
   const { name } = JSON.parse(await readFile(path.resolve(packageDir, 'package.json'), 'utf8')) as { name: string }
   return name
 }
 
-// The release notes derived from a package's CHANGELOG.md (the source of truth), keyed by version,
-// each carrying a footer that links back to the changelog on GitHub.
 async function readReleaseNotes(packageDir: string, changelogUrlBase: string): Promise<ReleaseNotesByVersion> {
   const changelog = await readFile(path.resolve(packageDir, 'CHANGELOG.md'), 'utf8')
   // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -20,7 +20,6 @@ function git(args: string[]): string {
   return execFileSync('git', args, { encoding: 'utf8' })
 }
 
-// git stdout as lines, dropping the trailing blank left by the final newline.
 function gitLines(args: string[]): string[] {
   return git(args).split('\n').filter(Boolean)
 }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -41,7 +41,6 @@ function createReleasesClient({
   apiUrl,
 }: { owner: string; repo: string; token: string; apiUrl: string }): ReleasesClient {
   const releasesPath = `/repos/${owner}/${repo}/releases`
-  // Writes performed so far, to delay only *between* them (not before the first, nor after reads).
   let writeCount = 0
 
   async function request<T = void>(


### PR DESCRIPTION
This PR removes inline explanatory comments from the GitHub release sync workflow scripts to improve code readability and reduce comment clutter.

## Summary
Removed multi-line and single-line comments that explained the purpose and behavior of functions and code sections throughout the sync workflow. These comments were largely redundant with the code itself and function names.

## Changes
- **sync-package.ts**: Removed comments explaining `createSyncContext`, `syncPackage`, `readPackageName`, and `readReleaseNotes` functions
- **sync.ts**: Removed comment explaining CLI argument parsing
- **git.ts**: Removed comment explaining `gitLines` function behavior
- **github.ts**: Removed comment explaining `writeCount` variable purpose

## Notes
The code logic remains unchanged—only documentation comments were removed. Function names and implementation details are clear enough to convey intent without the additional explanatory text.

https://claude.ai/code/session_011Z3hfAJQWVVq6tBHBSTiv9