### PR TITLE
sync-github-releases: name the repeated refs/tags/&lt;tag&gt; ref builder

### DIFF
--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -54,10 +54,16 @@ function getTrackedChangelogFiles(): string[] {
   return gitLines(['ls-files', '--', CHANGELOG_PATHSPEC])
 }
 
+// A release tag's fully-qualified ref. The `refs/tags/` prefix pins it to a tag, so git can't resolve
+// a like-named branch (or any other ref) instead.
+function tagRef(releaseTag: string): string {
+  return `refs/tags/${releaseTag}`
+}
+
 function gitTagExists(releaseTag: string): boolean {
   // `rev-parse --verify` exits non-zero (so git() throws) when the tag is missing.
   try {
-    git(['rev-parse', '-q', '--verify', `refs/tags/${releaseTag}`])
+    git(['rev-parse', '-q', '--verify', tagRef(releaseTag)])
     return true
   } catch {
     return false
@@ -76,7 +82,7 @@ function findReleaseCommit(version: string): string | null {
 // (the same commit apply-release-plan.ts would tag). null when neither resolves. The commit date is
 // what GitHub derives the release's own date (`created_at`) from, and what CHANGELOG.md headings show.
 function getReleaseDate(releaseTag: string, version: string): string | null {
-  const commitish = gitTagExists(releaseTag) ? `refs/tags/${releaseTag}` : findReleaseCommit(version)
+  const commitish = gitTagExists(releaseTag) ? tagRef(releaseTag) : findReleaseCommit(version)
   if (!commitish) return null
   // %cs is the committer date in short form (YYYY-MM-DD).
   return git(['log', '-1', '--format=%cs', commitish]).trim()


### PR DESCRIPTION
Rebased onto the latest `brillout/sync-github-releases`.

This PR originally carried two refactors. The first — extracting `mapReleaseNotes` to DRY the per-version notes value-map — **converged with #3406**, which independently landed a functionally identical helper (same name, signature, and body). So that commit was dropped on rebase, and this PR is now the one refactor that's still unique:

## `tagRef` — name the repeated `refs/tags/<tag>` builder
`gitTagExists()` and `getReleaseDate()` each spelled out `` `refs/tags/${releaseTag}` `` inline. Pulled it into `tagRef()`, matching how `CHANGELOG_PATHSPEC` already names the other repeated git literal in that file, and documented *why* the form is fully-qualified: the `refs/tags/` prefix pins the lookup to a tag so git can't resolve a like-named branch (or any other ref) instead.

One file, +8/−2. No behaviour change.

## Verification
- `tsc --noEmit` clean
- All 24 unit tests pass
- `biome ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)