### PR TITLE
sync-github-releases: three small client-cohesion refactors

### DIFF
--- a/.github/workflows/sync-github-releases/delete-all.ts
+++ b/.github/workflows/sync-github-releases/delete-all.ts
@@ -6,7 +6,7 @@ main()
 import { createReleasesClientFromEnv } from './utils/github-env.ts'
 
 async function main(): Promise<void> {
-  const { client, owner, repo } = createReleasesClientFromEnv(false)
+  const { client, owner, repo } = createReleasesClientFromEnv()
 
   console.log(`Fetching releases for ${owner}/${repo} …`)
   const githubReleases = await client.list()

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -14,8 +14,9 @@ import { createReleasesClient, type ReleasesClient } from './github.ts'
 
 // A GitHub Releases client for the repository this run targets, wired up from the environment. Returns
 // the resolved owner/repo too — callers need them for the web links and log lines the client doesn't
-// expose. dryRun is passed straight through to the client, which is what gates and logs the writes.
-function createReleasesClientFromEnv(dryRun: boolean): { client: ReleasesClient; owner: string; repo: string } {
+// expose. dryRun (passed straight through to the client, which gates and logs the writes) defaults to
+// false, for callers like delete-all that have no dry-run mode.
+function createReleasesClientFromEnv(dryRun = false): { client: ReleasesClient; owner: string; repo: string } {
   const { owner, repo } = getRepository()
   const client = createReleasesClient({ owner, repo, token: getGithubToken(), apiUrl: getApiUrl(), dryRun })
   return { client, owner, repo }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -60,14 +60,6 @@ function createReleasesClient({
     pathname: string,
     { body, method = 'GET' }: { body?: unknown; method?: 'GET' | 'PATCH' | 'POST' | 'DELETE' } = {},
   ): Promise<T> {
-    // Throttle between writes only: reads aren't the rate-limit concern, and a lone write — the common
-    // case of a single new release — shouldn't wait at all. So a backfill of N writes pays N-1 delays,
-    // while one write pays none.
-    if (method !== 'GET') {
-      if (hasWritten) await setTimeout(RATE_LIMIT_DELAY_MS)
-      hasWritten = true
-    }
-
     const response = await fetch(new URL(pathname, apiUrl), {
       method,
       headers,
@@ -85,12 +77,16 @@ function createReleasesClient({
   }
 
   // Perform a write — or, under --dry-run, just announce it — and log the outcome. Shared by all three
-  // write methods so they gate and narrate identically.
+  // write methods so they gate, throttle, and narrate identically.
   async function write(action: keyof typeof pastTense, tagName: string, send: () => Promise<void>): Promise<void> {
     if (dryRun) {
       console.log(`[dry-run] Would ${action} release ${tagName}`)
       return
     }
+    // Throttle between writes (see RATE_LIMIT_DELAY_MS): the first doesn't wait, so a lone write — the
+    // common case of a single new release — pays nothing, while a backfill of N writes pays N-1 delays.
+    if (hasWritten) await setTimeout(RATE_LIMIT_DELAY_MS)
+    hasWritten = true
     await send()
     console.log(`${pastTense[action]} release ${tagName}`)
   }

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -20,6 +20,10 @@ type NewRelease = {
   make_latest: 'true' | 'false'
 }
 
+// A reference to an existing GitHub Release: the numeric id addresses it in the API; the tag_name rides
+// along only for the log line write() prints.
+type ReleaseRef = { release_id: number; tag_name: string }
+
 // A client for one repository's GitHub Releases. It binds the owner/repo/token and API base URL once,
 // so callers just say what to do — not where, nor as whom. The write methods gate on --dry-run (logging
 // what they would do instead of doing it) and otherwise log what they did, so every caller — the sync
@@ -27,8 +31,8 @@ type NewRelease = {
 type ReleasesClient = {
   list(): Promise<Release[]>
   create(release: NewRelease): Promise<void>
-  update(release: { release_id: number; tag_name: string; body: string }): Promise<void>
-  delete(release: { release_id: number; tag_name: string }): Promise<void>
+  update(release: ReleaseRef & { body: string }): Promise<void>
+  delete(release: ReleaseRef): Promise<void>
 }
 
 // Pause between write requests so bursts (e.g. backfilling many releases) stay under GitHub's


### PR DESCRIPTION
Three more small refactors on top of `brillout/sync-github-releases`, continuing the theme of consolidating the write pipeline into the client. Each is its own commit.

### 1. Throttle inside the client's write pipeline (`github.ts`)
The rate-limit throttle lived in `request()` behind a `method !== 'GET'` guard — the one thing keeping `request()` from being a plain HTTP call. Moved it into `write()`, which already owns the dry-run gate and the per-write logging and is only ever reached for writes. Now `request()` is unconditional transport and everything write-specific (throttle, gate, log) sits together.

### 2. Name the release-reference shape (`github.ts`)
`update()` and `delete()` each took an inline `{ release_id, tag_name, … }` object, repeating the shape and leaving unexplained why a *delete* needs a `tag_name`. Named it `ReleaseRef`, documented: the id addresses the release in the API, the `tag_name` is only there for `write()`'s log line.

### 3. Default the client's `dryRun` to `false` (`github-env.ts`, `delete-all.ts`)
`delete-all` has no dry-run mode, yet had to pass a bare `false` to `createReleasesClientFromEnv()`. Defaulted `dryRun` to `false` so `delete-all` can omit it; `sync.ts` still passes its parsed flag. (This was the residual wart I flagged on #3412.)

No behavior changes. Verified after each commit: `tsc --noEmit` clean, `biome check` clean, 24 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmbUVKHd2SGJYY8NnZ1FeK)_