### PR TITLE
sync-github-releases: drop comments that duplicate the README or restate the code

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all.ts
+++ b/.github/workflows/sync-github-releases/delete-all.ts
@@ -1,5 +1,4 @@
 // Deletes every GitHub Release.
-// Run via the `delete-all` package.json script — see README.md
 
 main()
 

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -1,5 +1,4 @@
 // Synchronize CHANGELOG.md -> GitHub Releases.
-// Run via the package.json scripts `sync` or `sync:check` — see README.md
 
 main()
 
@@ -42,10 +41,6 @@ async function main(): Promise<void> {
   }
 }
 
-// Which package directories to sync, in priority order:
-//  - the explicit <package-dir> arguments, if any, or
-//  - on push (CI): the packages whose CHANGELOG.md changed, or
-//  - otherwise (manual workflow_dispatch, or a local run with no <package-dir>): every package.
 function getPackageDirsToSync(explicitPackageDirs: string[], allPackageDirs: string[]): string[] {
   if (explicitPackageDirs.length > 0) return explicitPackageDirs
   const pushedFiles = getPushedFiles()

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -66,7 +66,6 @@ function resolveTargetCommitish(release: ReleaseToCreate, defaultBranch: string)
   return commit
 }
 
-// Perform one write against GitHub — or, under --dry-run, just announce it.
 const pastTense = { create: 'Created', update: 'Updated', delete: 'Deleted' } as const
 async function applyWrite(
   dryRun: boolean,

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -24,8 +24,6 @@ function parseChangelog(changelog: string): ReleaseNotesByVersion {
   )
 }
 
-// The release notes we publish for each changelog version: the parsed entry plus a footer linking back
-// to its CHANGELOG.md.
 function getReleaseNotesByVersion(changelog: string, changelogUrl: string): ReleaseNotesByVersion {
   return Object.fromEntries(
     Object.entries(parseChangelog(changelog)).map(([version, notes]) => [

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -78,26 +78,21 @@ function createReleasesClient({
   }
 
   return {
-    // https://docs.github.com/en/rest/releases/releases#list-releases
     async list(): Promise<Release[]> {
       const releases: Release[] = []
       const perPage = 100
-      // Keep paging until a short (or empty) page signals the end.
       for (let page = 1; ; page++) {
         const pageReleases = await request<Release[]>(`${releasesPath}?per_page=${perPage}&page=${page}`)
         releases.push(...pageReleases)
         if (pageReleases.length < perPage) return releases
       }
     },
-    // https://docs.github.com/en/rest/releases/releases#create-a-release
     create(release: NewRelease): Promise<void> {
       return request(releasesPath, { method: 'POST', body: release })
     },
-    // https://docs.github.com/en/rest/releases/releases#update-a-release
     update(releaseId: number, body: string): Promise<void> {
       return request(`${releasesPath}/${releaseId}`, { method: 'PATCH', body: { body } })
     },
-    // https://docs.github.com/en/rest/releases/releases#delete-a-release
     delete(releaseId: number): Promise<void> {
       return request(`${releasesPath}/${releaseId}`, { method: 'DELETE' })
     },


### PR DESCRIPTION
A stricter follow-up to #3401. Removes the next tier — comments that duplicate the README/`package.json` or merely restate the code right beside them — while keeping every *why* / gotcha / security / format-decoding comment.

## Removed (10)

| Location | Comment | Why it goes |
|---|---|---|
| `sync.ts` | `// Run via the package.json scripts …` | Duplicates `package.json` + README; discoverable. |
| `sync.ts` | `getPackageDirsToSync()` precedence list | Duplicates the README's "How it works" step 1; the three guard clauses already read as the precedence, and the CI/manual/local mapping is documented at `getPushedFiles()`. |
| `delete-all.ts` | `// Run via the delete-all script …` | Same as above. |
| `changelog.ts` | `getReleaseNotesByVersion` summary | Restates two self-naming calls (`parseChangelog` + `withChangelogFooter`). |
| `apply-release-plan.ts` | `// Perform one write … just announce it.` | `applyWrite(dryRun, …)` + its body are self-evident. |
| `github.ts` ×4 | per-method endpoint doc-links (`list`/`create`/`update`/`delete`) | Bare URLs over standard CRUD wrappers; the `Release` type already links the Releases API. |
| `github.ts` | `// Keep paging until a short … page signals the end.` | Restates the visible `length < perPage → return`. |

## Deliberately kept

The comments that carry information the code can't: the GitHub `make_latest` / `target_commitish` behaviors, the pickaxe `-S` changelog-history search, the secondary-rate-limit throttle, the argv-no-injection note, the all-zero-SHA fact, the module-boundary headers, `parseChangelog`'s "newest-first" contract, and the cross-module `syncPackage` overview.

Comment-only change — no code logic touched, behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN7hsb5EDJQv9VrHzoLAoU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN7hsb5EDJQv9VrHzoLAoU)_