### PR TITLE
sync-github-releases: remove comments that restate the adjacent code

### DIFF
--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -66,8 +66,7 @@ function resolveTargetCommitish(release: ReleaseToCreate, defaultBranch: string)
   return commit
 }
 
-// Perform one write against GitHub — or, under --dry-run, just announce it. Centralizing the gate here
-// keeps create/update/delete from each repeating the dry-run branch, and logs every action once.
+// Perform one write against GitHub — or, under --dry-run, just announce it.
 const pastTense = { create: 'Created', update: 'Updated', delete: 'Deleted' } as const
 async function applyWrite(
   dryRun: boolean,

--- a/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
@@ -19,7 +19,6 @@ describe('getReleasePlan()', () => {
     })
 
     expect(plan).toEqual({
-      // Oldest-first, and only the newest version is flagged isLatest.
       releasesToCreate: [
         { tag_name: 'v0.8.0', body: 'Missing past notes', version: '0.8.0', isLatest: false },
         { tag_name: 'v1.0.1', body: 'New release notes', version: '1.0.1', isLatest: true },
@@ -65,7 +64,6 @@ describe('getReleasePlan()', () => {
       releaseNotesByVersion: { '1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
-        // Owned tag, no longer in the changelog → delete.
         { id: 2, tag_name: 'v0.9.0', body: 'Removed from changelog' },
       ],
     })

--- a/.github/workflows/sync-github-releases/sync/tag-scheme.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/tag-scheme.spec.ts
@@ -7,7 +7,6 @@ describe('getTagScheme()', () => {
     expect(scheme.build('0.4.259')).toBe('v0.4.259')
     expect(scheme.build('0.1.0-beta.6')).toBe('v0.1.0-beta.6')
     expect(scheme.owns('v0.4.259')).toBe(true)
-    // A tag we never create — left untouched.
     expect(scheme.owns('nightly')).toBe(false)
   })
 
@@ -16,7 +15,6 @@ describe('getTagScheme()', () => {
     expect(scheme.build('0.0.391')).toBe('create-vike-core@0.0.391')
     expect(scheme.build('0.1.0-beta.6')).toBe('create-vike-core@0.1.0-beta.6')
     expect(scheme.owns('create-vike-core@0.0.391')).toBe(true)
-    // Another package's release — not ours.
     expect(scheme.owns('vike@0.4.0')).toBe(false)
   })
 })

--- a/.github/workflows/sync-github-releases/utils/changelog.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.spec.ts
@@ -23,7 +23,6 @@ describe('parseChangelog()', () => {
 `
 
     expect(parseChangelog(changelog)).toEqual({
-      // Compare link surfaced as a "Full Changelog" footer.
       '1.0.1':
         '### Features\n\n* Added release automation.\n\n**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.1',
       // Non-`/compare/` link → no footer.


### PR DESCRIPTION
A focused comment-cleanup pass over `.github/workflows/sync-github-releases/`. The module's comments are already a deliberate, "why"-heavy set (most rated 7–9 on scrutiny), so this is surgical: I rated **every** comment in the tool (65 of them) and removed only the few that earn their keep by restating what's right next to them.

## What's removed (5) + trimmed (1)

All but one are **test annotations that repeat the assertion, the test name, or the visible fixture data** they sit beside:

- `release-plan.spec.ts` — `// Oldest-first, and only the newest version is flagged isLatest.` (the expected array already shows the order and `isLatest`).
- `release-plan.spec.ts` — `// Owned tag, no longer in the changelog → delete.` (restates the test name + the fixture body `'Removed from changelog'`).
- `tag-scheme.spec.ts` — `// A tag we never create — left untouched.` (the line is literally `owns('nightly')).toBe(false)`).
- `tag-scheme.spec.ts` — `// Another package's release — not ours.` (self-evident from `owns('vike@…')).toBe(false)`).
- `changelog.spec.ts` — `// Compare link surfaced as a "Full Changelog" footer.` (the expected string already contains the footer).
- `apply-release-plan.ts` — trimmed the second sentence of `applyWrite()`'s comment; the centralization rationale is already stated on `applyReleasePlan()`.

## What's deliberately kept

The structurally similar comments that explain a non-obvious **absence** or **why**, e.g.:

- the untouched `nightly` / foreign-package releases (the outcome is an empty plan, not a visible value);
- the non-`/compare/` heading that yields **no** footer (explains why `1.0.0` differs);
- and all the production "why" comments (GitHub `make_latest` default, `target_commitish`-vs-tag precedence, the pickaxe `-S` search, the secondary-rate-limit throttle, etc.).

## Notes

Comment-only change — no code logic is touched, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN7hsb5EDJQv9VrHzoLAoU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN7hsb5EDJQv9VrHzoLAoU)_