### PR TITLE
sync-github-releases: don't delete all releases when a CHANGELOG.md parses to zero versions

### DIFF
--- a/.github/workflows/sync-github-releases/sync/sync-package.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSyncContext, syncPackage } from './sync-package.ts'
+import type { Release, ReleasesClient } from '../utils/github.ts'
+
+// syncPackage() reads package.json and CHANGELOG.md from disk; stub both so the test can hand it a
+// CHANGELOG.md that parses to zero versions.
+vi.mock('node:fs/promises', () => ({
+  readFile: async (filePath: string) =>
+    filePath.endsWith('package.json') ? '{ "name": "vike" }' : 'A CHANGELOG.md with no version headings.',
+}))
+
+function createFakeClient(): { client: ReleasesClient; calls: string[] } {
+  const calls: string[] = []
+  const client: ReleasesClient = {
+    async list() {
+      calls.push('list')
+      return [{ id: 1, tag_name: 'v1.0.0', body: 'Notes' }] as Release[]
+    },
+    async create() {
+      calls.push('create')
+    },
+    async update() {
+      calls.push('update')
+    },
+    async delete() {
+      calls.push('delete')
+    },
+  }
+  return { client, calls }
+}
+
+describe('syncPackage()', () => {
+  it('skips the package when its CHANGELOG.md parses to zero versions, touching nothing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { client, calls } = createFakeClient()
+    const context = createSyncContext({
+      client,
+      owner: 'vikejs',
+      repo: 'vike',
+      defaultBranch: 'main',
+      hasMultiplePackages: false,
+    })
+
+    await syncPackage('packages/vike', context)
+
+    // It must not even fetch the releases, let alone delete them: an empty parse is never "delete everything".
+    expect(calls).toEqual([])
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('No versions parsed'))
+    warn.mockRestore()
+  })
+})

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -42,6 +42,13 @@ async function syncPackage(packageDir: string, context: SyncContext): Promise<vo
   const packageName = await readPackageName(packageDir)
   const tagScheme = getTagScheme(packageName, context.hasMultiplePackages)
   const changelogNotes = await readChangelogNotes(packageDir)
+  if (Object.keys(changelogNotes).length === 0) {
+    // A tracked CHANGELOG.md that parses to zero versions points at a parser/format drift, not an
+    // intentional removal — so skip the package (loudly) rather than reconcile against an empty version
+    // set, which getReleasePlan() would read as "every release is gone from the changelog: delete them all".
+    console.warn(`No versions parsed from ${packageDir}/CHANGELOG.md — skipping it.`)
+    return
+  }
   const changelogUrl = getChangelogUrl(packageDir, context.changelogUrlBase)
   const releaseBodyByVersion = buildReleaseBodies(changelogNotes, { tagScheme, changelogUrl })
   const githubReleases = await context.client.list()


### PR DESCRIPTION
A safety guard (not a cosmetic refactor) surfaced while re-surveying the tool.

## The gap

If a tracked `CHANGELOG.md` ever parses to **zero versions**, `getReleasePlan()` builds `expectedTags = {}`, so its delete filter (`owns(tag) && !expectedTags.has(tag)`) matches **every one of that package's releases** — the sync would delete them all. It won't happen with today's changelogs, but the day release-me changes its heading format and the regex stops matching, a routine sync would quietly wipe a package's entire release history. The existing `packageDirs.length === 0` check in `sync.ts` doesn't cover this (it's about *which dirs*, not an empty parse).

## The fix

Guard `syncPackage()` right after the parse — upstream of `getReleasePlan()`, so the empty version set never reaches the planner:

```ts
const changelogNotes = await readChangelogNotes(packageDir)
if (Object.keys(changelogNotes).length === 0) {
  console.warn(`No versions parsed from ${packageDir}/CHANGELOG.md — skipping it.`)
  return
}
```

A zero-version parse is treated as a parser/format drift (skip the package, loudly) rather than an intentional removal of every version. Added `sync-package.spec.ts` covering it: with an empty parse, the client is never even asked to `list`, let alone `delete`.

Verified: `tsc --noEmit` clean, `biome check` clean, 25 unit tests pass (was 24).

Note: this is behavior-preserving for every real changelog — it only changes the pathological zero-version case from "delete everything" to "skip and warn."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmbUVKHd2SGJYY8NnZ1FeK)_