### PR TITLE
sync-github-releases: four clarity & altitude refactors

### DIFF
--- a/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/apply-release-plan.ts
@@ -2,7 +2,7 @@ export { applyReleasePlan }
 
 import type { ReleasePlan, ReleaseToCreate } from './release-plan.ts'
 import { findReleaseCommit, gitTagExists } from '../utils/git.ts'
-import type { ReleasesClient } from '../utils/github.ts'
+import type { NewRelease, ReleasesClient } from '../utils/github.ts'
 
 // Carry out a plan from getReleasePlan() against GitHub: create, then update, then delete. The
 // --dry-run gate lives here rather than in the client, so the client stays a plain transport and each
@@ -22,18 +22,7 @@ async function applyReleasePlan({
     // Resolve (and validate) the tag's commit before the dry-run gate, so a dry run still surfaces a
     // missing-tag failure or a deduced-commit warning.
     const targetCommitish = resolveTargetCommitish(release, defaultBranch)
-    await applyWrite(dryRun, 'create', release.tag_name, () =>
-      client.create({
-        tag_name: release.tag_name,
-        name: release.tag_name,
-        body: release.body,
-        target_commitish: targetCommitish,
-        // Only the newest version may be the repo's "Latest". create-release otherwise defaults
-        // make_latest=true, so backfilling an older release while a newer one already exists would
-        // wrongly mark the old one Latest.
-        make_latest: release.isLatest ? 'true' : 'false',
-      }),
-    )
+    await applyWrite(dryRun, 'create', release.tag_name, () => client.create(buildNewRelease(release, targetCommitish)))
   }
 
   for (const release of plan.releasesToUpdate)
@@ -64,6 +53,20 @@ function resolveTargetCommitish(release: ReleaseToCreate, defaultBranch: string)
   }
   console.warn(`Tag ${releaseTag} is missing — creating its release at deduced commit ${commit}`)
   return commit
+}
+
+// The GitHub create-release payload for one planned release, tagged at the already-resolved commit.
+function buildNewRelease(release: ReleaseToCreate, targetCommitish: string): NewRelease {
+  return {
+    tag_name: release.tag_name,
+    name: release.tag_name,
+    body: release.body,
+    target_commitish: targetCommitish,
+    // Only the newest version may be the repo's "Latest". create-release otherwise defaults
+    // make_latest=true, so backfilling an older release while a newer one already exists would
+    // wrongly mark the old one Latest.
+    make_latest: release.isLatest ? 'true' : 'false',
+  }
 }
 
 // Perform one write against GitHub — or, under --dry-run, just announce it.

--- a/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.spec.ts
@@ -6,7 +6,7 @@ describe('getReleasePlan()', () => {
   it('creates missing past releases alongside the current release and updates stale notes', () => {
     const plan = getReleasePlan({
       tagScheme: getTagScheme('vike', false),
-      releaseNotesByVersion: {
+      releaseBodyByVersion: {
         '1.0.1': 'New release notes',
         '1.0.0': 'Updated old notes',
         '0.9.0': 'Existing notes',
@@ -31,7 +31,7 @@ describe('getReleasePlan()', () => {
   it('updates the current release instead of creating a duplicate', () => {
     const plan = getReleasePlan({
       tagScheme: getTagScheme('vike', false),
-      releaseNotesByVersion: {
+      releaseBodyByVersion: {
         '1.0.1': 'Fresh release notes',
       },
       githubReleases: [{ id: 3, tag_name: 'v1.0.1', body: 'Stale release notes' }],
@@ -47,7 +47,7 @@ describe('getReleasePlan()', () => {
   it('leaves releases we do not own untouched (no spurious update or delete)', () => {
     const plan = getReleasePlan({
       tagScheme: getTagScheme('vike', false),
-      releaseNotesByVersion: { '1.0.0': 'Notes' },
+      releaseBodyByVersion: { '1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
         // Not one of our vX.Y.Z tags: must not be updated (no undefined body) nor deleted.
@@ -61,7 +61,7 @@ describe('getReleasePlan()', () => {
   it('deletes a release whose version was removed from the changelog', () => {
     const plan = getReleasePlan({
       tagScheme: getTagScheme('vike', false),
-      releaseNotesByVersion: { '1.0.0': 'Notes' },
+      releaseBodyByVersion: { '1.0.0': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'v1.0.0', body: 'Notes' },
         { id: 2, tag_name: 'v0.9.0', body: 'Removed from changelog' },
@@ -78,7 +78,7 @@ describe('getReleasePlan()', () => {
   it('only deletes releases in its own namespace', () => {
     const plan = getReleasePlan({
       tagScheme: getTagScheme('create-vike-core', true),
-      releaseNotesByVersion: { '0.0.1': 'Notes' },
+      releaseBodyByVersion: { '0.0.1': 'Notes' },
       githubReleases: [
         { id: 1, tag_name: 'create-vike-core@0.0.1', body: 'Notes' },
         // Another package's release — not ours to delete.
@@ -92,7 +92,7 @@ describe('getReleasePlan()', () => {
   it('qualifies tags with the package name when several packages share the repo', () => {
     const plan = getReleasePlan({
       tagScheme: getTagScheme('create-vike-core', true),
-      releaseNotesByVersion: {
+      releaseBodyByVersion: {
         '0.0.2': 'New notes',
         '0.0.1': 'Old notes',
       },

--- a/.github/workflows/sync-github-releases/sync/release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.ts
@@ -64,6 +64,9 @@ function getReleasePlan({
     if (!existingRelease) {
       releasesToCreate.push({ tag_name: releaseTag, body, version, isLatest: version === latestVersion })
     } else if (existingRelease.body?.trim() !== body) {
+      // Only the stored body is trimmed: GitHub can hand it back padded with surrounding whitespace,
+      // whereas our freshly built body has none — without the trim, every sync would see a phantom
+      // drift and re-update.
       releasesToUpdate.push({ release_id: existingRelease.id, tag_name: releaseTag, body })
     }
   }

--- a/.github/workflows/sync-github-releases/sync/release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.ts
@@ -2,7 +2,7 @@ export { getReleasePlan }
 export type { ReleasePlan }
 export type { ReleaseToCreate }
 
-import type { ReleaseNotesByVersion } from '../utils/changelog.ts'
+import type { ReleaseBodyByVersion } from '../utils/changelog.ts'
 import type { Release } from '../utils/github.ts'
 import type { TagScheme } from './tag-scheme.ts'
 
@@ -31,11 +31,11 @@ type ReleaseToDelete = {
 
 function getReleasePlan({
   githubReleases,
-  releaseNotesByVersion,
+  releaseBodyByVersion,
   tagScheme,
 }: {
   githubReleases: Release[]
-  releaseNotesByVersion: ReleaseNotesByVersion
+  releaseBodyByVersion: ReleaseBodyByVersion
   tagScheme: TagScheme
 }): ReleasePlan {
   // Reconcile from the changelog (the source of truth), not from the GitHub Releases: iterating the
@@ -47,9 +47,9 @@ function getReleasePlan({
   const releasesToCreate: ReleaseToCreate[] = []
   const releasesToUpdate: ReleaseToUpdate[] = []
 
-  // releaseNotesByVersion is newest-first; the newest version is the one eligible to be the repo's
+  // releaseBodyByVersion is newest-first; the newest version is the one eligible to be the repo's
   // "Latest". Capture it before reversing.
-  const versions = Object.keys(releaseNotesByVersion)
+  const versions = Object.keys(releaseBodyByVersion)
   const latestVersion = versions[0]
 
   // Iterate oldest-first so releases are created (and their notifications sent) in chronological
@@ -57,7 +57,7 @@ function getReleasePlan({
   // (GitHub orders the releases list by tag semver regardless:
   // https://github.com/vikejs/vike/pull/3157#issuecomment-4406846257)
   for (const version of [...versions].reverse()) {
-    const body = releaseNotesByVersion[version]
+    const body = releaseBodyByVersion[version]
     const releaseTag = tagScheme.build(version)
     expectedTags.add(releaseTag)
     const existingRelease = releasesByTag.get(releaseTag)

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -7,7 +7,12 @@ import path from 'node:path'
 import { applyReleasePlan } from './apply-release-plan.ts'
 import { getReleasePlan } from './release-plan.ts'
 import { getTagScheme, type TagScheme } from './tag-scheme.ts'
-import { buildReleaseBody, parseChangelog, type ReleaseNotesByVersion } from '../utils/changelog.ts'
+import {
+  buildReleaseBody,
+  parseChangelog,
+  type ReleaseBodyByVersion,
+  type ReleaseNotesByVersion,
+} from '../utils/changelog.ts'
 import { getReleaseDate } from '../utils/git.ts'
 import type { ReleasesClient } from '../utils/github.ts'
 
@@ -38,12 +43,10 @@ async function syncPackage(packageDir: string, context: SyncContext): Promise<vo
   const packageName = await readPackageName(packageDir)
   const tagScheme = getTagScheme(packageName, context.hasMultiplePackages)
   const changelogNotes = await readChangelogNotes(packageDir)
-  const releaseNotesByVersion = buildReleaseBodies(changelogNotes, {
-    tagScheme,
-    changelogUrl: getChangelogUrl(packageDir, context.changelogUrlBase),
-  })
+  const changelogUrl = getChangelogUrl(packageDir, context.changelogUrlBase)
+  const releaseBodyByVersion = buildReleaseBodies(changelogNotes, { tagScheme, changelogUrl })
   const githubReleases = await context.client.list()
-  const plan = getReleasePlan({ githubReleases, releaseNotesByVersion, tagScheme })
+  const plan = getReleasePlan({ githubReleases, releaseBodyByVersion, tagScheme })
   await applyReleasePlan({ plan, client: context.client, defaultBranch: context.defaultBranch, dryRun: context.dryRun })
 }
 
@@ -53,7 +56,7 @@ async function syncPackage(packageDir: string, context: SyncContext): Promise<vo
 function buildReleaseBodies(
   changelogNotes: ReleaseNotesByVersion,
   { tagScheme, changelogUrl }: { tagScheme: TagScheme; changelogUrl: string },
-): ReleaseNotesByVersion {
+): ReleaseBodyByVersion {
   return Object.fromEntries(
     Object.entries(changelogNotes).map(([version, notes]) => [
       version,

--- a/.github/workflows/sync-github-releases/utils/changelog.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.ts
@@ -1,10 +1,14 @@
 export { parseChangelog }
 export { buildReleaseBody }
 
+// Release info keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`), newest first — two stages of the
+// same shape: the notes parsed straight from CHANGELOG.md (ReleaseNotesByVersion) become the body we
+// publish (ReleaseBodyByVersion) once buildReleaseBody() adds a date line and a footer.
 export type ReleaseNotesByVersion = Record<string, string>
+export type ReleaseBodyByVersion = Record<string, string>
 
-// Parse a CHANGELOG.md into release notes keyed by raw version (e.g. `0.4.257`, `0.1.0-beta.6`),
-// newest first. Decorating a version into its git tag is getTagScheme()'s job, not ours.
+// Parse a CHANGELOG.md into one notes entry per version. Decorating a version into its git tag is
+// getTagScheme()'s job, not ours.
 function parseChangelog(changelog: string): ReleaseNotesByVersion {
   // Match each version heading, ignoring any link release-me appends after the version
   // (`## [0.4.257](…)`) — only the version itself is captured.

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -49,7 +49,7 @@ function createReleasesClient({
     'User-Agent': 'sync-github-releases-workflow',
     'X-GitHub-Api-Version': '2022-11-28',
   }
-  let writeCount = 0
+  let hasWritten = false
 
   async function request<T = void>(
     pathname: string,
@@ -59,8 +59,8 @@ function createReleasesClient({
     // case of a single new release — shouldn't wait at all. So a backfill of N writes pays N-1 delays,
     // while one write pays none.
     if (method !== 'GET') {
-      if (writeCount > 0) await setTimeout(RATE_LIMIT_DELAY_MS)
-      writeCount++
+      if (hasWritten) await setTimeout(RATE_LIMIT_DELAY_MS)
+      hasWritten = true
     }
 
     const response = await fetch(new URL(pathname, apiUrl), {

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -1,5 +1,6 @@
 export { createReleasesClient }
 export type { Release }
+export type { NewRelease }
 export type { ReleasesClient }
 
 import { setTimeout } from 'node:timers/promises'


### PR DESCRIPTION
Four small, behavior-preserving refactors targeting the weakest remaining spots in the `sync-github-releases` tooling. Each is its own commit; tests (23), typecheck, and Biome all stay green.

### 1. Name the published body apart from the parsed notes
`ReleaseNotesByVersion` was doing double duty — it typed both the raw notes parsed out of `CHANGELOG.md` and the published release *body* (notes + date line + footer) built from them. The map returned by `buildReleaseBodies()` and consumed by `getReleasePlan()` holds bodies, yet was typed and named "notes", so the planner literally read `const body = releaseNotesByVersion[version]` out of a map called "notes". Added a `ReleaseBodyByVersion` type and renamed the variable/parameter/spec keys so the notes→body pipeline shows up in the types.

### 2. Express the write throttle's state as a boolean
`writeCount` was only ever tested as `> 0` and incremented — never read as a count. What it tracks is "have we written yet", so it's now `hasWritten` and the guard reads as "delay before every write except the first", matching the adjacent comment.

### 3. Move the create-release payload out of the apply loop
Reading `applyReleasePlan()` top to bottom, the create loop dropped into a six-field GitHub payload (plus the `make_latest` conditional and its rationale) while the update/delete loops beside it were one-liners. Moved the payload assembly into a `buildNewRelease()` helper below, so all three loops read at one altitude; the create loop still shows its one genuine extra step, `resolveTargetCommitish()`.

### 4. Explain why only the stored release body is trimmed
The drift check `existingRelease.body?.trim() !== body` trims one side and not the other, which reads like an oversight. It isn't — GitHub can hand the stored body back padded with whitespace while our freshly built body has none, so trimming only the stored side is what stops every sync from seeing phantom drift. Documented that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019q2mqCroF56PMHYkrU7Wzo)_