### PR TITLE
chore(deps): bump telefunc from 0.2.20 to 0.2.21 (with deprecation fixes)

### DIFF
--- a/examples/telefunc/package.json
+++ b/examples/telefunc/package.json
@@ -14,7 +14,7 @@
     "express": "^5.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "telefunc": "^0.2.20",
+    "telefunc": "^0.2.21",
     "typescript": "^5.9.3",
     "vike": "0.4.260",
     "vite": "^7.1.5"

--- a/examples/telefunc/server/index.js
+++ b/examples/telefunc/server/index.js
@@ -5,7 +5,7 @@
 //  - To use your path aliases defined in your vite.config.js, you need to tell Node.js about them, see https://vike.dev/path-aliases
 
 import express from 'express'
-import { telefunc } from 'telefunc'
+import { serve } from 'telefunc'
 import { createDevMiddleware, renderPage } from 'vike/server'
 import { root } from './root.js'
 const isProduction = process.env.NODE_ENV === 'production'
@@ -25,9 +25,10 @@ async function startServer() {
   app.use(express.text()) // Parse & make HTTP request body available at `req.body`
   app.all('/_telefunc', async (req, res) => {
     const context = {}
-    const httpResponse = await telefunc({ url: req.originalUrl, method: req.method, body: req.body, context })
-    const { body, statusCode, contentType } = httpResponse
-    res.status(statusCode).type(contentType).send(body)
+    const httpResponse = await serve({ url: req.originalUrl, method: req.method, body: req.body, context })
+    const { body, statusCode, headers } = httpResponse
+    headers.forEach(([name, value]) => res.setHeader(name, value))
+    res.status(statusCode).send(body)
   })
 
   app.get('/{*vikeCatchAll}', async (req, res) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,8 +588,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       telefunc:
-        specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        specifier: ^0.2.21
+        version: 0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1294,8 +1294,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       telefunc:
-        specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        specifier: ^0.2.21
+        version: 0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1378,8 +1378,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       telefunc:
-        specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        specifier: ^0.2.21
+        version: 0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1424,8 +1424,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       telefunc:
-        specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6))
+        specifier: ^0.2.21
+        version: 0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1869,8 +1869,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       telefunc:
-        specifier: ^0.2.20
-        version: 0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        specifier: ^0.2.21
+        version: 0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       vike-react:
         specifier: ^0.6.25
         version: 0.6.25(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vike@packages+vike)
@@ -5480,6 +5480,9 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -5776,6 +5779,14 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crossws@0.4.7:
+    resolution: {integrity: sha512-N+BXE5AetLJ3/glz4DYLirKApAWg+V2guueoMenvAGVvqF/IA1PAzMYqYS+UfBkdz3tDXoQIevDaaxLy1Ch/4w==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
 
   csstype@2.6.21:
     resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
@@ -6850,6 +6861,10 @@ packages:
     resolution: {integrity: sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -7681,9 +7696,9 @@ packages:
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  telefunc@0.2.20:
-    resolution: {integrity: sha512-WzvLZtGorY4mLdVgS+eskMzT5f0/Ob6FbaMEW78RhPFPImZwOVeh4k5wNz6jQujBiRIVbZ6t90k0+Mxo/yrsdA==}
-    engines: {node: '>=12.19.0'}
+  telefunc@0.2.21:
+    resolution: {integrity: sha512-8sTdXK9SiryN17hwtZrIU6VRjKNqdVZVpbZS1ZFouBq/jXz18jrNGXmm5cC4Env9V73Sl4yoYFnGuVkpP/ln9g==}
+    engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': '>=7.0.0'
       '@babel/parser': '>=7.0.0'
@@ -11818,6 +11833,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -12099,6 +12118,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crossws@0.4.7(srvx@0.11.16):
+    optionalDependencies:
+      srvx: 0.11.16
 
   csstype@2.6.21: {}
 
@@ -12577,7 +12600,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.6
+      minimatch: 9.0.9
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -13548,6 +13571,10 @@ snapshots:
   minimatch@9.0.6:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
 
   minimist@1.2.8: {}
 
@@ -14598,12 +14625,13 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
+  telefunc@0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.25
       '@brillout/picocolors': 1.0.31
       '@brillout/vite-plugin-server-entry': 0.7.18
+      crossws: 0.4.7(srvx@0.11.16)
       es-module-lexer: 1.7.0
       magic-string: 0.30.21
       ts-morph: 26.0.0
@@ -14614,13 +14642,16 @@ snapshots:
       react: 19.2.6
       react-streaming: 0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
+    transitivePeerDependencies:
+      - srvx
 
-  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
+  telefunc@0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.25
       '@brillout/picocolors': 1.0.31
       '@brillout/vite-plugin-server-entry': 0.7.18
+      crossws: 0.4.7(srvx@0.11.16)
       es-module-lexer: 1.7.0
       magic-string: 0.30.21
       ts-morph: 26.0.0
@@ -14631,13 +14662,16 @@ snapshots:
       react: 19.2.6
       react-streaming: 0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
+    transitivePeerDependencies:
+      - srvx
 
-  telefunc@0.2.20(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6)):
+  telefunc@0.2.21(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.11.16)(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.25
       '@brillout/picocolors': 1.0.31
       '@brillout/vite-plugin-server-entry': 0.7.18
+      crossws: 0.4.7(srvx@0.11.16)
       es-module-lexer: 1.7.0
       magic-string: 0.30.21
       ts-morph: 26.0.0
@@ -14648,6 +14682,8 @@ snapshots:
       react: 19.2.6
       react-streaming: 0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6)
+    transitivePeerDependencies:
+      - srvx
 
   terser-webpack-plugin@5.3.10(esbuild@0.27.3)(webpack@5.97.1):
     dependencies:

--- a/test-deprecated-design/telefunc/package.json
+++ b/test-deprecated-design/telefunc/package.json
@@ -14,7 +14,7 @@
     "express": "^5.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "telefunc": "^0.2.20",
+    "telefunc": "^0.2.21",
     "typescript": "^5.9.3",
     "vike": "0.4.260",
     "vite": "6.3.0"

--- a/test-deprecated-design/telefunc/server/index.js
+++ b/test-deprecated-design/telefunc/server/index.js
@@ -5,7 +5,7 @@
 //  - To use your path aliases defined in your vite.config.js, you need to tell Node.js about them, see https://vike.dev/path-aliases
 
 import express from 'express'
-import { telefunc } from 'telefunc'
+import { serve } from 'telefunc'
 import { renderPage } from 'vike/server'
 import { root } from './root.js'
 const isProduction = process.env.NODE_ENV === 'production'
@@ -31,9 +31,10 @@ async function startServer() {
   app.use(express.text()) // Parse & make HTTP request body available at `req.body`
   app.all('/_telefunc', async (req, res) => {
     const context = {}
-    const httpResponse = await telefunc({ url: req.originalUrl, method: req.method, body: req.body, context })
-    const { body, statusCode, contentType } = httpResponse
-    res.status(statusCode).type(contentType).send(body)
+    const httpResponse = await serve({ url: req.originalUrl, method: req.method, body: req.body, context })
+    const { body, statusCode, headers } = httpResponse
+    headers.forEach(([name, value]) => res.setHeader(name, value))
+    res.status(statusCode).send(body)
   })
 
   app.get('/{*vikeCatchAll}', async (req, res, next) => {

--- a/test/@cloudflare_vite-plugin/package.json
+++ b/test/@cloudflare_vite-plugin/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "telefunc": "^0.2.20",
+    "telefunc": "^0.2.21",
     "vike": "0.4.260",
     "vike-react": "^0.6.25"
   },

--- a/test/@cloudflare_vite-plugin/worker/telefunc.ts
+++ b/test/@cloudflare_vite-plugin/worker/telefunc.ts
@@ -1,15 +1,15 @@
 export { handleTelefunc }
 
-import { telefunc } from 'telefunc'
+import { serve } from 'telefunc'
 
 async function handleTelefunc(request: Request) {
   const { pathname } = new URL(request.url)
   if (!pathname.startsWith('/_telefunc')) return null
   const { method } = request
   const body = await request.text()
-  const httpResponse = await telefunc({ url: pathname, method, body })
+  const httpResponse = await serve({ url: pathname, method, body })
   return new Response(httpResponse.body, {
-    headers: { 'content-type': httpResponse.contentType },
+    headers: httpResponse.headers,
     status: httpResponse.statusCode,
   })
 }

--- a/test/@cloudflare_vite-plugin_ud/middlewareTelefunc.ts
+++ b/test/@cloudflare_vite-plugin_ud/middlewareTelefunc.ts
@@ -1,22 +1,20 @@
 export { middlewareTelefunc }
 
 import { type UniversalMiddleware, enhance } from '@universal-middleware/core'
-import { telefunc } from 'telefunc'
+import { serve } from 'telefunc'
 
 const telefuncUniversalMiddleware: UniversalMiddleware = async (request, context, runtime) => {
-  const httpResponse = await telefunc({
+  const httpResponse = await serve({
     request,
     context: {
       ...context,
       ...runtime,
     },
   })
-  const { body, statusCode, contentType } = httpResponse
+  const { body, statusCode, headers } = httpResponse
   return new Response(body, {
     status: statusCode,
-    headers: {
-      'content-type': contentType,
-    },
+    headers,
   })
 }
 

--- a/test/@cloudflare_vite-plugin_ud/package.json
+++ b/test/@cloudflare_vite-plugin_ud/package.json
@@ -10,7 +10,7 @@
     "@universal-middleware/core": "^0.4.18",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "telefunc": "^0.2.20",
+    "telefunc": "^0.2.21",
     "vike": "0.4.260",
     "vike-react": "^0.6.25"
   },

--- a/test/universal-deploy/package.json
+++ b/test/universal-deploy/package.json
@@ -12,7 +12,7 @@
     "express": "^5.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "telefunc": "^0.2.20",
+    "telefunc": "^0.2.21",
     "vike-react": "^0.6.25"
   },
   "devDependencies": {

--- a/test/universal-deploy/pages/middlewareTelefunc.ts
+++ b/test/universal-deploy/pages/middlewareTelefunc.ts
@@ -1,22 +1,20 @@
 export { middlewareTelefunc }
 
 import { type UniversalMiddleware, enhance } from '@universal-middleware/core'
-import { telefunc } from 'telefunc'
+import { serve } from 'telefunc'
 
 const telefuncUniversalMiddleware: UniversalMiddleware = async (request, context, runtime) => {
-  const httpResponse = await telefunc({
+  const httpResponse = await serve({
     request,
     context: {
       ...context,
       ...runtime,
     },
   })
-  const { body, statusCode, contentType } = httpResponse
+  const { body, statusCode, headers } = httpResponse
   return new Response(body, {
     status: statusCode,
-    headers: {
-      'content-type': contentType,
-    },
+    headers,
   })
 }
 


### PR DESCRIPTION
Supersedes #3426 — the Dependabot bump alone fails CI because telefunc 0.2.21 emits new deprecation warnings on stderr, and the e2e test harness fails any test that produces stderr output.

This PR contains the Dependabot bump (telefunc 0.2.20 → 0.2.21) plus migration of the deprecated APIs in the test apps and the telefunc example:

- `telefunc()` → `serve()` (same signature; `telefunc()` is deprecated in favor of `serve()` / `new Telefunc()`, see https://telefunc.com/Telefunc)
- `httpResponse.contentType` → `httpResponse.headers` (which now includes `Content-Type`, see https://telefunc.com/serve)

Updated files:
- `examples/telefunc/server/index.js`
- `test-deprecated-design/telefunc/server/index.js`
- `test/universal-deploy/pages/middlewareTelefunc.ts`
- `test/@cloudflare_vite-plugin/worker/telefunc.ts`
- `test/@cloudflare_vite-plugin_ud/middlewareTelefunc.ts`

All 9 previously failing e2e test files pass locally:
`examples/telefunc` (dev/prod), `test-deprecated-design/telefunc` (dev/prod), `test/universal-deploy` (dev/preview), `test/@cloudflare_vite-plugin` (dev/preview), `test/@cloudflare_vite-plugin_ud` (dev/preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfBDxuLkqRH3dL2Apqy3RH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfBDxuLkqRH3dL2Apqy3RH)_