### PR TITLE
sync-github-releases: assemble the release body in one place

### DIFF
--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -7,12 +7,7 @@ import path from 'node:path'
 import { applyReleasePlan } from './apply-release-plan.ts'
 import { getReleasePlan } from './release-plan.ts'
 import { getTagScheme, type TagScheme } from './tag-scheme.ts'
-import {
-  getReleaseNotesByVersion,
-  mapReleaseNotes,
-  withReleaseDate,
-  type ReleaseNotesByVersion,
-} from '../utils/changelog.ts'
+import { buildReleaseBody, parseChangelog, type ReleaseNotesByVersion } from '../utils/changelog.ts'
 import { getReleaseDate } from '../utils/git.ts'
 import type { ReleasesClient } from '../utils/github.ts'
 
@@ -42,18 +37,28 @@ function createSyncContext(
 async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
   const packageName = await readPackageName(packageDir)
   const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
-  const releaseNotesByVersion = stampReleaseDates(await readReleaseNotes(packageDir, ctx.changelogUrlBase), tagScheme)
+  const changelogNotes = await readChangelogNotes(packageDir)
+  const releaseNotesByVersion = buildReleaseBodies(changelogNotes, {
+    tagScheme,
+    changelogUrl: getChangelogUrl(packageDir, ctx.changelogUrlBase),
+  })
   const githubReleases = await ctx.client.list()
   const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
   await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
 }
 
-// Stamp each release's notes with the date it was released, derived from its git tag (getReleaseDate()).
-// Done here, not in readReleaseNotes(), so that reader stays a single-purpose disk read and the git
-// lookups need the tag scheme that turns a version into its tag.
-function stampReleaseDates(releaseNotesByVersion: ReleaseNotesByVersion, tagScheme: TagScheme): ReleaseNotesByVersion {
-  return mapReleaseNotes(releaseNotesByVersion, (body, version) =>
-    withReleaseDate(body, getReleaseDate(tagScheme.build(version), version)),
+// Turn each version's parsed changelog notes into the release body we publish (buildReleaseBody()). Kept
+// out of the disk read (readChangelogNotes()) because the release date is resolved from git — the tag
+// scheme turns a version into its tag (getReleaseDate()) — which the pure changelog parsing knows nothing of.
+function buildReleaseBodies(
+  changelogNotes: ReleaseNotesByVersion,
+  { tagScheme, changelogUrl }: { tagScheme: TagScheme; changelogUrl: string },
+): ReleaseNotesByVersion {
+  return Object.fromEntries(
+    Object.entries(changelogNotes).map(([version, notes]) => [
+      version,
+      buildReleaseBody(notes, { releaseDate: getReleaseDate(tagScheme.build(version), version), changelogUrl }),
+    ]),
   )
 }
 
@@ -62,9 +67,13 @@ async function readPackageName(packageDir: string): Promise<string> {
   return name
 }
 
-async function readReleaseNotes(packageDir: string, changelogUrlBase: string): Promise<ReleaseNotesByVersion> {
+async function readChangelogNotes(packageDir: string): Promise<ReleaseNotesByVersion> {
   const changelog = await readFile(path.resolve(packageDir, 'CHANGELOG.md'), 'utf8')
-  // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
-  const changelogUrl = `${changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
-  return getReleaseNotesByVersion(changelog, changelogUrl)
+  return parseChangelog(changelog)
+}
+
+// The GitHub web (blob) URL of the package's CHANGELOG.md, which each release body's footer links back to.
+// path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
+function getChangelogUrl(packageDir: string, changelogUrlBase: string): string {
+  return `${changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
 }

--- a/.github/workflows/sync-github-releases/utils/changelog.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { getReleaseNotesByVersion, parseChangelog, withReleaseDate } from './changelog.ts'
+import { buildReleaseBody, parseChangelog } from './changelog.ts'
 
 function readFixture(name: string): string {
   return readFileSync(path.join(__dirname, 'changelog-spec-fixtures', name), 'utf8')
@@ -71,31 +71,23 @@ describe('parseChangelog()', () => {
   })
 })
 
-describe('getReleaseNotesByVersion()', () => {
-  it('appends the synced-from-CHANGELOG.md footer to each version', () => {
-    const changelog = `## [1.0.0](https://github.com/owner/repo/compare/v0.9.0...v1.0.0) (2026-02-28)
+describe('buildReleaseBody()', () => {
+  const changelogUrl = 'https://example.com/CHANGELOG.md'
+  const footer = `<sub>Automatically synced from [\`CHANGELOG.md\`](${changelogUrl})</sub>`
 
-### Bug Fixes
-
-* Fixed it.
-`
-    expect(getReleaseNotesByVersion(changelog, 'https://example.com/CHANGELOG.md')).toEqual({
-      '1.0.0':
-        '### Bug Fixes\n\n* Fixed it.\n\n<sub>Automatically synced from [`CHANGELOG.md`](https://example.com/CHANGELOG.md)</sub>',
-    })
-  })
-})
-
-describe('withReleaseDate()', () => {
-  it('states the release date — human-friendly — at the top of the notes', () => {
-    expect(withReleaseDate('### Bug Fixes\n\n* Fixed it.', '2026-05-06')).toBe(
-      '_May 6, 2026_\n\n### Bug Fixes\n\n* Fixed it.',
+  it('tops the notes with the release date and tails them with the CHANGELOG.md footer', () => {
+    expect(buildReleaseBody('### Bug Fixes\n\n* Fixed it.', { releaseDate: '2026-05-06', changelogUrl })).toBe(
+      `_May 6, 2026_\n\n### Bug Fixes\n\n* Fixed it.\n\n${footer}`,
     )
     // Two-digit day at year-end: guards against UTC date drift and confirms no leading zero on the day.
-    expect(withReleaseDate('* Note.', '2021-12-31')).toBe('_December 31, 2021_\n\n* Note.')
+    expect(buildReleaseBody('* Note.', { releaseDate: '2021-12-31', changelogUrl })).toBe(
+      `_December 31, 2021_\n\n* Note.\n\n${footer}`,
+    )
   })
 
-  it('leaves the notes unchanged when the date is unknown (no tag, no deducible commit)', () => {
-    expect(withReleaseDate('### Bug Fixes\n\n* Fixed it.', null)).toBe('### Bug Fixes\n\n* Fixed it.')
+  it('omits the date line when the date is unknown (no tag, no deducible commit)', () => {
+    expect(buildReleaseBody('### Bug Fixes\n\n* Fixed it.', { releaseDate: null, changelogUrl })).toBe(
+      `### Bug Fixes\n\n* Fixed it.\n\n${footer}`,
+    )
   })
 })

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -1,20 +1,7 @@
 export { parseChangelog }
-export { getReleaseNotesByVersion }
-export { mapReleaseNotes }
-export { withReleaseDate }
+export { buildReleaseBody }
 
 export type ReleaseNotesByVersion = Record<string, string>
-
-// Rewrite each version's notes while preserving the version keys and their newest-first order — the
-// shared shape behind every release-notes decoration (footer, release date, …).
-function mapReleaseNotes(
-  notesByVersion: ReleaseNotesByVersion,
-  transform: (notes: string, version: string) => string,
-): ReleaseNotesByVersion {
-  return Object.fromEntries(
-    Object.entries(notesByVersion).map(([version, notes]) => [version, transform(notes, version)]),
-  )
-}
 
 // Parse a CHANGELOG.md into release notes keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`),
 // newest first. Decorating a version into its git tag is getTagScheme()'s job, not ours.
@@ -35,25 +22,19 @@ function parseChangelog(changelog: string): ReleaseNotesByVersion {
   )
 }
 
-// The release notes we publish for each changelog version: the parsed entry plus a footer linking back
-// to its CHANGELOG.md.
-function getReleaseNotesByVersion(changelog: string, changelogUrl: string): ReleaseNotesByVersion {
-  return mapReleaseNotes(parseChangelog(changelog), (notes) => withChangelogFooter(notes, changelogUrl))
-}
-
-// These releases are generated, so point each one back to the CHANGELOG.md it mirrors to discourage
-// editing the GitHub Release directly — a sync would overwrite it.
-function withChangelogFooter(body: string, changelogUrl: string): string {
-  return `${body}\n\n<sub>Automatically synced from [\`CHANGELOG.md\`](${changelogUrl})</sub>`
-}
-
-// State, at the top of the notes, the date the version was released. A created GitHub Release records
-// the date the sync ran (its `published_at`), not when the version actually shipped — so we surface the
-// real date, taken from the git tag (see getReleaseDate()). A null date (no tag, no deducible commit)
-// leaves the notes unchanged.
-function withReleaseDate(body: string, releaseDate: string | null): string {
-  if (!releaseDate) return body
-  return `_${formatReleaseDate(releaseDate)}_\n\n${body}`
+// The body we publish for one changelog version, assembled here in a single place from its parsed notes:
+//  - topped with the release date, when known. A created GitHub Release otherwise only records when the
+//    sync ran (its `published_at`), not when the version shipped — so we surface the real date, taken
+//    from the git tag (see getReleaseDate()). A null date (no tag, no deducible commit) drops the line.
+//  - tailed with a footer pointing back to the CHANGELOG.md it mirrors, to discourage editing the
+//    GitHub Release directly — the next sync would overwrite it.
+function buildReleaseBody(
+  notes: string,
+  { releaseDate, changelogUrl }: { releaseDate: string | null; changelogUrl: string },
+): string {
+  const dateLine = releaseDate ? `_${formatReleaseDate(releaseDate)}_\n\n` : ''
+  const footer = `<sub>Automatically synced from [\`CHANGELOG.md\`](${changelogUrl})</sub>`
+  return `${dateLine}${notes}\n\n${footer}`
 }
 
 // Render an ISO date (`2026-05-06`) in a human-friendly long form (`May 6, 2026`). Formatted in UTC so


### PR DESCRIPTION
Follow-up to #3406, addressing review feedback: *define the GitHub Release body in a single place, and drop the "middleware".*

### The problem
The published release body was assembled across **two modules**:
- `getReleaseNotesByVersion()` appended the `CHANGELOG.md` footer in `changelog.ts`
- `stampReleaseDates()` prepended the release date in `sync-package.ts`

Because the two halves lived in separate passes, gluing them needed a generic `mapReleaseNotes(notes, transform)` helper applied twice — a middleware that existed only to paper over the split. #3406's `mapReleaseNotes` DRY'd the *symptom* (two structurally-identical passes); the real cause was that the body had no single definition.

### The change
`buildReleaseBody(notes, { releaseDate, changelogUrl })` now states the **date line + notes + footer in one function**, and `sync-package.ts` maps it over the parsed changelog in a single pass. That removes `mapReleaseNotes`, `withChangelogFooter`, `withReleaseDate`, and `getReleaseNotesByVersion` outright.

```
readChangelogNotes(packageDir)            // pure disk read → raw parsed notes
  → buildReleaseBodies(notes, { tagScheme, changelogUrl })   // one pass; resolves each date from git
      → buildReleaseBody(notes, { releaseDate, changelogUrl })  // the single body definition
```

The pre-existing separation is preserved: the disk read stays split from the git date lookup, so `changelog.ts` stays pure (no tag-scheme/git knowledge) and `buildReleaseBody` is a pure function the unit tests pin directly.

**Net −18 lines, and the body shape now changes in exactly one place.**

### Verification
- `vitest` unit tests pass (23; the two `changelog.spec.ts` blocks merged into a `buildReleaseBody()` block covering footer + date + UTC year-end edge + null-date)
- `tsc --noEmit` clean
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF5HQiPei91GMq11ZMbEWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EF5HQiPei91GMq11ZMbEWm)_