### PR TITLE
feat: getUniversalMiddlewares() — apply +middleware to all URLs (#3407)

### DIFF
--- a/packages/vike/getUniversalMiddlewares.js
+++ b/packages/vike/getUniversalMiddlewares.js
@@ -1,0 +1,2 @@
+// Some tools still need this as of January 2025
+export * from './dist/server/runtime/getUniversalMiddlewares.js'

--- a/packages/vike/package.json
+++ b/packages/vike/package.json
@@ -102,6 +102,14 @@
       "browser": "./dist/client/node.js",
       "default": "./dist/server/runtime/fetch.js"
     },
+    "./getUniversalMiddlewares": {
+      "types": "./dist/server/runtime/getUniversalMiddlewares.d.ts",
+      "worker": "./dist/server/runtime/getUniversalMiddlewares.js",
+      "workerd": "./dist/server/runtime/getUniversalMiddlewares.js",
+      "node": "./dist/server/runtime/getUniversalMiddlewares.js",
+      "browser": "./dist/client/node.js",
+      "default": "./dist/server/runtime/getUniversalMiddlewares.js"
+    },
     "./__internal": {
       "types": "./dist/server/__internal/index.d.ts",
       "node": "./dist/server/__internal/index.js",
@@ -221,6 +229,9 @@
       "fetch": [
         "./dist/server/runtime/fetch.d.ts"
       ],
+      "getUniversalMiddlewares": [
+        "./dist/server/runtime/getUniversalMiddlewares.d.ts"
+      ],
       "__internal": [
         "./dist/server/__internal/index.d.ts"
       ],
@@ -256,7 +267,8 @@
     "./server.js",
     "./types.js",
     "./universal-middleware.js",
-    "./fetch.js"
+    "./fetch.js",
+    "./getUniversalMiddlewares.js"
   ],
   "devDependencies": {
     "@brillout/release-me": "^0.4.15",

--- a/packages/vike/src/node/vite/plugins/pluginDev.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev.ts
@@ -5,6 +5,7 @@ import { type Plugin, type ResolvedConfig, type UserConfig } from 'vite'
 import { optimizeDeps, resolveOptimizeDeps } from './pluginDev/optimizeDeps.js'
 import { determineFsAllowList } from './pluginDev/determineFsAllowList.js'
 import { addSsrMiddleware } from '../shared/addSsrMiddleware.js'
+import { addUniversalMiddlewares } from '../shared/addUniversalMiddlewares.js'
 import { isDebugError } from '../../../utils/debug.js'
 import { applyDev } from '../../../utils/isDev.js'
 import { isDocker } from '../../../utils/isDocker.js'
@@ -50,6 +51,8 @@ function pluginDev(): Plugin[] {
           const hasHonoViteDevServer = !!config.plugins.find((p) => p.name === '@hono/vite-dev-server')
           if (config.server.middlewareMode || hasHonoViteDevServer) return
           return () => {
+            // Apply `+middleware` (Universal Middlewares) before the SSR middleware, so they run for all URLs.
+            addUniversalMiddlewares(server.middlewares)
             addSsrMiddleware(server.middlewares, config, false, null)
           }
         },

--- a/packages/vike/src/node/vite/plugins/pluginPreview.ts
+++ b/packages/vike/src/node/vite/plugins/pluginPreview.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import type { ViteDevServer } from 'vite'
 import { addSsrMiddleware } from '../shared/addSsrMiddleware.js'
+import { addUniversalMiddlewares } from '../shared/addUniversalMiddlewares.js'
 import pc from '@brillout/picocolors'
 import { logDockerHint } from './pluginDev.js'
 import { getOutDirs } from '../shared/getOutDirs.js'
@@ -51,6 +52,8 @@ function pluginPreview(): Plugin[] {
             addStaticAssetsMiddleware(server.middlewares)
 
             if (!isPrerenderingEnabledForAllPages) {
+              // Apply `+middleware` (Universal Middlewares) before the SSR middleware, so they run for all URLs.
+              addUniversalMiddlewares(server.middlewares)
               addSsrMiddleware(server.middlewares, config, true, isPrerenderingEnabled)
             }
 

--- a/packages/vike/src/node/vite/shared/addUniversalMiddlewares.ts
+++ b/packages/vike/src/node/vite/shared/addUniversalMiddlewares.ts
@@ -1,0 +1,47 @@
+export { addUniversalMiddlewares }
+
+import type { ViteDevServer } from 'vite'
+import { getAdapterRuntime, type EnhancedMiddleware } from '@universal-middleware/core'
+import { createRequestAdapter } from '@universal-middleware/node/request'
+import { sendResponse, setResponseHeaders } from '@universal-middleware/node/response'
+import { getUniversalMiddlewares } from '../../../server/runtime/getUniversalMiddlewares.js'
+import { runUniversalMiddlewares } from '../../../server/runtime/runUniversalMiddlewares.js'
+import '../assertEnvVite.js'
+type ConnectServer = ViteDevServer['middlewares']
+
+const requestAdapter = createRequestAdapter()
+
+// Applies the app's `+middleware` (Universal Middlewares) to *all* URLs reaching Vike's dev/preview
+// server, before the SSR middleware. This matches production, where `+middleware` is applied
+// independently of page rendering.
+function addUniversalMiddlewares(middlewares: ConnectServer) {
+  middlewares.use(async (req, res, next) => {
+    if (res.headersSent) return next()
+
+    let universalMiddlewares: EnhancedMiddleware[]
+    try {
+      universalMiddlewares = await getUniversalMiddlewares()
+    } catch {
+      // Vike config errors are surfaced by the SSR middleware (renderPage()).
+      return next()
+    }
+    if (universalMiddlewares.length === 0) return next()
+
+    const request = requestAdapter(req, res)
+    const runtime = getAdapterRuntime('other', { params: undefined })
+    let response: Response | null
+    try {
+      response = await runUniversalMiddlewares(universalMiddlewares, request, {}, runtime)
+    } catch (err) {
+      // Throwing in a Connect middleware shuts down the dev server.
+      console.error(err)
+      return next()
+    }
+
+    // No middleware handled the request: let the SSR middleware (and others) handle it.
+    if (!response) return next()
+
+    setResponseHeaders(response, res)
+    await sendResponse(response, res)
+  })
+}

--- a/packages/vike/src/server/runtime/fetch.ts
+++ b/packages/vike/src/server/runtime/fetch.ts
@@ -1,6 +1,27 @@
 import '../assertEnvServer.js'
+import { getAdapterRuntime, type EnhancedMiddleware, type RuntimeAdapter } from '@universal-middleware/core'
 import vikeHandler from './universal-middleware.js'
+import { getUniversalMiddlewares } from './getUniversalMiddlewares.js'
+import { runUniversalMiddlewares } from './runUniversalMiddlewares.js'
+
+// Zero-config `fetch` handler: applies the app's `+middleware` (Universal Middlewares) to *all*
+// requests, then renders the page.
+async function fetch(request: Request, context?: Universal.Context, runtime?: RuntimeAdapter): Promise<Response> {
+  const ctx = context ?? {}
+  const rt = runtime ?? getAdapterRuntime('other', { params: undefined })
+
+  let middlewares: EnhancedMiddleware[] = []
+  try {
+    middlewares = await getUniversalMiddlewares()
+  } catch {
+    // Vike config errors are surfaced (and logged) by the Vike handler below.
+  }
+
+  if (middlewares.length === 0) return vikeHandler(request, ctx, rt)
+  // `vikeHandler` is the terminal handler, so a `Response` is always returned.
+  return (await runUniversalMiddlewares(middlewares, request, ctx, rt, vikeHandler))!
+}
 
 export default {
-  fetch: vikeHandler,
+  fetch,
 }

--- a/packages/vike/src/server/runtime/getUniversalMiddlewares.ts
+++ b/packages/vike/src/server/runtime/getUniversalMiddlewares.ts
@@ -1,7 +1,9 @@
 export { getUniversalMiddlewares }
+export { universalMiddleware }
 
 import { getGlobalContextServerInternal, initGlobalContext_renderPage } from './globalContext.js'
-import type { EnhancedMiddleware } from '@universal-middleware/core'
+import { runUniversalMiddlewares } from './runUniversalMiddlewares.js'
+import { enhance, type EnhancedMiddleware } from '@universal-middleware/core'
 import '../assertEnvServer.js'
 
 /**
@@ -9,6 +11,10 @@ import '../assertEnvServer.js'
  *
  * Apply them to your server in order to run your `+middleware` for *all* HTTP requests (instead of
  * only the requests that render a page).
+ *
+ * For most servers, prefer the ready-to-use {@link universalMiddleware} which resolves the list
+ * lazily (upon the first request). Resolving it eagerly (`await getUniversalMiddlewares()` at
+ * startup) deadlocks Vike's development server, which awaits your server entry to finish loading.
  *
  * @example
  * ```js
@@ -26,3 +32,35 @@ async function getUniversalMiddlewares(): Promise<EnhancedMiddleware[]> {
   const { globalContext } = await getGlobalContextServerInternal()
   return (globalContext.config.middleware ?? []).flat()
 }
+
+/**
+ * A ready-to-use Universal Middleware that applies your app's `+middleware` to *all* HTTP requests.
+ *
+ * Register it before Vike's render handler. If one of your `+middleware` returns a `Response`, it
+ * short-circuits; otherwise the request falls through to the next handler.
+ *
+ * Your `+middleware` are resolved *lazily* (upon the first request): unlike
+ * {@link getUniversalMiddlewares}, this can safely be registered at server startup, including in
+ * Vike's development server.
+ *
+ * @example
+ * ```js
+ * import { apply } from '@universal-middleware/express'
+ * import { universalMiddleware } from 'vike/getUniversalMiddlewares'
+ * import vikeHandler from 'vike/universal-middleware'
+ *
+ * apply(app, [universalMiddleware, vikeHandler])
+ * ```
+ *
+ * https://github.com/magne4000/universal-middleware
+ */
+const universalMiddleware: EnhancedMiddleware = enhance(
+  async (request, context, runtime) => {
+    const middlewares = await getUniversalMiddlewares()
+    if (middlewares.length === 0) return
+    const response = await runUniversalMiddlewares(middlewares, request, context, runtime)
+    // A `Response` short-circuits; `null` means no `+middleware` handled the request (fall through).
+    return response ?? undefined
+  },
+  { name: 'vike:universal-middleware', immutable: true },
+)

--- a/packages/vike/src/server/runtime/getUniversalMiddlewares.ts
+++ b/packages/vike/src/server/runtime/getUniversalMiddlewares.ts
@@ -1,0 +1,28 @@
+export { getUniversalMiddlewares }
+
+import { getGlobalContextServerInternal, initGlobalContext_renderPage } from './globalContext.js'
+import type { EnhancedMiddleware } from '@universal-middleware/core'
+import '../assertEnvServer.js'
+
+/**
+ * Get the list of Universal Middlewares defined by your app via the `+middleware` setting.
+ *
+ * Apply them to your server in order to run your `+middleware` for *all* HTTP requests (instead of
+ * only the requests that render a page).
+ *
+ * @example
+ * ```js
+ * import { apply } from '@universal-middleware/express'
+ * import { getUniversalMiddlewares } from 'vike/getUniversalMiddlewares'
+ * import vikeHandler from 'vike/universal-middleware'
+ *
+ * apply(app, [...(await getUniversalMiddlewares()), vikeHandler])
+ * ```
+ *
+ * https://github.com/magne4000/universal-middleware
+ */
+async function getUniversalMiddlewares(): Promise<EnhancedMiddleware[]> {
+  await initGlobalContext_renderPage()
+  const { globalContext } = await getGlobalContextServerInternal()
+  return (globalContext.config.middleware ?? []).flat()
+}

--- a/packages/vike/src/server/runtime/renderPageServer.ts
+++ b/packages/vike/src/server/runtime/renderPageServer.ts
@@ -53,7 +53,6 @@ import {
   createHttpResponseErrorFallback,
   createHttpResponseErrorFallback_noGlobalContext,
   createHttpResponseBaseIsMissing,
-  createHttpResponseFromUniversalMiddleware,
 } from './renderPageServer/createHttpResponse.js'
 import { logRuntimeError, logRuntimeInfo } from './loggerRuntime.js'
 import { assertArguments } from './renderPageServer/assertArguments.js'
@@ -76,16 +75,6 @@ import { getVikeConfigError } from '../../shared-server-node/getVikeConfigError.
 import { forkPageContext } from '../../shared-server-client/forkPageContext.js'
 import { getAsyncLocalStorage, type AsyncStore } from './asyncHook.js'
 import '../assertEnvServer.js'
-import {
-  enhance,
-  apply,
-  universalSymbol,
-  UniversalRouter,
-  getAdapterRuntime,
-  type EnhancedMiddleware,
-  type UniversalHandler,
-} from '@universal-middleware/core'
-import { createRequestAdapter } from '@universal-middleware/node/request'
 
 const globalObject = getGlobalObject('runtime/renderPageServer.ts', {
   httpRequestsCount: 0,
@@ -172,13 +161,9 @@ async function renderPageServerEntryOnceBegin(
 
   const pageContextBegin = getPageContextBegin(pageContextInit, globalContext, requestId, asyncStore)
 
-  const middlewares: EnhancedMiddleware[] = (globalContext.config.middleware ?? []).flat()
-  const renderPageServerEntry = () => renderPageServerEntryOnce(pageContextBegin, globalContext, requestId)
-  if (middlewares.length === 0) {
-    return renderPageServerEntry()
-  } else {
-    return renderPageServerEntryWithMiddlewares(pageContextBegin, renderPageServerEntry, middlewares)
-  }
+  // `+middleware` (Universal Middlewares) are applied independently of page rendering, see
+  // getUniversalMiddlewares(). They aren't run here on purpose.
+  return renderPageServerEntryOnce(pageContextBegin, globalContext, requestId)
 }
 
 async function renderPageServerEntryOnce(
@@ -367,54 +352,6 @@ async function renderPageServerEntryRecursive_onError(
   return pageContextErrorPage
 }
 
-const requestAdapter = createRequestAdapter()
-async function renderPageServerEntryWithMiddlewares(
-  pageContext: PageContextBegin,
-  renderPageServerEntry: () => Promise<PageContextAfterRender>,
-  middlewares: EnhancedMiddleware[],
-) {
-  const router = new UniversalRouter(true, false)
-  let httpResponseVikeCore = undefined as undefined | HttpResponse
-  // Wrap rendering into universal-middleware routing
-  apply(router, [
-    enhance(
-      async function adaptRenderPageServerEntryOnceInternal(): Promise<Response> {
-        const pageContextHttpResponse = await renderPageServerEntry()
-        const { httpResponse } = pageContextHttpResponse
-        pageContext = pageContextHttpResponse as any
-        httpResponseVikeCore = httpResponse
-        const readable = httpResponse.getReadableWebStream()
-        return new Response(readable, {
-          status: httpResponse.statusCode,
-          headers: httpResponse.headers,
-        })
-      },
-      {
-        name: 'vike',
-        method: ['GET', 'POST', 'PUT', 'PATCH', 'HEAD', 'OPTIONS'],
-        path: '/**', // rou3 format
-        immutable: true, // avoids cloning the function we just created
-      },
-    ),
-    ...middlewares,
-  ])
-  const handler = router[universalSymbol] as UniversalHandler
-
-  const request =
-    pageContext._reqWeb ??
-    (pageContext._nodeDev
-      ? requestAdapter(pageContext._nodeDev.req, pageContext._nodeDev.res)
-      : new Request(new URL(pageContext.urlOriginal, 'http://localhost').toString(), {
-          headers: pageContext.headers ?? {},
-        }))
-
-  const res = await handler(request, {}, getAdapterRuntime('other', { params: undefined }))
-
-  const httpResponse = createHttpResponseFromUniversalMiddleware(res, httpResponseVikeCore?.earlyHints)
-  objectAssign(pageContext, { httpResponse })
-  return pageContext
-}
-
 function logHttpRequest(urlOriginal: string, pageContextInit: PageContextInit, requestId: number) {
   const pageContext = createPageContextServerWithoutGlobalContext(pageContextInit, requestId)
   logRuntimeInfo?.(getRequestInfoMessage(urlOriginal), pageContext, 'info')
@@ -459,8 +396,7 @@ function logHttpResponse(urlOriginalPretty: string, pageContextReturn: PageConte
         const headerRedirect = pageContextReturn.httpResponse.headers
           .slice()
           .reverse()
-          // Case-insensitive: a redirect returned by a +middleware comes from a Web Response whose
-          // Headers object lower-cases header names (`location`), while Vike's own redirect() uses `Location`.
+          // Case-insensitive: Vike's own redirect() uses `Location` but other redirects may use `location`.
           .find((header) => header[0].toLowerCase() === 'location')
         assert(headerRedirect)
         const urlRedirect = headerRedirect[1]

--- a/packages/vike/src/server/runtime/renderPageServer/createHttpResponse.ts
+++ b/packages/vike/src/server/runtime/renderPageServer/createHttpResponse.ts
@@ -6,7 +6,6 @@ export { createHttpResponseErrorFallbackJson }
 export { createHttpResponseRedirect }
 export { createHttpResponse404 }
 export { createHttpResponseBaseIsMissing }
-export { createHttpResponseFromUniversalMiddleware }
 export type { HttpResponse }
 
 import type { GetPageAssets } from './getPageAssets.js'
@@ -159,17 +158,6 @@ function createHttpResponseRedirect({ url, statusCode }: UrlRedirect, pageContex
     // For users: showing a blank page is probably better than a flickering text.
     getHtmlFallback(`<p style="display: none">Redirecting to ${escapeHtml(url)}</p>`),
   )
-}
-
-function createHttpResponseFromUniversalMiddleware(response: Response, earlyHints?: EarlyHint[]) {
-  const body = response.body ?? getHtmlFallback('<p style="display: none">No HTTP response body.</p>')
-  const httpResponse = createHttpResponseCommon(
-    response.status,
-    Array.from(response.headers.entries()),
-    body,
-    earlyHints,
-  )
-  return httpResponse
 }
 
 function getHtmlFallback(bodyHtml: string, logText: string = htmlFallbackLog): string {

--- a/packages/vike/src/server/runtime/runUniversalMiddlewares.ts
+++ b/packages/vike/src/server/runtime/runUniversalMiddlewares.ts
@@ -1,0 +1,50 @@
+export { runUniversalMiddlewares }
+
+import {
+  apply,
+  enhance,
+  universalSymbol,
+  UniversalRouter,
+  type EnhancedMiddleware,
+  type HttpMethod,
+  type RuntimeAdapter,
+  type UniversalHandler,
+} from '@universal-middleware/core'
+import '../assertEnvServer.js'
+
+// All HTTP methods, so that the fall-through sentinel matches every request.
+// (Universal Middleware's `pipe()` throws `No Response found` when no terminal handler is reached.)
+const httpMethods: HttpMethod[] = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+
+/**
+ * Run Universal Middlewares (`+middleware`) against a request, decoupled from page rendering.
+ *
+ * - If a middleware returns a `Response`, it's returned (short-circuit).
+ * - Otherwise:
+ *   - With `terminalHandler`, its `Response` is returned.
+ *   - Without `terminalHandler`, `null` is returned and the caller should fall through to the next handler.
+ */
+async function runUniversalMiddlewares(
+  middlewares: EnhancedMiddleware[],
+  request: Request,
+  context: Universal.Context,
+  runtime: RuntimeAdapter,
+  terminalHandler?: EnhancedMiddleware,
+): Promise<Response | null> {
+  const router = new UniversalRouter(true, false)
+  // Sentinel terminal handler representing "no middleware handled this request" (i.e. fall through).
+  const fallThrough = new Response(null)
+  const terminal =
+    terminalHandler ??
+    enhance(() => fallThrough, {
+      name: 'vike:fall-through',
+      method: httpMethods,
+      path: '/**',
+      immutable: true,
+    })
+  apply(router, [terminal, ...middlewares])
+  const handler = router[universalSymbol] as UniversalHandler
+  const response = await handler(request, context, runtime)
+  if (!terminalHandler && response === fallThrough) return null
+  return response
+}

--- a/test/universal-deploy/+server.ts
+++ b/test/universal-deploy/+server.ts
@@ -1,15 +1,50 @@
 import type { Server } from 'vike/types'
 import vike, { toFetchHandler } from '@vikejs/express'
+import { getUniversalMiddlewares } from 'vike/getUniversalMiddlewares'
+import {
+  apply,
+  enhance,
+  universalSymbol,
+  UniversalRouter,
+  type HttpMethod,
+  type UniversalHandler,
+} from '@universal-middleware/core'
 import express from 'express'
 
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000
+
+const httpMethods: HttpMethod[] = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+
+// Applies the app's +middleware (Universal Middlewares), e.g. the Telefunc middleware, to all URLs.
+//
+// The +middleware are resolved *lazily* (upon the first request) on purpose: resolving them eagerly
+// (`await getUniversalMiddlewares()` at startup) would, in development, await Vike's dev server before
+// it's ready — deadlocking, since Vike's dev server awaits this server entry to finish loading.
+let middlewaresPromise: ReturnType<typeof getUniversalMiddlewares> | undefined
+const universalMiddlewares = enhance(
+  async (request, context, runtime) => {
+    const middlewares = await (middlewaresPromise ??= getUniversalMiddlewares())
+    if (middlewares.length === 0) return
+    const router = new UniversalRouter(true, false)
+    const fallThrough = new Response(null)
+    apply(router, [
+      enhance(() => fallThrough, { name: 'fall-through', method: httpMethods, path: '/**', immutable: true }),
+      ...middlewares,
+    ])
+    const handler = router[universalSymbol] as UniversalHandler
+    const response = await handler(request, context, runtime)
+    // No +middleware handled the request: fall through to Vike's render handler.
+    return response === fallThrough ? undefined : response
+  },
+  { name: 'universal-middlewares' },
+)
 
 async function serve() {
   const app = express()
 
   app.get('/express', (_req, res) => res.send('Running express server'))
 
-  vike(app)
+  vike(app, [universalMiddlewares])
 
   return toFetchHandler(app)
 }

--- a/test/universal-deploy/+server.ts
+++ b/test/universal-deploy/+server.ts
@@ -1,50 +1,17 @@
 import type { Server } from 'vike/types'
 import vike, { toFetchHandler } from '@vikejs/express'
-import { getUniversalMiddlewares } from 'vike/getUniversalMiddlewares'
-import {
-  apply,
-  enhance,
-  universalSymbol,
-  UniversalRouter,
-  type HttpMethod,
-  type UniversalHandler,
-} from '@universal-middleware/core'
+import { universalMiddleware } from 'vike/getUniversalMiddlewares'
 import express from 'express'
 
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000
-
-const httpMethods: HttpMethod[] = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
-
-// Applies the app's +middleware (Universal Middlewares), e.g. the Telefunc middleware, to all URLs.
-//
-// The +middleware are resolved *lazily* (upon the first request) on purpose: resolving them eagerly
-// (`await getUniversalMiddlewares()` at startup) would, in development, await Vike's dev server before
-// it's ready — deadlocking, since Vike's dev server awaits this server entry to finish loading.
-let middlewaresPromise: ReturnType<typeof getUniversalMiddlewares> | undefined
-const universalMiddlewares = enhance(
-  async (request, context, runtime) => {
-    const middlewares = await (middlewaresPromise ??= getUniversalMiddlewares())
-    if (middlewares.length === 0) return
-    const router = new UniversalRouter(true, false)
-    const fallThrough = new Response(null)
-    apply(router, [
-      enhance(() => fallThrough, { name: 'fall-through', method: httpMethods, path: '/**', immutable: true }),
-      ...middlewares,
-    ])
-    const handler = router[universalSymbol] as UniversalHandler
-    const response = await handler(request, context, runtime)
-    // No +middleware handled the request: fall through to Vike's render handler.
-    return response === fallThrough ? undefined : response
-  },
-  { name: 'universal-middlewares' },
-)
 
 async function serve() {
   const app = express()
 
   app.get('/express', (_req, res) => res.send('Running express server'))
 
-  vike(app, [universalMiddlewares])
+  // Applies the app's +middleware (Universal Middlewares), e.g. the Telefunc middleware, to all URLs.
+  vike(app, [universalMiddleware])
 
   return toFetchHandler(app)
 }


### PR DESCRIPTION
Closes #3407.

Implements the design agreed in the issue: decouple Universal Middlewares (`+middleware`) from page rendering so they apply to **all** HTTP requests and can be positioned independently of `renderPage()`.

Per your decisions on the issue:
1. **Move it out entirely** — `+middleware` no longer runs inside `renderPage()`.
2. **`EnhancedMiddleware[]`** — `getUniversalMiddlewares()` returns the resolved list.
3. **Adapters** — kept non-breaking (see "Adapters" below).
4. **Naming** — `getUniversalMiddlewares()`, export path `vike/getUniversalMiddlewares`.

## What changed

- **`getUniversalMiddlewares(): Promise<EnhancedMiddleware[]>`** (`vike/getUniversalMiddlewares`) — the resolved `+middleware` list, for manual composition.
- **`universalMiddleware`** (also `vike/getUniversalMiddlewares`) — a ready-to-use single Universal Middleware that applies all your `+middleware`, resolved **lazily** (see deadlock note below). This is the drop-in for servers/adapters:
  ```js
  import { universalMiddleware } from 'vike/getUniversalMiddlewares'
  import vikeHandler from 'vike/universal-middleware'
  apply(app, [universalMiddleware, vikeHandler])
  ```
- **`renderPage()` no longer runs `+middleware`** — removed `renderPageServerEntryWithMiddlewares()`.
- **`vike/fetch`** composes `+middleware` + the render handler (lazily, per request).
- **Vike's dev & preview servers** run `+middleware` before the SSR middleware (new `addUniversalMiddlewares()` Connect middleware).
- Render handler (`vike/universal-middleware`) unchanged → existing adapters keep rendering.

## ⚠️ Why "lazy"

The natural usage `apply(server, [...await getUniversalMiddlewares(), vikeHandler])` works for a **standalone prod server**, but **deadlocks** at `+server.js` startup in dev: `getUniversalMiddlewares()` awaits the Vite dev server, which is itself awaiting the server entry to finish loading. So the `+server.js`/adapter path must resolve `+middleware` **per-request** — which is exactly what `universalMiddleware`, `vike/fetch`, and the dev/preview wiring do.

## Adapters (`vike-server-adapters`)

No breaking change required: `universalMiddleware` composes through the existing `vike(app, [...])` argument (`test/universal-deploy` uses it). Making `vike(app)` auto-apply `+middleware` is an optional ergonomic follow-up (a separate PR on the same branch), cleanly built on `universalMiddleware`.

## Validation

- `tsc` build clean; **180 unit tests pass**.
- **`test/plusMiddlewares`** (dev + preview): middleware short-circuit, redirect (`303`), fall-through — verified by running the servers.
- **`test/universal-deploy`** (dev + prod build): Telefunc `+middleware` (`POST /_telefunc`), the `/express` route, and page rendering — verified via `universalMiddleware`.
- **`test/@cloudflare_vite-plugin_ud`** (`vike/fetch`): typechecks; covered by the fetch composition.
- Adversarial unit tests of the router logic against the real `@universal-middleware/core` (short-circuit, fall-through, method routing, context flow, terminal-vs-sentinel).

Docs note: new JSDoc points at `https://github.com/magne4000/universal-middleware` (matching the existing `+middleware` config doc) since `vike.dev/middleware` doesn't exist yet — tell me the canonical URL and I'll update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tc8dfjnaHuFb923GoT1dVT