### PR TITLE
sync-github-releases: four small clarity/consistency refactors

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all.ts
+++ b/.github/workflows/sync-github-releases/delete-all.ts
@@ -5,7 +5,7 @@ main()
 
 import { createReleasesClientFromEnv } from './utils/github-env.ts'
 
-async function main() {
+async function main(): Promise<void> {
   const { client, owner, repo } = createReleasesClientFromEnv()
 
   console.log(`Fetching releases for ${owner}/${repo} …`)

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -33,17 +33,17 @@ function createSyncContext(
 
 // Sync one package: derive its expected releases from CHANGELOG.md (the source of truth), reconcile
 // them against the package's existing GitHub Releases into a plan, then apply that plan.
-async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> {
+async function syncPackage(packageDir: string, context: SyncContext): Promise<void> {
   const packageName = await readPackageName(packageDir)
-  const tagScheme = getTagScheme(packageName, ctx.hasMultiplePackages)
+  const tagScheme = getTagScheme(packageName, context.hasMultiplePackages)
   const changelogNotes = await readChangelogNotes(packageDir)
   const releaseNotesByVersion = buildReleaseBodies(changelogNotes, {
     tagScheme,
-    changelogUrl: getChangelogUrl(packageDir, ctx.changelogUrlBase),
+    changelogUrl: getChangelogUrl(packageDir, context.changelogUrlBase),
   })
-  const githubReleases = await ctx.client.list()
+  const githubReleases = await context.client.list()
   const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
-  await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
+  await applyReleasePlan({ plan, client: context.client, defaultBranch: context.defaultBranch, dryRun: context.dryRun })
 }
 
 // Turn each version's parsed changelog notes into the release body we publish (buildReleaseBody()). Separate

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -46,9 +46,9 @@ async function syncPackage(packageDir: string, ctx: SyncContext): Promise<void> 
   await applyReleasePlan({ plan, client: ctx.client, defaultBranch: ctx.defaultBranch, dryRun: ctx.dryRun })
 }
 
-// Turn each version's parsed changelog notes into the release body we publish (buildReleaseBody()). Kept
-// out of the disk read (readChangelogNotes()) because the release date is resolved from git — the tag
-// scheme turns a version into its tag (getReleaseDate()) — which the pure changelog parsing knows nothing of.
+// Turn each version's parsed changelog notes into the release body we publish (buildReleaseBody()). Separate
+// from the disk read (readChangelogNotes()) because each body is stamped with the version's release date,
+// which is resolved from git (getReleaseDate()) — something the pure changelog parsing knows nothing of.
 function buildReleaseBodies(
   changelogNotes: ReleaseNotesByVersion,
   { tagScheme, changelogUrl }: { tagScheme: TagScheme; changelogUrl: string },

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -41,6 +41,14 @@ function createReleasesClient({
   apiUrl,
 }: { owner: string; repo: string; token: string; apiUrl: string }): ReleasesClient {
   const releasesPath = `/repos/${owner}/${repo}/releases`
+  // Identical on every request of this client, so build them once.
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'User-Agent': 'sync-github-releases-workflow',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
   let writeCount = 0
 
   async function request<T = void>(
@@ -57,13 +65,7 @@ function createReleasesClient({
 
     const response = await fetch(new URL(pathname, apiUrl), {
       method,
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'User-Agent': 'sync-github-releases-workflow',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
+      headers,
       body: body ? JSON.stringify(body) : undefined,
     })
 


### PR DESCRIPTION
A focused audit-and-refactor pass over `.github/workflows/sync-github-releases/`. I rated every file, every function, and every distinct piece of logic in the tool, and this is the set of changes that were genuinely justified — the directory is already in very good shape after its prior refactors, so I deliberately kept this small rather than manufacturing churn.

Each refactor is its own commit:

1. **Fix the `buildReleaseBodies` comment misattribution** — it credited `getReleaseDate()` with "turning a version into its tag" (that's the tag scheme's job). Reworded to state what's actually true: each body is stamped with the release date, which `getReleaseDate()` resolves from git.
2. **Name `syncPackage`'s context parameter consistently** — it was the only place abbreviating `SyncContext` to `ctx`; `sync.ts` and `createSyncContext` both use `context`. Now one name everywhere.
3. **Annotate `delete-all.ts`'s `main(): Promise<void>`** — it was the lone function in the tool without a return-type annotation; `sync.ts`'s `main()` already has one.
4. **Build the GitHub request headers once per client** — the headers are invariant for a given client (token + static GitHub headers), yet `request()` rebuilt the object on every call. Hoisted into the closure next to `releasesPath`.

No behavior changes. Verified after each commit:
- `tsc --noEmit` clean
- `biome check` clean (16 files)
- 23 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmbUVKHd2SGJYY8NnZ1FeK)_