### PR TITLE
sync-github-releases: resolve the TODO/now release-notes tweaks

### DIFF
--- a/.github/workflows/sync-github-releases/utils/changelog.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.spec.ts
@@ -1,14 +1,14 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { parseChangelog, withReleaseDate } from './changelog.ts'
+import { getReleaseNotesByVersion, parseChangelog, withReleaseDate } from './changelog.ts'
 
 function readFixture(name: string): string {
   return readFileSync(path.join(__dirname, 'changelog-spec-fixtures', name), 'utf8')
 }
 
 describe('parseChangelog()', () => {
-  it('maps changelog headings to version tags and appends the compare link', () => {
+  it('maps changelog headings to versions, ignoring any heading link', () => {
     const changelog = `## [1.0.1](https://github.com/owner/repo/compare/v1.0.0...v1.0.1) (2026-03-01)
 
 ### Features
@@ -23,9 +23,7 @@ describe('parseChangelog()', () => {
 `
 
     expect(parseChangelog(changelog)).toEqual({
-      '1.0.1':
-        '### Features\n\n* Added release automation.\n\n**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.1',
-      // Non-`/compare/` link → no footer.
+      '1.0.1': '### Features\n\n* Added release automation.',
       '1.0.0': '### Bug Fixes\n\n* Fixed old release notes.',
     })
   })
@@ -70,6 +68,21 @@ describe('parseChangelog()', () => {
     expect(Object.keys(changelogSections)).toEqual(['0.1.6', '0.1.5', '0.1.4', '0.1.3', '0.1.2', '0.1.1'])
     expect(changelogSections['0.1.6']).toContain("fix 'vike-react' type")
     expect(changelogSections['0.1.1']).toContain('fix ESM import paths')
+  })
+})
+
+describe('getReleaseNotesByVersion()', () => {
+  it('appends the synced-from-CHANGELOG.md footer to each version', () => {
+    const changelog = `## [1.0.0](https://github.com/owner/repo/compare/v0.9.0...v1.0.0) (2026-02-28)
+
+### Bug Fixes
+
+* Fixed it.
+`
+    expect(getReleaseNotesByVersion(changelog, 'https://example.com/CHANGELOG.md')).toEqual({
+      '1.0.0':
+        '### Bug Fixes\n\n* Fixed it.\n\n<sub>Automatically synced from [`CHANGELOG.md`](https://example.com/CHANGELOG.md)</sub>',
+    })
   })
 })
 

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -7,20 +7,17 @@ export type ReleaseNotesByVersion = Record<string, string>
 // Parse a CHANGELOG.md into release notes keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`),
 // newest first. Decorating a version into its git tag is getTagScheme()'s job, not ours.
 function parseChangelog(changelog: string): ReleaseNotesByVersion {
-  // Each heading captures the version and, optionally, its link. release-me links the version to a
-  // `…/compare/…` URL — `## [0.4.257](…/compare/…)` — which we surface as the release's "Full
-  // Changelog". (The very first release links to a `…/tree/…` URL instead, which we skip.)
-  const matches = [...changelog.matchAll(/^##? \[(\d+\.\d+\.\d+[^\]]*)\](?:\(([^)]+)\))?/gm)]
+  // Match each version heading, ignoring any link release-me appends after the version
+  // (`## [0.4.257](…)`) — only the version itself is captured.
+  const matches = [...changelog.matchAll(/^##? \[(\d+\.\d+\.\d+[^\]]*)\](?:\([^)]+\))?/gm)]
 
   return Object.fromEntries(
     matches.map((match, index) => {
-      const [, version, headingUrl] = match
+      const [, version] = match
       // A version's notes run from the end of its heading line to the start of the next heading.
       const notesStart = changelog.indexOf('\n', match.index)
       const notesEnd = matches[index + 1]?.index ?? changelog.length
-      let notes = changelog.slice(notesStart, notesEnd).trim()
-      // TODO/now remove the `Full Changelog` line
-      if (headingUrl?.includes('/compare/')) notes += `\n\n**Full Changelog**: ${headingUrl}`
+      const notes = changelog.slice(notesStart, notesEnd).trim()
       return [version, notes]
     }),
   )
@@ -37,11 +34,10 @@ function getReleaseNotesByVersion(changelog: string, changelogUrl: string): Rele
   )
 }
 
-// These releases are generated, so point each one back to the CHANGELOG.md it mirrors (the source of
-// truth) to discourage editing the GitHub Release directly — a sync would overwrite it.
+// These releases are generated, so point each one back to the CHANGELOG.md it mirrors to discourage
+// editing the GitHub Release directly — a sync would overwrite it.
 function withChangelogFooter(body: string, changelogUrl: string): string {
-  // TODO/now change it to: `<sub>Automatically synced from [\`CHANGELOG.md\`](${changelogUrl})</sub>`
-  return `${body}\n\n_Source of truth: [\`CHANGELOG.md\`](${changelogUrl})._`
+  return `${body}\n\n<sub>Automatically synced from [\`CHANGELOG.md\`](${changelogUrl})</sub>`
 }
 
 // State, at the top of the notes, the date the version was released. A created GitHub Release records


### PR DESCRIPTION
## What

Resolves the two `TODO/now` notes added in `056c24f3d` ("update to-do") to the release-notes builder:

1. **Drop the `Full Changelog` line** — `parseChangelog()` no longer appends `**Full Changelog**: …/compare/…` to each version's notes. The heading link is now matched-and-ignored, so the now-unused `headingUrl` capture and its `let`/reassignment are gone too (regex group made non-capturing, `let`→`const`).
2. **Reword the footer** — `withChangelogFooter()` now emits `<sub>Automatically synced from [\`CHANGELOG.md\`](…)</sub>` instead of `_Source of truth: [\`CHANGELOG.md\`](…)._`.

### Resulting release body

```
_February 28, 2026_

### Bug Fixes

* Fixed a thing ([abc123](…/commit/abc123))

<sub>Automatically synced from [`CHANGELOG.md`](…/blob/main/CHANGELOG.md)</sub>
```

## Testing

- Updated the `parseChangelog()` test (no longer expects the compare link).
- Added a `getReleaseNotesByVersion()` test pinning the new footer.
- Full feature suite green (5 files, 24 tests); `tsc --noEmit` clean; Biome clean.

## Notes

- Based on `brillout/sync-github-releases` (where the `TODO/now` markers live), so this PR targets that branch — its diff is just the two tweaks.
- The README's intro sentence "Source of truth is `CHANGELOG.md`" is conceptual prose, not the footer string, so it's left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMosyJkKzfvSGEJFCgTTRR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMosyJkKzfvSGEJFCgTTRR)_