### PR TITLE
sync-github-releases: three refinement refactors (layering + DRY)

### DIFF
--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -7,7 +7,12 @@ import path from 'node:path'
 import { applyReleasePlan } from './apply-release-plan.ts'
 import { getReleasePlan } from './release-plan.ts'
 import { getTagScheme, type TagScheme } from './tag-scheme.ts'
-import { getReleaseNotesByVersion, withReleaseDate, type ReleaseNotesByVersion } from '../utils/changelog.ts'
+import {
+  getReleaseNotesByVersion,
+  mapReleaseNotes,
+  withReleaseDate,
+  type ReleaseNotesByVersion,
+} from '../utils/changelog.ts'
 import { getReleaseDate } from '../utils/git.ts'
 import type { ReleasesClient } from '../utils/github.ts'
 
@@ -60,11 +65,8 @@ async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> 
 // Done here, not in readReleaseNotes(), so that reader stays a single-purpose disk read and the git
 // lookups need the tag scheme that turns a version into its tag.
 function stampReleaseDates(releaseNotesByVersion: ReleaseNotesByVersion, tagScheme: TagScheme): ReleaseNotesByVersion {
-  return Object.fromEntries(
-    Object.entries(releaseNotesByVersion).map(([version, body]) => [
-      version,
-      withReleaseDate(body, getReleaseDate(tagScheme.build(version), version)),
-    ]),
+  return mapReleaseNotes(releaseNotesByVersion, (body, version) =>
+    withReleaseDate(body, getReleaseDate(tagScheme.build(version), version)),
   )
 }
 

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -26,27 +26,14 @@ type SyncContext = {
   changelogUrlBase: string
 }
 
-function createSyncContext({
-  client,
-  owner,
-  repo,
-  defaultBranch,
-  hasMultiplePackages,
-  dryRun,
-}: {
-  client: ReleasesClient
-  owner: string
-  repo: string
-  defaultBranch: string
-  hasMultiplePackages: boolean
-  dryRun: boolean
-}): SyncContext {
+// owner/repo are consumed only to bake the changelog URL base; every other field is the context as-is.
+function createSyncContext(
+  input: Omit<SyncContext, 'changelogUrlBase'> & { owner: string; repo: string },
+): SyncContext {
+  const { owner, repo, ...context } = input
   return {
-    client,
-    defaultBranch,
-    hasMultiplePackages,
-    dryRun,
-    changelogUrlBase: `https://github.com/${owner}/${repo}/blob/${defaultBranch}`,
+    ...context,
+    changelogUrlBase: `https://github.com/${owner}/${repo}/blob/${context.defaultBranch}`,
   }
 }
 

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -1,8 +1,20 @@
 export { parseChangelog }
 export { getReleaseNotesByVersion }
+export { mapReleaseNotes }
 export { withReleaseDate }
 
 export type ReleaseNotesByVersion = Record<string, string>
+
+// Rewrite each version's notes while preserving the version keys and their newest-first order — the
+// shared shape behind every release-notes decoration (footer, release date, …).
+function mapReleaseNotes(
+  notesByVersion: ReleaseNotesByVersion,
+  transform: (notes: string, version: string) => string,
+): ReleaseNotesByVersion {
+  return Object.fromEntries(
+    Object.entries(notesByVersion).map(([version, notes]) => [version, transform(notes, version)]),
+  )
+}
 
 // Parse a CHANGELOG.md into release notes keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`),
 // newest first. Decorating a version into its git tag is getTagScheme()'s job, not ours.
@@ -26,12 +38,7 @@ function parseChangelog(changelog: string): ReleaseNotesByVersion {
 // The release notes we publish for each changelog version: the parsed entry plus a footer linking back
 // to its CHANGELOG.md.
 function getReleaseNotesByVersion(changelog: string, changelogUrl: string): ReleaseNotesByVersion {
-  return Object.fromEntries(
-    Object.entries(parseChangelog(changelog)).map(([version, notes]) => [
-      version,
-      withChangelogFooter(notes, changelogUrl),
-    ]),
-  )
+  return mapReleaseNotes(parseChangelog(changelog), (notes) => withChangelogFooter(notes, changelogUrl))
 }
 
 // These releases are generated, so point each one back to the CHANGELOG.md it mirrors to discourage

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -2,15 +2,16 @@
 // package dirs). Knows nothing of the GitHub Actions environment (github-env.ts) nor the GitHub API
 // (github.ts).
 
-export { git }
 export { gitLines }
 export { getRepoRoot }
+export { getRepositoryFromGitRemote }
 export { gitTagExists }
 export { findReleaseCommit }
 export { getReleaseDate }
 export { getTrackedChangelogFiles }
 export { toPackageDirs }
 
+import assert from 'node:assert'
 import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 
@@ -27,6 +28,16 @@ function gitLines(args: string[]): string[] {
 
 function getRepoRoot(): string {
   return git(['rev-parse', '--show-toplevel']).trim()
+}
+
+// The repository's `owner/repo` slug, parsed from the origin remote's GitHub URL. A fallback for local
+// runs where GITHUB_REPOSITORY isn't set (see github-env.ts). Handles both
+// https://github.com/owner/repo.git and git@github.com:owner/repo.git.
+function getRepositoryFromGitRemote(): string {
+  const url = git(['remote', 'get-url', 'origin']).trim()
+  const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/)
+  assert(match, `Cannot parse GitHub repository from git remote: ${url}`)
+  return match[1]
 }
 
 function toPackageDirs(files: string[]): string[] {

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -4,7 +4,7 @@ export { getPushedFiles }
 
 import assert from 'node:assert'
 import { readFileSync } from 'node:fs'
-import { git, gitLines } from './git.ts'
+import { getRepositoryFromGitRemote, gitLines } from './git.ts'
 import { createReleasesClient, type ReleasesClient } from './github.ts'
 
 // How a run discovers what to act on, as whom, and against which branch: the repository, the auth
@@ -41,18 +41,10 @@ function getDefaultBranch(): string {
 
 function getRepository(): { owner: string; repo: string } {
   // Either source can be malformed, so keep the message source-neutral (it isn't always GITHUB_REPOSITORY).
-  const repository = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGit()
+  const repository = process.env.GITHUB_REPOSITORY ?? getRepositoryFromGitRemote()
   const [owner, repo] = repository.split('/')
   assert(owner && repo, `Cannot parse owner/repo from repository: ${repository}`)
   return { owner, repo }
-}
-
-function getRepositoryFromGit(): string {
-  const url = git(['remote', 'get-url', 'origin']).trim()
-  // Handles both https://github.com/owner/repo.git and git@github.com:owner/repo.git
-  const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/)
-  assert(match, `Cannot parse GitHub repository from git remote: ${url}`)
-  return match[1]
 }
 
 // The files the triggering push changed, or null when this isn't a push (manual workflow_dispatch, or


### PR DESCRIPTION
Continuation of the `sync-github-releases` refactor. I rated every file, function, and logic unit in the tool (0–10) before touching anything; the code was already near-pinnacle after the prior passes, so this is three high-confidence refinements at the margin rather than a broad rework. Each is its own commit; **24/24 unit tests, `tsc`, and biome stay green** throughout.

### 1. Move the git-remote repo parse into the git plumbing (layering)
`getRepositoryFromGit()` lived in `github-env.ts` but did exactly what `git.ts` is defined to own — *"runs the `git` CLI and shapes its output"*: it shells `git remote get-url origin` and parses the `owner/repo` slug, the same shape as the neighbouring `getRepoRoot()`. Moved it to `git.ts` as `getRepositoryFromGitRemote()`; `getRepository()` keeps only the env-vs-fallback choice and the split. Its sole external caller gone, the raw `git()` escape hatch is now internal to `git.ts` and no longer exported — the module exposes only its named operations.

### 2. DRY the release-notes value-map behind one helper
`getReleaseNotesByVersion()` (footer) and `stampReleaseDates()` (release date) each spelled out the same `Object.fromEntries(Object.entries(notes).map(([v, body]) => [v, decorate(body)]))` boilerplate, in two different modules. Named that shape once as `mapReleaseNotes(notesByVersion, transform)` beside the `ReleaseNotesByVersion` type; both call sites now state only their intent on a single line.

### 3. Derive the `createSyncContext` input type from `SyncContext`
The factory's parameter object re-listed the four field types it shares with `SyncContext`. Typed the input as `Omit<SyncContext, 'changelogUrlBase'> & { owner, repo }` instead — one source of truth for the shared fields, and the `{ owner, repo, ...context }` destructure now says outright that owner/repo are consumed to build the URL while everything else is the context verbatim.

### Deliberately declined (flagged, not churned)
Two independent reviews plus my own pass surfaced these as ≤50%-confidence — i.e. likely churn an expert team would reject. Documented here so they aren't "rediscovered" later:
- **Splitting the dense `stampReleaseDates(await readReleaseNotes(...))` line** — the only clean intermediate name collides with `releaseNotesByVersion`; net negative.
- **`findReleaseCommit` computed twice for a tag-missing backfill** (`getReleaseDate` vs `resolveTargetCommitish`) — spans two intentionally-decoupled phases and returns different things (date vs SHA); threading it through the plan would couple them.
- **Wrapping the push-diff in a named `git.ts` helper** — indirection for a single caller.
- **camelCase-ing the plan DTO fields** (`tag_name`/`release_id`) — they ride the GitHub API response shape through; renaming is churn across the plan, apply, and specs for no clarity gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF5HQiPei91GMq11ZMbEWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EF5HQiPei91GMq11ZMbEWm)_