### PR TITLE
sync-github-releases: two locating/simplification refactors

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -3,7 +3,7 @@
 
 main()
 
-import { createSyncContext, syncPackage } from './sync/sync-package.ts'
+import { syncPackage, type SyncContext } from './sync/sync-package.ts'
 import { getRepoRoot, getTrackedChangelogFiles, toPackageDirs } from './utils/git.ts'
 import { createReleasesClientFromEnv, getDefaultBranch, getPushedFiles } from './utils/github-env.ts'
 
@@ -27,13 +27,13 @@ async function main(): Promise<void> {
   }
 
   const { client, owner, repo } = createReleasesClientFromEnv(dryRun)
-  const context = createSyncContext({
+  const context: SyncContext = {
     client,
     owner,
     repo,
     defaultBranch: getDefaultBranch(),
     hasMultiplePackages: allPackageDirs.length > 1,
-  })
+  }
 
   for (const packageDir of packageDirs) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)

--- a/.github/workflows/sync-github-releases/sync/sync-package.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createSyncContext, syncPackage } from './sync-package.ts'
+import { syncPackage, type SyncContext } from './sync-package.ts'
 import type { Release, ReleasesClient } from '../utils/github.ts'
 
 // syncPackage() reads package.json and CHANGELOG.md from disk; stub both so the test can hand it a
@@ -33,13 +33,13 @@ describe('syncPackage()', () => {
   it('skips the package when its CHANGELOG.md parses to zero versions, touching nothing', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { client, calls } = createFakeClient()
-    const context = createSyncContext({
+    const context: SyncContext = {
       client,
       owner: 'vikejs',
       repo: 'vike',
       defaultBranch: 'main',
       hasMultiplePackages: false,
-    })
+    }
 
     await syncPackage('packages/vike', context)
 

--- a/.github/workflows/sync-github-releases/sync/sync-package.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.ts
@@ -1,5 +1,4 @@
 export { syncPackage }
-export { createSyncContext }
 export type { SyncContext }
 
 import { readFile } from 'node:fs/promises'
@@ -16,24 +15,15 @@ import {
 import { getReleaseDate } from '../utils/git.ts'
 import type { ReleasesClient } from '../utils/github.ts'
 
-// The loop-invariant inputs of a sync run, built once and shared across packages. owner/repo aren't
-// here: the client already binds them, and the changelog URL base bakes them in.
+// The loop-invariant inputs of a sync run, built once in main() and shared across every package.
+// owner/repo ride along so each package's changelog URL can be built (see getChangelogUrl); the client
+// also binds them internally for its own API calls.
 type SyncContext = {
   client: ReleasesClient
+  owner: string
+  repo: string
   defaultBranch: string
   hasMultiplePackages: boolean
-  changelogUrlBase: string
-}
-
-// owner/repo are consumed only to bake the changelog URL base; every other field is the context as-is.
-function createSyncContext(
-  input: Omit<SyncContext, 'changelogUrlBase'> & { owner: string; repo: string },
-): SyncContext {
-  const { owner, repo, ...context } = input
-  return {
-    ...context,
-    changelogUrlBase: `https://github.com/${owner}/${repo}/blob/${context.defaultBranch}`,
-  }
 }
 
 // Sync one package: derive its expected releases from CHANGELOG.md (the source of truth), reconcile
@@ -49,7 +39,7 @@ async function syncPackage(packageDir: string, context: SyncContext): Promise<vo
     console.warn(`No versions parsed from ${packageDir}/CHANGELOG.md — skipping it.`)
     return
   }
-  const changelogUrl = getChangelogUrl(packageDir, context.changelogUrlBase)
+  const changelogUrl = getChangelogUrl(packageDir, context)
   const releaseBodyByVersion = buildReleaseBodies(changelogNotes, { tagScheme, changelogUrl })
   const githubReleases = await context.client.list()
   const plan = getReleasePlan({ githubReleases, releaseBodyByVersion, tagScheme })
@@ -83,6 +73,6 @@ async function readChangelogNotes(packageDir: string): Promise<ReleaseNotesByVer
 
 // The GitHub web (blob) URL of the package's CHANGELOG.md, which each release body's footer links back to.
 // path.posix.join keeps the URL clean when packageDir is '.' (a repo-root CHANGELOG.md): no `/./`.
-function getChangelogUrl(packageDir: string, changelogUrlBase: string): string {
-  return `${changelogUrlBase}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
+function getChangelogUrl(packageDir: string, { owner, repo, defaultBranch }: SyncContext): string {
+  return `https://github.com/${owner}/${repo}/blob/${defaultBranch}/${path.posix.join(packageDir, 'CHANGELOG.md')}`
 }

--- a/.github/workflows/sync-github-releases/utils/git.ts
+++ b/.github/workflows/sync-github-releases/utils/git.ts
@@ -2,13 +2,13 @@
 // package dirs). Knows nothing of the GitHub Actions environment (github-env.ts) nor the GitHub API
 // (github.ts).
 
-export { gitLines }
 export { getRepoRoot }
 export { getRepositoryFromGitRemote }
 export { gitTagExists }
 export { findReleaseCommit }
 export { getReleaseDate }
 export { getTrackedChangelogFiles }
+export { getChangedFiles }
 export { toPackageDirs }
 
 import assert from 'node:assert'
@@ -52,6 +52,13 @@ function toPackageDirs(files: string[]): string[] {
 
 function getTrackedChangelogFiles(): string[] {
   return gitLines(['ls-files', '--', CHANGELOG_PATHSPEC])
+}
+
+// The files that changed between two commits, one path per line — used to scope a push to the packages
+// it touched (see getPushedFiles()).
+function getChangedFiles(beforeSha: string, headSha: string): string[] {
+  // The SHAs are passed as argv (git() uses no shell), so they can't cause injection.
+  return gitLines(['diff', '--name-only', beforeSha, headSha])
 }
 
 // A release tag's fully-qualified ref. The `refs/tags/` prefix pins it to a tag, so git can't resolve

--- a/.github/workflows/sync-github-releases/utils/github-env.ts
+++ b/.github/workflows/sync-github-releases/utils/github-env.ts
@@ -4,7 +4,7 @@ export { getPushedFiles }
 
 import assert from 'node:assert'
 import { readFileSync } from 'node:fs'
-import { getRepositoryFromGitRemote, gitLines } from './git.ts'
+import { getChangedFiles, getRepositoryFromGitRemote } from './git.ts'
 import { createReleasesClient, type ReleasesClient } from './github.ts'
 
 // How a run discovers what to act on, as whom, and against which branch: the repository, the auth
@@ -55,8 +55,7 @@ function getPushedFiles(): string[] | null {
   const beforeSha = getCommitBeforePush()
   const headSha = process.env.GITHUB_SHA
   if (!beforeSha || !headSha) return null
-  // The SHAs are passed as argv (git() uses no shell), so they can't cause injection.
-  return gitLines(['diff', '--name-only', beforeSha, headSha])
+  return getChangedFiles(beforeSha, headSha)
 }
 
 // The commit the branch pointed at before the push (`github.event.before`). GitHub Actions writes the


### PR DESCRIPTION
Two surgical refactors to `.github/workflows/sync-github-releases/`, each its own commit. Behaviour is unchanged — **25 unit tests pass, `tsc` clean, Biome clean**.

This tool has already been polished heavily, so this is the result of an exhaustive seam/altitude audit (every file, function, and logic block rated; three independent adversarial reviews cross-checked). Most candidate changes were **rejected as churn** — only the two below were genuine improvements. The audit's reasoning lives in the session; the rejected alternatives are summarised at the end.

## 1. Drop the `SyncContext` factory, carry `owner`/`repo`
`createSyncContext()` existed only to pre-bake a `changelogUrlBase` from `owner`/`repo`, hidden behind an `Omit<SyncContext,'changelogUrlBase'> & {owner,repo}` input type. Carrying `owner`/`repo` as plain context fields and letting `getChangelogUrl()` build the whole blob URL lets `main()` assemble the context as a plain object literal — **no factory, no derived field, no `Omit` dance** (net −10 lines). The URL produced is byte-identical.

## 2. Wrap the push diff in a named git function
`getPushedFiles()` was the *only* code outside `git.ts` that constructed a raw git command, reaching for the exported `gitLines()` to run `git diff --name-only`. Every other git command in `git.ts` is a named wrapper, so this one now gets the same treatment via `getChangedFiles(beforeSha, headSha)`. `gitLines()` becomes internal (no longer exported), `github-env.ts` no longer knows git argv, and the injection-safety comment moves to where the argv actually is.

## Notable changes considered and deliberately *not* made
- **Merge `resolveTargetCommitish` into `buildNewRelease`** — rejected: it would make a "build" function shell out to git and *throw*, hiding the safety-critical commit resolution.
- **Extract a shared "tag-or-deduced-commit" helper** between `getReleaseDate` and `resolveTargetCommitish` — rejected: they do *opposite* things when the tag exists (one reads the tag's commit, the other returns the branch and ignores it).
- **Extract `parseArgs()` / inline `tagRef`, `readPackageName`, `readChangelogNotes`** — rejected as either frivolous-tiny-function churn or a loss of altitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuKq4wynxAPBWdpjcHmRRf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuKq4wynxAPBWdpjcHmRRf)_