### PR TITLE
docs: new vike-vue setting `+vue`

### DIFF
--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -1392,6 +1392,10 @@ function api() {
         url: '/onCreateApp',
       },
       {
+        title: '`+vue`',
+        url: '/vue-setting',
+      },
+      {
         title: '`+react`',
         url: '/react-setting',
       },

--- a/docs/pages/settings/+Page.mdx
+++ b/docs/pages/settings/+Page.mdx
@@ -25,6 +25,7 @@ See also: <Link href="/hooks" />.
 - [**`csp`**](/csp): Content Security Policy (CSP).
 - [**`extends`**](/extends): Install <Link href="/extensions" />.
 - [**`react`**](/react-setting): Options passed to React functions such as `createRoot()` or `hydrateRoot()`.
+- [**`vue`**](/vue-setting): Vue integration options, such as wrapping pages with Vue's `<KeepAlive>`.
 
 
 ## HTML shell

--- a/docs/pages/vue-setting/+Page.mdx
+++ b/docs/pages/vue-setting/+Page.mdx
@@ -1,0 +1,104 @@
+import { Link } from '@brillout/docpress'
+import { ConfigSpec } from '../../components'
+
+<ConfigSpec
+  env="client, server"
+  cumulative
+  providedByExtension={{ kind: 'setting', name: '+vue', extension: ['vike-vue'], noCustomGuide: true }}
+/>
+
+The `+vue` setting sets Vue integration options. It's the Vue counterpart of <Link href="/react-setting">`+react`</Link>.
+
+```ts
+// pages/+vue.ts
+// Environment: server & client
+
+import type { Config } from 'vike/types'
+
+export default {
+  keepAlive: true
+} satisfies Config['vue']
+```
+
+> You can access <Link href="/pageContext">`pageContext`</Link>:
+>
+> ```ts
+> // pages/+vue.ts
+>
+> import type { Config, PageContext } from 'vike/types'
+>
+> export const vue: Config['vue'] = (pageContext: PageContext) => {
+>   return {
+>     keepAlive: !pageContext.urlPathname.startsWith('/admin')
+>   }
+> }
+> ```
+
+
+## `keepAlive`
+
+```ts ts-only
+keepAlive?: boolean | KeepAliveProps // default: false
+```
+
+Whether to wrap your <Link href="/Page">`Page` component</Link> with Vue's built-in [`<KeepAlive>`](https://vuejs.org/guide/built-ins/keep-alive.html) component, preserving page component instances — and thus their state — across <Link href="/client-routing">client-side navigation</Link>.
+
+```ts
+// pages/+vue.ts
+
+import type { Config } from 'vike/types'
+
+export default {
+  keepAlive: true // [!code ++]
+} satisfies Config['vue']
+```
+
+Instead of `true`, you can provide [`<KeepAlive>` props](https://vuejs.org/api/built-in-components.html#keepalive) for controlling which page components are cached:
+
+```ts
+// pages/+vue.ts
+
+import type { Config } from 'vike/types'
+
+export default {
+  // Cache at most 10 page instances, and never cache the component named 'HugePage'
+  keepAlive: { max: 10, exclude: ['HugePage'] } // [!code ++]
+} satisfies Config['vue']
+```
+
+> The `include`/`exclude` props match against the [`name`](https://vuejs.org/api/options-misc.html#name) of your `+Page.vue` components.
+
+You can use Vue's [`onActivated()` and `onDeactivated()`](https://vuejs.org/guide/built-ins/keep-alive.html#lifecycle-of-cached-instance) lifecycle hooks inside your page components to react to the page being shown/hidden.
+
+### Why not `<KeepAlive>` inside `+Layout`?
+
+Wrapping `<slot />` with `<KeepAlive>` inside a <Link href="/Layout">`+Layout`</Link> component doesn't work:
+
+```vue
+<!-- pages/+Layout.vue -->
+<template>
+  <!-- ❌ Doesn't work -->
+  <KeepAlive>
+    <slot />
+  </KeepAlive>
+</template>
+```
+
+That's a Vue limitation: `<KeepAlive>` only caches its direct child component, whereas slot content is rendered as a [Fragment](https://vuejs.org/guide/extras/rendering-mechanism.html) which `<KeepAlive>` cannot cache.
+
+That's why `vike-vue` applies `<KeepAlive>` where it works: directly around the routed `Page` component (inside all `+Layout` components).
+
+### Caveat
+
+The `<KeepAlive>` cache only lives while `keepAlive` is enabled: if the user navigates to a page that doesn't enable `keepAlive`, then the cache is discarded (all cached page instances are unmounted).
+
+Thus, we recommend enabling `keepAlive` for all your pages (e.g. at `pages/+vue.ts`) and using the `include`/`exclude`/`max` props for fine-grained control over which page components are cached.
+
+
+## See also
+
+- [Vue > `<KeepAlive>`](https://vuejs.org/guide/built-ins/keep-alive.html)
+- <Link href="/react-setting" />
+- <Link href="/Layout" />
+- <Link href="/vike-vue" />
+- <Link href="/settings" />


### PR DESCRIPTION
## Description

Documents the new `vike-vue` setting `+vue` (implemented in https://github.com/vikejs/vike-vue/pull/236) — the Vue counterpart of vike-react's [`+react`](https://vike.dev/react-setting) setting — and its first option `keepAlive`, which preserves page component instances across client-side navigation by wrapping the `<Page>` component with Vue's built-in `<KeepAlive>` component.

See https://github.com/orgs/vikejs/discussions/3433.

### Changes

- New page `docs/pages/vue-setting/+Page.mdx` (`https://vike.dev/vue-setting`), mirroring `/react-setting`: usage (including the function-of-`pageContext` form), the `keepAlive` option and its `<KeepAlive>` props, why `<KeepAlive>` inside `+Layout` cannot work (slot content is rendered as a Fragment which `<KeepAlive>` cannot cache), and the caveat that the cache is discarded when navigating to a page that doesn't enable the option.
- `docs/headings.ts`: add `+vue` to the detached API headings.
- `docs/pages/settings/+Page.mdx`: list `vue` under Basics, next to `react`.

### Testing

- `pnpm run build` in `docs/` ✅ (352 pages pre-rendered, including `vue-setting.html`)
- `pnpm run format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU13ncNmLi5rz2xySmm5rZ