### PR TITLE
sync-github-releases: move the dry-run gate and write logging into the client

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all.ts
+++ b/.github/workflows/sync-github-releases/delete-all.ts
@@ -6,15 +6,15 @@ main()
 import { createReleasesClientFromEnv } from './utils/github-env.ts'
 
 async function main(): Promise<void> {
-  const { client, owner, repo } = createReleasesClientFromEnv()
+  const { client, owner, repo } = createReleasesClientFromEnv(false)
 
   console.log(`Fetching releases for ${owner}/${repo} …`)
   const githubReleases = await client.list()
 
+  // The client logs each deletion (`Deleted release <tag>`).
   console.log(`Starting delete of ${githubReleases.length} releases …`)
   for (const release of githubReleases) {
-    console.log(`Deleting release ${release.tag_name} (ID: ${release.id}) …`)
-    await client.delete(release.id)
+    await client.delete({ release_id: release.id, tag_name: release.tag_name })
   }
 
   console.log(`Deleted ${githubReleases.length} releases.`)

--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -26,14 +26,13 @@ async function main(): Promise<void> {
     return
   }
 
-  const { client, owner, repo } = createReleasesClientFromEnv()
+  const { client, owner, repo } = createReleasesClientFromEnv(dryRun)
   const context = createSyncContext({
     client,
     owner,
     repo,
     defaultBranch: getDefaultBranch(),
     hasMultiplePackages: allPackageDirs.length > 1,
-    dryRun,
   })
 
   for (const packageDir of packageDirs) {

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.spec.ts
@@ -8,6 +8,8 @@ import { findReleaseCommit, gitTagExists } from '../utils/git.ts'
 // (and its two refuse-to-tag failures) can run without a real repo. update/delete don't touch git.
 vi.mock('../utils/git.ts', () => ({ gitTagExists: vi.fn(), findReleaseCommit: vi.fn() }))
 
+// The --dry-run gate and the per-write logging live in the client now (see github.spec.ts); this fake
+// just records which writes the plan drives, in which order.
 function createFakeClient(): { client: ReleasesClient; calls: string[] } {
   const calls: string[] = []
   const client: ReleasesClient = {
@@ -17,53 +19,36 @@ function createFakeClient(): { client: ReleasesClient; calls: string[] } {
     async create() {
       calls.push('create')
     },
-    async update(releaseId) {
-      calls.push(`update:${releaseId}`)
+    async update(release) {
+      calls.push(`update:${release.release_id}`)
     },
-    async delete(releaseId) {
-      calls.push(`delete:${releaseId}`)
+    async delete(release) {
+      calls.push(`delete:${release.release_id}`)
     },
   }
   return { client, calls }
 }
 
 describe('applyReleasePlan()', () => {
-  // update + delete only (no creates), so the git stub stays untouched. The dry-run gate is shared by
-  // all three actions via applyWrite(), so update + delete prove it.
-  const plan: ReleasePlan = {
-    releasesToCreate: [],
-    releasesToUpdate: [{ release_id: 1, tag_name: 'v1.0.0', body: 'Fresh notes' }],
-    releasesToDelete: [{ release_id: 2, tag_name: 'v0.9.0' }],
-  }
-
-  it('performs each write and logs it', async () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+  it('issues each write to the client', async () => {
     const { client, calls } = createFakeClient()
 
-    await applyReleasePlan({ plan, client, defaultBranch: 'main', dryRun: false })
+    await applyReleasePlan({
+      plan: {
+        releasesToCreate: [],
+        releasesToUpdate: [{ release_id: 1, tag_name: 'v1.0.0', body: 'Fresh notes' }],
+        releasesToDelete: [{ release_id: 2, tag_name: 'v0.9.0' }],
+      },
+      client,
+      defaultBranch: 'main',
+    })
 
     expect(calls).toEqual(['update:1', 'delete:2'])
-    expect(log.mock.calls.flat()).toEqual(['Updated release v1.0.0', 'Deleted release v0.9.0'])
-    log.mockRestore()
   })
 
-  it('under --dry-run, announces every action but performs no write', async () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
-    const { client, calls } = createFakeClient()
-
-    await applyReleasePlan({ plan, client, defaultBranch: 'main', dryRun: true })
-
-    expect(calls).toEqual([])
-    expect(log.mock.calls.flat()).toEqual([
-      '[dry-run] Would update release v1.0.0',
-      '[dry-run] Would delete release v0.9.0',
-    ])
-    log.mockRestore()
-  })
-
-  // A create whose git tag is missing must never be tagged at the wrong commit. These two hard fails
-  // are the tool's safety guards, and the create path has no e2e net — so they earn a test even though
-  // the dry-run gate can't reach them (resolution happens before it, so a dry run still fails fast).
+  // A create whose git tag is missing must never be tagged at the wrong commit. These two hard fails are
+  // the tool's safety guards, and the create path has no e2e net — so they earn a test. Resolution runs
+  // before the client is called, so even a dry run fails fast.
   describe('refuses to create a release whose git tag is missing', () => {
     const createPlan = (isLatest: boolean): ReleasePlan => ({
       releasesToCreate: [{ tag_name: 'v1.0.0', body: 'Notes', version: '1.0.0', isLatest }],
@@ -75,9 +60,9 @@ describe('applyReleasePlan()', () => {
       vi.mocked(gitTagExists).mockReturnValue(false)
       const { client } = createFakeClient()
 
-      await expect(
-        applyReleasePlan({ plan: createPlan(true), client, defaultBranch: 'main', dryRun: false }),
-      ).rejects.toThrow(/latest release must already be tagged/)
+      await expect(applyReleasePlan({ plan: createPlan(true), client, defaultBranch: 'main' })).rejects.toThrow(
+        /latest release must already be tagged/,
+      )
     })
 
     it("hard-fails an older release whose commit can't be deduced", async () => {
@@ -85,9 +70,9 @@ describe('applyReleasePlan()', () => {
       vi.mocked(findReleaseCommit).mockReturnValue(null)
       const { client } = createFakeClient()
 
-      await expect(
-        applyReleasePlan({ plan: createPlan(false), client, defaultBranch: 'main', dryRun: false }),
-      ).rejects.toThrow(/couldn't be deduced/)
+      await expect(applyReleasePlan({ plan: createPlan(false), client, defaultBranch: 'main' })).rejects.toThrow(
+        /couldn't be deduced/,
+      )
     })
   })
 })

--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -4,32 +4,27 @@ import type { ReleasePlan, ReleaseToCreate } from './release-plan.ts'
 import { findReleaseCommit, gitTagExists } from '../utils/git.ts'
 import type { NewRelease, ReleasesClient } from '../utils/github.ts'
 
-// Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. The
-// --dry-run gate lives here rather than in the client, so the client stays a plain transport and each
-// action is logged the same way whether or not it's actually performed.
+// Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. The client
+// gates each write on --dry-run and logs it (see createReleasesClient()); the one thing that must happen
+// here, before the client is even called, is resolving each create's target commit — so a dry run still
+// surfaces a missing-tag failure or a deduced-commit warning.
 async function applyReleasePlan({
   plan,
   client,
   defaultBranch,
-  dryRun,
 }: {
   plan: ReleasePlan
   client: ReleasesClient
   defaultBranch: string
-  dryRun: boolean
 }): Promise<void> {
   for (const release of plan.releasesToCreate) {
-    // Resolve (and validate) the tag's commit before the dry-run gate, so a dry run still surfaces a
-    // missing-tag failure or a deduced-commit warning.
     const targetCommitish = resolveTargetCommitish(release, defaultBranch)
-    await applyWrite(dryRun, 'create', release.tag_name, () => client.create(buildNewRelease(release, targetCommitish)))
+    await client.create(buildNewRelease(release, targetCommitish))
   }
 
-  for (const release of plan.releasesToUpdate)
-    await applyWrite(dryRun, 'update', release.tag_name, () => client.update(release.release_id, release.body))
+  for (const release of plan.releasesToUpdate) await client.update(release)
 
-  for (const release of plan.releasesToDelete)
-    await applyWrite(dryRun, 'delete', release.tag_name, () => client.delete(release.release_id))
+  for (const release of plan.releasesToDelete) await client.delete(release)
 }
 
 // The commit a to-be-created release is tagged at (its GitHub `target_commitish`):
@@ -67,20 +62,4 @@ function buildNewRelease(release: ReleaseToCreate, targetCommitish: string): New
     // wrongly mark the old one Latest.
     make_latest: release.isLatest ? 'true' : 'false',
   }
-}
-
-// Perform one write against GitHub — or, under --dry-run, just announce it.
-const pastTense = { create: 'Created', update: 'Updated', delete: 'Deleted' } as const
-async function applyWrite(
-  dryRun: boolean,
-  action: keyof typeof pastTense,
-  releaseTag: string,
-  write: () => Promise<void>,
-): Promise<void> {
-  if (dryRun) {
-    console.log(`[dry-run] Would ${action} release ${releaseTag}`)
-    return
-  }
-  await write()
-  console.log(`${pastTense[action]} release ${releaseTag}`)
 }

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -22,7 +22,6 @@ type SyncContext = {
   client: ReleasesClient
   defaultBranch: string
   hasMultiplePackages: boolean
-  dryRun: boolean
   changelogUrlBase: string
 }
 
@@ -47,7 +46,7 @@ async function syncPackage(packageDir: string, context: SyncContext): Promise<vo
   const releaseBodyByVersion = buildReleaseBodies(changelogNotes, { tagScheme, changelogUrl })
   const githubReleases = await context.client.list()
   const plan = getReleasePlan({ githubReleases, releaseBodyByVersion, tagScheme })
-  await applyReleasePlan({ plan, client: context.client, defaultBranch: context.defaultBranch, dryRun: context.dryRun })
+  await applyReleasePlan({ plan, client: context.client, defaultBranch: context.defaultBranch })
 }
 
 // Turn each version's parsed changelog notes into the release body we publish (buildReleaseBody()). Separate

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -9,15 +9,15 @@ import { createReleasesClient, type ReleasesClient } from './github.ts'
 
 // How a run discovers what to act on, as whom, and against which branch: the repository, the auth
 // token, the default branch, and — on a push — which files changed. All read from the GitHub Actions
-// environment, with fallbacks for local runs. Kept apart from the API client (github.ts), which is
-// pure transport and shouldn't care where these values come from.
+// environment, with fallbacks for local runs. Kept apart from the API client (github.ts), which
+// shouldn't care where these values come from.
 
 // A GitHub Releases client for the repository this run targets, wired up from the environment. Returns
-// the resolved owner/repo too — callers need them for the web links and log lines that the client
-// (pure transport) doesn't expose.
-function createReleasesClientFromEnv(): { client: ReleasesClient; owner: string; repo: string } {
+// the resolved owner/repo too — callers need them for the web links and log lines the client doesn't
+// expose. dryRun is passed straight through to the client, which is what gates and logs the writes.
+function createReleasesClientFromEnv(dryRun: boolean): { client: ReleasesClient; owner: string; repo: string } {
   const { owner, repo } = getRepository()
-  const client = createReleasesClient({ owner, repo, token: getGithubToken(), apiUrl: getApiUrl() })
+  const client = createReleasesClient({ owner, repo, token: getGithubToken(), apiUrl: getApiUrl(), dryRun })
   return { client, owner, repo }
 }
 

--- a/.github/workflows/sync-github-releases/utils/github.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/github.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createReleasesClient } from './github.ts'
+
+// The throttle between writes sleeps via node:timers/promises; no-op it so the test doesn't actually wait.
+vi.mock('node:timers/promises', () => ({ setTimeout: () => Promise.resolve() }))
+
+function createClient(dryRun: boolean) {
+  return createReleasesClient({
+    owner: 'owner',
+    repo: 'repo',
+    token: 'token',
+    apiUrl: 'https://api.github.com',
+    dryRun,
+  })
+}
+
+const newRelease = {
+  tag_name: 'v1.0.0',
+  name: 'v1.0.0',
+  body: 'Notes',
+  target_commitish: 'main',
+  make_latest: 'true',
+} as const
+
+describe('createReleasesClient() writes', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('under --dry-run, logs what it would do and sends no request', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const client = createClient(true)
+
+    await client.create(newRelease)
+    await client.update({ release_id: 1, tag_name: 'v0.9.0', body: 'Fresh' })
+    await client.delete({ release_id: 2, tag_name: 'v0.8.0' })
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(log.mock.calls.flat()).toEqual([
+      '[dry-run] Would create release v1.0.0',
+      '[dry-run] Would update release v0.9.0',
+      '[dry-run] Would delete release v0.8.0',
+    ])
+  })
+
+  it('otherwise performs each write and logs it', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const client = createClient(false)
+
+    await client.create(newRelease)
+    await client.update({ release_id: 1, tag_name: 'v0.9.0', body: 'Fresh' })
+    await client.delete({ release_id: 2, tag_name: 'v0.8.0' })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+    expect(log.mock.calls.flat()).toEqual([
+      'Created release v1.0.0',
+      'Updated release v0.9.0',
+      'Deleted release v0.8.0',
+    ])
+  })
+})

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -21,13 +21,14 @@ type NewRelease = {
 }
 
 // A client for one repository's GitHub Releases. It binds the owner/repo/token and API base URL once,
-// so callers just say what to do — not where, nor as whom. It's a plain transport: skipping writes
-// under --dry-run is the apply step's job (see applyReleasePlan()).
+// so callers just say what to do — not where, nor as whom. The write methods gate on --dry-run (logging
+// what they would do instead of doing it) and otherwise log what they did, so every caller — the sync
+// step and delete-all alike — narrates releases the same way.
 type ReleasesClient = {
   list(): Promise<Release[]>
   create(release: NewRelease): Promise<void>
-  update(releaseId: number, body: string): Promise<void>
-  delete(releaseId: number): Promise<void>
+  update(release: { release_id: number; tag_name: string; body: string }): Promise<void>
+  delete(release: { release_id: number; tag_name: string }): Promise<void>
 }
 
 // Pause between write requests so bursts (e.g. backfilling many releases) stay under GitHub's
@@ -35,12 +36,15 @@ type ReleasesClient = {
 // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 const RATE_LIMIT_DELAY_MS = 500
 
+const pastTense = { create: 'Created', update: 'Updated', delete: 'Deleted' } as const
+
 function createReleasesClient({
   owner,
   repo,
   token,
   apiUrl,
-}: { owner: string; repo: string; token: string; apiUrl: string }): ReleasesClient {
+  dryRun,
+}: { owner: string; repo: string; token: string; apiUrl: string; dryRun: boolean }): ReleasesClient {
   const releasesPath = `/repos/${owner}/${repo}/releases`
   // Identical on every request of this client, so build them once.
   const headers = {
@@ -80,6 +84,17 @@ function createReleasesClient({
     return response.status === 204 ? (undefined as T) : ((await response.json()) as T)
   }
 
+  // Perform a write — or, under --dry-run, just announce it — and log the outcome. Shared by all three
+  // write methods so they gate and narrate identically.
+  async function write(action: keyof typeof pastTense, tagName: string, send: () => Promise<void>): Promise<void> {
+    if (dryRun) {
+      console.log(`[dry-run] Would ${action} release ${tagName}`)
+      return
+    }
+    await send()
+    console.log(`${pastTense[action]} release ${tagName}`)
+  }
+
   return {
     // https://docs.github.com/en/rest/releases/releases#list-releases
     async list(): Promise<Release[]> {
@@ -94,15 +109,19 @@ function createReleasesClient({
     },
     // https://docs.github.com/en/rest/releases/releases#create-a-release
     create(release: NewRelease): Promise<void> {
-      return request(releasesPath, { method: 'POST', body: release })
+      return write('create', release.tag_name, () => request(releasesPath, { method: 'POST', body: release }))
     },
     // https://docs.github.com/en/rest/releases/releases#update-a-release
-    update(releaseId: number, body: string): Promise<void> {
-      return request(`${releasesPath}/${releaseId}`, { method: 'PATCH', body: { body } })
+    update(release): Promise<void> {
+      return write('update', release.tag_name, () =>
+        request(`${releasesPath}/${release.release_id}`, { method: 'PATCH', body: { body: release.body } }),
+      )
     },
     // https://docs.github.com/en/rest/releases/releases#delete-a-release
-    delete(releaseId: number): Promise<void> {
-      return request(`${releasesPath}/${releaseId}`, { method: 'DELETE' })
+    delete(release): Promise<void> {
+      return write('delete', release.tag_name, () =>
+        request(`${releasesPath}/${release.release_id}`, { method: 'DELETE' }),
+      )
     },
   }
 }


### PR DESCRIPTION
Per review feedback (follow-up to #3411): inline `applyWrite` into the `ReleasesClient` instead of wrapping the client from the apply step.

Rebased onto `brillout/sync-github-releases`, so this PR is now just the single commit on top of the latest integration branch (picking up `buildNewRelease`, the `hasWritten` throttle, and the `ReleaseBodyByVersion` rename already on the branch).

## What changed

The client now takes a `dryRun` flag, and its `create`/`update`/`delete` methods share a single internal `write()` helper that:
- under `--dry-run`, logs `[dry-run] Would <action> release <tag>` and sends no request;
- otherwise performs the request and logs `<Action>ed release <tag>`.

So the dry-run gate and the per-write logging now live in one place, next to the writes themselves — and `applyReleasePlan` reads at one consistent altitude (create each / update each / delete each), with the mechanism pushed down into the client.

## Knock-on effects

- **`applyReleasePlan()` gets simpler** — drops its `dryRun` param, the `applyWrite()`/`pastTense` helpers, and its wrapper closures. The update/delete loops are now one-liners; the create loop still resolves the target commit first and reuses `buildNewRelease()`.
- **`dryRun` now flows to the client at construction** — `sync.ts` passes it to `createReleasesClientFromEnv()`; `SyncContext` no longer carries it.
- **`update()`/`delete()` now take the release object** (they need its `tag_name` for the log line) rather than bare ids.
- **`delete-all.ts` drops its own per-release log** since the client now emits one (costs the `(ID: …)` detail; passes `dryRun: false`).
- **The dry-run/logging tests moved** from `apply-release-plan.spec.ts` into a new `utils/github.spec.ts`, which mocks `fetch` to assert the gate and the exact log lines.

Verified after rebase: `tsc --noEmit` clean, `biome check` clean (17 files), 24 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)