### PR TITLE
fix(docs): stop the landing page's --color-bg leaking into the docs

### DIFF
--- a/docs/pages/index/tailwind.css
+++ b/docs/pages/index/tailwind.css
@@ -18,7 +18,11 @@
   --color-grey-300: oklch(0.93 0 0);
   --color-grey-300-hex: #e8e8e8;
   --color-grey-400: oklch(0.9502 0 0);
-  --color-bg: oklch(0.9702 0 0);
+  /* Not `--color-bg`: Tailwind emits @theme vars to the global :root, and the
+     landing page's CSS is injected globally when prefetched (hover the logo).
+     DocPress (>=0.16.46) reads `var(--color-bg, #fdfdfd)` for its background, so
+     a generic --color-bg here leaked into the docs and washed out a white line. */
+  --color-canvas: oklch(0.9702 0 0);
   --color-white: #fdfdfd;
 
   /* daisyUI specific */
@@ -69,31 +73,31 @@
   name: 'vike';
   --color-base-100: var(--color-grey-300);
   --color-base-200: var(--color-grey-400);
-  --color-base-300: var(--color-bg);
+  --color-base-300: var(--color-canvas);
   --color-base-content: var(--color-content);
 
   /* flexibility - green */
   --color-primary: var(--d-color-primary);
-  --color-primary-content: var(--color-bg);
+  --color-primary-content: var(--color-canvas);
 
   /* stability - blue */
   --color-secondary: var(--d-color-secondary);
-  --color-secondary-content: var(--color-bg);
+  --color-secondary-content: var(--color-canvas);
 
   /* dx - orange */
   --color-accent: var(--d-color-accent);
-  --color-accent-content: var(--color-bg);
+  --color-accent-content: var(--color-canvas);
 
   --color-neutral: var(--color-content);
-  --color-neutral-content: var(--color-bg);
+  --color-neutral-content: var(--color-canvas);
   --color-info: var(--d-color-info);
-  --color-info-content: var(--color-bg);
+  --color-info-content: var(--color-canvas);
   --color-success: var(--d-color-success);
-  --color-success-content: var(--color-bg);
+  --color-success-content: var(--color-canvas);
   --color-warning: var(--d-color-warning);
   --color-warning-content: var(--color-black);
   --color-error: var(--d-color-error);
-  --color-error-content: var(--color-bg);
+  --color-error-content: var(--color-canvas);
   /* .rounded-selector = 0.25rem */
   --radius-selector: 0.25rem;
   /* .rounded-field = 0.5rem */


### PR DESCRIPTION
The white separator line on doc pages (e.g. /data-fetching) disappears after hovering the logo. Hovering prefetches the landing page, whose CSS is injected globally.

**Cause:** Tailwind emits `@theme` vars to the global `:root`. The landing page defines a generic `--color-bg`, and DocPress (>=0.16.46) reads `var(--color-bg, #fdfdfd)` for its background. So once the landing CSS is injected, DocPress's background resolves to the landing page's `--color-bg` (a light grey) instead of `#fdfdfd`, washing out the white line.

**Fix:** rename the landing page's `--color-bg` to `--color-canvas` (landing-only, referenced just inside `pages/index/tailwind.css`). No collision, landing page renders unchanged.

**Verified** with the exact Tailwind 4.1.18 + daisyUI 5.5.14 this repo uses:
- before: output contains `:root, :host { … --color-bg: oklch(0.9702 0 0) … }` (global)
- after: no `--color-bg` is emitted; `--color-canvas` takes its place, so DocPress falls back to `#fdfdfd`.