### PR TITLE
sync-github-releases: name-only polish (9 renames)

### DIFF
--- a/.github/workflows/sync-github-releases/sync.ts
+++ b/.github/workflows/sync-github-releases/sync.ts
@@ -20,8 +20,8 @@ async function main(): Promise<void> {
   // to pick the tag scheme: when several packages share the repo they also share its tag namespace, so
   // their release tags are qualified with the package name (see getTagScheme()).
   const allPackageDirs = toPackageDirs(getTrackedChangelogFiles())
-  const packageDirs = getPackageDirsToSync(explicitPackageDirs, allPackageDirs)
-  if (packageDirs.length === 0) {
+  const packageDirsToSync = getPackageDirsToSync(explicitPackageDirs, allPackageDirs)
+  if (packageDirsToSync.length === 0) {
     console.log('No CHANGELOG.md changes detected — nothing to sync.')
     return
   }
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
     hasMultiplePackages: allPackageDirs.length > 1,
   }
 
-  for (const packageDir of packageDirs) {
+  for (const packageDir of packageDirsToSync) {
     console.log(`Syncing GitHub releases for package directory: ${packageDir}`)
     await syncPackage(packageDir, context)
   }

--- a/.github/workflows/sync-github-releases/sync/release-plan.ts
+++ b/.github/workflows/sync-github-releases/sync/release-plan.ts
@@ -42,7 +42,7 @@ function getReleasePlan({
   // releases for updates would try to rewrite any release whose tag isn't in the changelog (e.g. a
   // release of another package, or a manually-created one) with an `undefined` body. Driving both
   // create and update off the changelog can only ever touch the versions the changelog declares.
-  const releasesByTag = new Map(githubReleases.map((release) => [release.tag_name, release]))
+  const releaseByTag = new Map(githubReleases.map((release) => [release.tag_name, release]))
   const expectedTags = new Set<string>()
   const releasesToCreate: ReleaseToCreate[] = []
   const releasesToUpdate: ReleaseToUpdate[] = []
@@ -60,7 +60,7 @@ function getReleasePlan({
     const body = releaseBodyByVersion[version]
     const releaseTag = tagScheme.build(version)
     expectedTags.add(releaseTag)
-    const existingRelease = releasesByTag.get(releaseTag)
+    const existingRelease = releaseByTag.get(releaseTag)
     if (!existingRelease) {
       releasesToCreate.push({ tag_name: releaseTag, body, version, isLatest: version === latestVersion })
     } else if (existingRelease.body?.trim() !== body) {

--- a/.github/workflows/sync-github-releases/sync/sync-package.spec.ts
+++ b/.github/workflows/sync-github-releases/sync/sync-package.spec.ts
@@ -31,7 +31,7 @@ function createFakeClient(): { client: ReleasesClient; calls: string[] } {
 
 describe('syncPackage()', () => {
   it('skips the package when its CHANGELOG.md parses to zero versions, touching nothing', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { client, calls } = createFakeClient()
     const context: SyncContext = {
       client,
@@ -45,7 +45,7 @@ describe('syncPackage()', () => {
 
     // It must not even fetch the releases, let alone delete them: an empty parse is never "delete everything".
     expect(calls).toEqual([])
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('No versions parsed'))
-    warn.mockRestore()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No versions parsed'))
+    warnSpy.mockRestore()
   })
 })

--- a/.github/workflows/sync-github-releases/sync/tag-scheme.ts
+++ b/.github/workflows/sync-github-releases/sync/tag-scheme.ts
@@ -15,10 +15,10 @@ type TagScheme = {
 }
 function getTagScheme(packageName: string, hasMultiplePackages: boolean): TagScheme {
   if (hasMultiplePackages) {
-    const prefix = `${packageName}@`
+    const tagPrefix = `${packageName}@`
     return {
-      build: (version) => `${prefix}${version}`,
-      owns: (releaseTag) => releaseTag.startsWith(prefix),
+      build: (version) => `${tagPrefix}${version}`,
+      owns: (releaseTag) => releaseTag.startsWith(tagPrefix),
     }
   }
   return {

--- a/.github/workflows/sync-github-releases/utils/changelog.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/changelog.spec.ts
@@ -29,45 +29,45 @@ describe('parseChangelog()', () => {
   })
 
   it('parses oldest Vike entries (single # headings, pre-release versions)', () => {
-    const changelogSections = parseChangelog(readFixture('changelog-vike.md'))
-    expect(Object.keys(changelogSections)).toEqual([
+    const changelogNotes = parseChangelog(readFixture('changelog-vike.md'))
+    expect(Object.keys(changelogNotes)).toEqual([
       '0.1.0-beta.10',
       '0.1.0-beta.9',
       '0.1.0-beta.8',
       '0.1.0-beta.7',
       '0.1.0-beta.6',
     ])
-    expect(changelogSections['0.1.0-beta.10']).toContain('### Features')
-    expect(changelogSections['0.1.0-beta.8']).toContain('### BREAKING CHANGES')
-    expect(changelogSections['0.1.0-beta.6']).toContain('Initial public release')
+    expect(changelogNotes['0.1.0-beta.10']).toContain('### Features')
+    expect(changelogNotes['0.1.0-beta.8']).toContain('### BREAKING CHANGES')
+    expect(changelogNotes['0.1.0-beta.6']).toContain('Initial public release')
   })
 
   it('parses oldest Telefunc entries (trailing non-versioned sections)', () => {
-    const changelogSections = parseChangelog(readFixture('changelog-telefunc.md'))
-    expect(Object.keys(changelogSections)).toEqual(['0.1.2', '0.1.1'])
-    expect(changelogSections['0.1.2']).toContain('improve TelefunctionError type')
-    expect(changelogSections['0.1.1']).toContain('isomorphic imports')
+    const changelogNotes = parseChangelog(readFixture('changelog-telefunc.md'))
+    expect(Object.keys(changelogNotes)).toEqual(['0.1.2', '0.1.1'])
+    expect(changelogNotes['0.1.2']).toContain('improve TelefunctionError type')
+    expect(changelogNotes['0.1.1']).toContain('isomorphic imports')
   })
 
   it('parses oldest vike-vue entries (no-link headings, dash bullets)', () => {
-    const changelogSections = parseChangelog(readFixture('changelog-vike-vue.md'))
-    expect(Object.keys(changelogSections)).toEqual(['0.2.3', '0.2.2', '0.2.1', '0.2.0', '0.1.1'])
-    expect(changelogSections['0.2.1']).toContain('Fix peer dependency')
-    expect(changelogSections['0.2.0']).toContain('Add `Head` config option')
+    const changelogNotes = parseChangelog(readFixture('changelog-vike-vue.md'))
+    expect(Object.keys(changelogNotes)).toEqual(['0.2.3', '0.2.2', '0.2.1', '0.2.0', '0.1.1'])
+    expect(changelogNotes['0.2.1']).toContain('Fix peer dependency')
+    expect(changelogNotes['0.2.0']).toContain('Add `Head` config option')
   })
 
   it('parses oldest vike-solid entries (single # headings, mixed formats)', () => {
-    const changelogSections = parseChangelog(readFixture('changelog-vike-solid.md'))
-    expect(Object.keys(changelogSections)).toEqual(['0.7.2', '0.7.1', '0.7.0', '0.6.2', '0.6.1'])
-    expect(changelogSections['0.7.0']).toContain('### BREAKING CHANGES')
-    expect(changelogSections['0.6.1']).toContain('MIGRATION.md')
+    const changelogNotes = parseChangelog(readFixture('changelog-vike-solid.md'))
+    expect(Object.keys(changelogNotes)).toEqual(['0.7.2', '0.7.1', '0.7.0', '0.6.2', '0.6.1'])
+    expect(changelogNotes['0.7.0']).toContain('### BREAKING CHANGES')
+    expect(changelogNotes['0.6.1']).toContain('MIGRATION.md')
   })
 
   it('parses oldest vike-react entries (no-link initial version)', () => {
-    const changelogSections = parseChangelog(readFixture('changelog-vike-react.md'))
-    expect(Object.keys(changelogSections)).toEqual(['0.1.6', '0.1.5', '0.1.4', '0.1.3', '0.1.2', '0.1.1'])
-    expect(changelogSections['0.1.6']).toContain("fix 'vike-react' type")
-    expect(changelogSections['0.1.1']).toContain('fix ESM import paths')
+    const changelogNotes = parseChangelog(readFixture('changelog-vike-react.md'))
+    expect(Object.keys(changelogNotes)).toEqual(['0.1.6', '0.1.5', '0.1.4', '0.1.3', '0.1.2', '0.1.1'])
+    expect(changelogNotes['0.1.6']).toContain("fix 'vike-react' type")
+    expect(changelogNotes['0.1.1']).toContain('fix ESM import paths')
   })
 })
 

--- a/.github/workflows/sync-github-releases/utils/github.spec.ts
+++ b/.github/workflows/sync-github-releases/utils/github.spec.ts
@@ -27,7 +27,7 @@ describe('createReleasesClient() writes', () => {
 
   it('under --dry-run, logs what it would do and sends no request', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const client = createClient(true)
 
     await client.create(newRelease)
@@ -35,7 +35,7 @@ describe('createReleasesClient() writes', () => {
     await client.delete({ release_id: 2, tag_name: 'v0.8.0' })
 
     expect(fetchSpy).not.toHaveBeenCalled()
-    expect(log.mock.calls.flat()).toEqual([
+    expect(logSpy.mock.calls.flat()).toEqual([
       '[dry-run] Would create release v1.0.0',
       '[dry-run] Would update release v0.9.0',
       '[dry-run] Would delete release v0.8.0',
@@ -44,7 +44,7 @@ describe('createReleasesClient() writes', () => {
 
   it('otherwise performs each write and logs it', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const client = createClient(false)
 
     await client.create(newRelease)
@@ -52,7 +52,7 @@ describe('createReleasesClient() writes', () => {
     await client.delete({ release_id: 2, tag_name: 'v0.8.0' })
 
     expect(fetchSpy).toHaveBeenCalledTimes(3)
-    expect(log.mock.calls.flat()).toEqual([
+    expect(logSpy.mock.calls.flat()).toEqual([
       'Created release v1.0.0',
       'Updated release v0.9.0',
       'Deleted release v0.8.0',

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -40,7 +40,7 @@ type ReleasesClient = {
 // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 const RATE_LIMIT_DELAY_MS = 500
 
-const pastTense = { create: 'Created', update: 'Updated', delete: 'Deleted' } as const
+const pastTenseByAction = { create: 'Created', update: 'Updated', delete: 'Deleted' } as const
 
 function createReleasesClient({
   owner,
@@ -82,7 +82,7 @@ function createReleasesClient({
 
   // Perform a write — or, under --dry-run, just announce it — and log the outcome. Shared by all three
   // write methods so they gate, throttle, and narrate identically.
-  async function write(action: keyof typeof pastTense, tagName: string, send: () => Promise<void>): Promise<void> {
+  async function write(action: keyof typeof pastTenseByAction, tagName: string, send: () => Promise<void>): Promise<void> {
     if (dryRun) {
       console.log(`[dry-run] Would ${action} release ${tagName}`)
       return
@@ -92,7 +92,7 @@ function createReleasesClient({
     if (hasWritten) await setTimeout(RATE_LIMIT_DELAY_MS)
     hasWritten = true
     await send()
-    console.log(`${pastTense[action]} release ${tagName}`)
+    console.log(`${pastTenseByAction[action]} release ${tagName}`)
   }
 
   return {

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -84,11 +84,11 @@ function createReleasesClient({
   // write methods so they gate, throttle, and narrate identically.
   async function write(
     action: keyof typeof pastTenseByAction,
-    tagName: string,
+    releaseTag: string,
     sendRequest: () => Promise<void>,
   ): Promise<void> {
     if (dryRun) {
-      console.log(`[dry-run] Would ${action} release ${tagName}`)
+      console.log(`[dry-run] Would ${action} release ${releaseTag}`)
       return
     }
     // Throttle between writes (see RATE_LIMIT_DELAY_MS): the first doesn't wait, so a lone write — the
@@ -96,7 +96,7 @@ function createReleasesClient({
     if (hasWritten) await setTimeout(RATE_LIMIT_DELAY_MS)
     hasWritten = true
     await sendRequest()
-    console.log(`${pastTenseByAction[action]} release ${tagName}`)
+    console.log(`${pastTenseByAction[action]} release ${releaseTag}`)
   }
 
   return {

--- a/.github/workflows/sync-github-releases/utils/github.ts
+++ b/.github/workflows/sync-github-releases/utils/github.ts
@@ -82,7 +82,11 @@ function createReleasesClient({
 
   // Perform a write — or, under --dry-run, just announce it — and log the outcome. Shared by all three
   // write methods so they gate, throttle, and narrate identically.
-  async function write(action: keyof typeof pastTenseByAction, tagName: string, send: () => Promise<void>): Promise<void> {
+  async function write(
+    action: keyof typeof pastTenseByAction,
+    tagName: string,
+    sendRequest: () => Promise<void>,
+  ): Promise<void> {
     if (dryRun) {
       console.log(`[dry-run] Would ${action} release ${tagName}`)
       return
@@ -91,7 +95,7 @@ function createReleasesClient({
     // common case of a single new release — pays nothing, while a backfill of N writes pays N-1 delays.
     if (hasWritten) await setTimeout(RATE_LIMIT_DELAY_MS)
     hasWritten = true
-    await send()
+    await sendRequest()
     console.log(`${pastTenseByAction[action]} release ${tagName}`)
   }
 


### PR DESCRIPTION
Continues the `sync-github-releases` naming pass. **Names only** — no logic or structure changes. The single non-identifier hunk is biome-mandated signature wrapping (the longer `sendRequest` crosses the 120-col limit).

One commit per rename, each `oldName => newName`:

**Consistency (one concept → one word, one map convention)**
- `releasesByTag => releaseByTag` — Map holds one release per tag; singular value matches the `xByY` convention (`releaseBodyByVersion`).
- `pastTense => pastTenseByAction` — it's a lookup keyed by the write action; name the key.
- `tagName => releaseTag` — the codebase already spells a release tag `releaseTag` (tag-scheme/git/apply); drop the second synonym. The API field `tag_name` is unchanged.
- `changelogSections => changelogNotes` (spec) — match the production var + `ReleaseNotesByVersion`; "sections" clashed with the "notes" vocabulary.
- `log => logSpy`, `warn => warnSpy` — give the console spies the same `*Spy` suffix as `fetchSpy`.

**Clarity / reveals intent**
- `packageDirs => packageDirsToSync` — name the selected set after its producer `getPackageDirsToSync()` and set it apart from `allPackageDirs`/`explicitPackageDirs`.
- `send => sendRequest` — say what `write()`'s callback does.
- `prefix => tagPrefix` — reads clearer at `releaseTag.startsWith(tagPrefix)`.

**Considered and deliberately kept:** `utils/` (heterogeneous primitive layer; no clearly-better single word), `getGithubToken` (sole brand occurrence; `getGitHubToken` reads worse), `getReleasePlan` (fits the `get*` derive family vs `build*` for API artifacts), `request`'s `body`/`method` options (mirror the `fetch` API), and the snake_case API-boundary fields.

**Verification:** `tsc --noEmit` clean; 25/25 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EGvFEjHoXMdiqVtm3Yviv

---
_Generated by [Claude Code](https://claude.ai/code/session_019EGvFEjHoXMdiqVtm3Yviv)_