### PR TITLE
chore(deps): bump @brillout/docpress to ^0.17.0

### DIFF
--- a/docs/components/JustAMiddleware.mdx
+++ b/docs/components/JustAMiddleware.mdx
@@ -26,4 +26,4 @@ server.addMiddleware({
 
 You can embed {(() => {const content = <code>renderPage()</code>; return props.noLink ? content : <Link href="/renderPage">{content}</Link> })()} into any server and any deployment environment.
 
-> Alternatively, instead of using `renderPage()`, you can <Link text="pre-render" href="/pre-rendering" /> your pages and remove the need for a production server (and deploy to a <Link text="static host" href="/static-hosts" /> instead).
+> Alternatively, instead of using `renderPage()`, you can <Link href="/pre-rendering">pre-render</Link> your pages and remove the need for a production server (and deploy to a <Link href="/static-hosts">static host</Link> instead).

--- a/docs/components/JustAMiddlewareLink.tsx
+++ b/docs/components/JustAMiddlewareLink.tsx
@@ -7,7 +7,7 @@ function JustAMiddlewareLink() {
   return (
     <>
       From the perspective of the server, Vike is{' '}
-      <Link text="just a server middleware" href="/integration#server-manual-integration" />.
+      <Link href="/integration#server-manual-integration">just a server middleware</Link>.
     </>
   )
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@batijs/elements": "^0.0.87",
-    "@brillout/docpress": "^0.16.50",
+    "@brillout/docpress": "^0.17.0",
     "@classmatejs/react": "^0.2.1",
     "@gsap/react": "^2.1.2",
     "@tailwindcss/vite": "^4.1.18",

--- a/docs/pages/abort/+Page.mdx
+++ b/docs/pages/abort/+Page.mdx
@@ -41,7 +41,7 @@ If `throw redirect()` or `throw render()` doesn't work:
 
 If `throw redirect()` doesn't work:
  - **Make sure to add `pageContext.httpResponse.headers` to the HTTP response.**  
-   If you've embedded Vike into your server using <Link text={<code>renderPage()</code>} href="/renderPage" />, inspect whether `pageContext.httpResponse.headers` contains [the `Location` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Location) and then double check whether you're correctly adding `pageContext.httpResponse.headers` to the HTTP response.
+   If you've embedded Vike into your server using <Link href="/renderPage"><code>renderPage()</code></Link>, inspect whether `pageContext.httpResponse.headers` contains [the `Location` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Location) and then double check whether you're correctly adding `pageContext.httpResponse.headers` to the HTTP response.
 
 
 ## See also

--- a/docs/pages/auth/+Page.mdx
+++ b/docs/pages/auth/+Page.mdx
@@ -2,7 +2,7 @@ import { Link, RepoLink } from '@brillout/docpress'
 
 In principle, you can use Vike with any authentication tool such as:
 - [Better Auth](https://github.com/better-auth/better-auth)
-- <Link text="Auth.js" href="/Auth.js" />
+- <Link href="/Auth.js">Auth.js</Link>
 - [Grant](https://github.com/simov/grant)
 - [Passport.js](https://github.com/jaredhanson/passport)
 - [Auth0](https://auth0.com/)
@@ -155,7 +155,7 @@ export const guard = (pageContext: PageContextServer) => {
 > Using `render('/login')` instead of `redirect('/login')` allows the URL to be preserved during the entire login flow:
 >  1. Unauthenticated user goes to URL `/admin` and sees the login page. (URL is `/admin`.)
 >  2. User fills the sign-in form and successfully logs in. (URL is still `/admin`.)
->  3. <Link text="Reload" href="/reload" /> the page, the user now sees the admin page. (URL is still `/admin`.)
+>  3. <Link href="/reload">Reload</Link> the page, the user now sees the admin page. (URL is still `/admin`.)
 >
 > See <RepoLink text="example" path="/examples/auth/" />.
 

--- a/docs/pages/clientRouting/+Page.mdx
+++ b/docs/pages/clientRouting/+Page.mdx
@@ -10,9 +10,9 @@ import { UseVikeExtensionUiFramework, UiFrameworkExtension, ConfigSpec } from '.
 `boolean {:ts}`
 </ConfigSpec>
 
-If you don't use a <UiFrameworkExtension /> then Vike does <Link text="Server Routing" href="/server-routing" /> by default.
+If you don't use a <UiFrameworkExtension /> then Vike does <Link href="/server-routing">Server Routing</Link> by default.
 
-You can opt into <Link text="Client Routing" href="/client-routing" /> by using the `clientRouting` setting, see <Link href="#getting-started" />.
+You can opt into <Link href="/client-routing">Client Routing</Link> by using the `clientRouting` setting, see <Link href="#getting-started" />.
 
 <UseVikeExtensionUiFramework featureName="Client Routing" />
 
@@ -40,7 +40,7 @@ Vue example:
    } satisfies Config
    ```
 
-2. Adapt your <Link text={<><code>onRenderClient()</code></>} href="/onRenderClient" /> hook:
+2. Adapt your <Link href="/onRenderClient"><code>onRenderClient()</code></Link> hook:
 
    ```ts
    // /renderer/+onRenderClient.ts
@@ -107,7 +107,7 @@ And following hooks to implement page transition animations:
 
 Page settings:
 - `prefetchStaticAssets`: Link prefetching settings, see <Link href="/prefetchStaticAssets" />.
-- `hydrationCanBeAborted`: Whether the <Link text="UI framework" href="/ui-frameworks" /> allows the <Link href="/hydration">hydration</Link> to be aborted, see <Link href="/hydrationCanBeAborted" />.
+- `hydrationCanBeAborted`: Whether the <Link href="/ui-frameworks">UI framework</Link> allows the <Link href="/hydration">hydration</Link> to be aborted, see <Link href="/hydrationCanBeAborted" />.
 
 Anchor link options:
 - `<a href="/some/url" keep-scroll-position>`: Don't scroll to the top of the page, preserve the scroll position instead. See also:

--- a/docs/pages/cloudflare/+Page.mdx
+++ b/docs/pages/cloudflare/+Page.mdx
@@ -244,7 +244,7 @@ In other words:
 When using Node.js(/Bun/Deno) for development and Cloudflare Workers for production, you may need a `fetch()` function that works in both environments.
 
 You can define a fetch function at `pageContext.fetch` that works in all environments.
-The trick is to add a different `fetch()` implementation to `pageContextInit` at <Link text={<code>renderPage(pageContextInit)</code>} href="/renderPage" />.
+The trick is to add a different `fetch()` implementation to `pageContextInit` at <Link href="/renderPage"><code>renderPage(pageContextInit)</code></Link>.
 
 Example: <RepoLink path='/examples/cloudflare-workers-react-full#universal-fetch' />.
 

--- a/docs/pages/data/+Page.mdx
+++ b/docs/pages/data/+Page.mdx
@@ -44,9 +44,9 @@ async function data(pageContext: PageContextServer) {
 
 ## Error handling
 
-If an error is thrown by `data()`, then Vike renders your <Link text="error page" href="/error-page" /> and there is usually nothing for you to do (beyond defining an error page `/pages/_error/+Page.js`).
+If an error is thrown by `data()`, then Vike renders your <Link href="/error-page">error page</Link> and there is usually nothing for you to do (beyond defining an error page `/pages/_error/+Page.js`).
 
-But if you want a more precise error handling (such as showing an insightful error message to the user instead of some generic "Something went wrong"), then use <Link href="/render" text={<code>throw render()</code>}></Link> and/or <Link href="/redirect" text={<code>throw redirect()</code>}></Link>.
+But if you want a more precise error handling (such as showing an insightful error message to the user instead of some generic "Something went wrong"), then use <Link href="/render"><code>throw render()</code></Link> and/or <Link href="/redirect"><code>throw redirect()</code></Link>.
 
 ```ts
 // /pages/movies/+data.ts

--- a/docs/pages/deploy-sync/+Page.mdx
+++ b/docs/pages/deploy-sync/+Page.mdx
@@ -2,7 +2,7 @@ import { Link } from '@brillout/docpress'
 
 When you deploy a new version, then any user currently browsing your (now outdated) frontend will automatically transition to the new frontend as soon as the user navigates to a new page.
 
-This works for both <Link text="Server Routing" href="/server-routing" /> and <Link text="Client Routing" href="/client-routing" />.
+This works for both <Link href="/server-routing">Server Routing</Link> and <Link href="/client-routing">Client Routing</Link>.
 
 Everything is handled automatically and there is nothing for you to do.
 
@@ -10,7 +10,7 @@ Everything is handled automatically and there is nothing for you to do.
 >
 > The problem is this: when you deploy a new frontend, what should happen to your users that are currently browsing your frontend?
 >
-> If you do nothing, and if your app uses <Link text="Client Routing" href="/client-routing" />, then your users may end up staying a very long time on your outdated frontend with outdated client-side JavaScript. This may lead to many problems such as out-of-sync data requests and mutations.
+> If you do nothing, and if your app uses <Link href="/client-routing">Client Routing</Link>, then your users may end up staying a very long time on your outdated frontend with outdated client-side JavaScript. This may lead to many problems such as out-of-sync data requests and mutations.
 >
 > Reloading the page of your users as soon as a new frontend deployment is detected is a no-go: it disrupts your user's activity on your website and your user may lose ephemeral client-side state such as the text he entered in a form or in a comment textarea.
 >
@@ -20,7 +20,7 @@ Everything is handled automatically and there is nothing for you to do.
 
 > **How does Vike's solution work?**
 >
-> Vike temporarily falls back to <Link text="Server Routing" href="/server-routing" /> whenever retrieving a static asset returns a `404`: the URL of all static assets contain a unique hash and, consequently, when the user navigates to a new page then the old frontend requests static asset URLs that don't exist anymore.
+> Vike temporarily falls back to <Link href="/server-routing">Server Routing</Link> whenever retrieving a static asset returns a `404`: the URL of all static assets contain a unique hash and, consequently, when the user navigates to a new page then the old frontend requests static asset URLs that don't exist anymore.
 >
 > With Server Routing, when the user navigates to a new page, the entire client-side is reloaded (i.e. the new frontend is loaded). After the reload, Client Routing is resumed.
 >

--- a/docs/pages/disableAutoFullBuild/+Page.mdx
+++ b/docs/pages/disableAutoFullBuild/+Page.mdx
@@ -24,7 +24,7 @@ export default {
 Running `$ vite build` executes three build steps:
  1. Client-side build (`dist/client/`).
  1. Server-side build (`dist/server/`).
- 1. Pre-rendering (if <Link text="pre-rendering is enabled" href="/pre-rendering" />).
+ 1. Pre-rendering (if <Link href="/pre-rendering">pre-rendering is enabled</Link>).
 
 When setting `disableAutoFullBuild` to `true` then only step `1` is executed. To run the full build, you then have to:
 

--- a/docs/pages/error-page/+Page.mdx
+++ b/docs/pages/error-page/+Page.mdx
@@ -7,7 +7,7 @@ import { ConfigSpec } from '../../components'
 />
 
 The error page, which is defined by `/pages/_error/+Page.js`, is rendered when an error occurs. It's also rendered when
-you call <Link href="/render" text={<code>throw render(abortStatusCode)</code>}></Link>.
+you call <Link href="/render"><code>throw render(abortStatusCode)</code></Link>.
 
 ```tsx
 // /pages/_error/+Page.ts
@@ -72,12 +72,12 @@ declare global {
 
 > The global interface `Vike.PageContext` allows you to define `pageContext` types in a global fashion, see <Link href="/pageContext#typescript" />.
 
-The `pageContext.abortReason` and `pageContext.abortStatusCode` values are set by <Link href="/render" text={<code>throw render(abortStatusCode, abortReason)</code>} />, and `pageContext.is404` is set by Vike.
+The `pageContext.abortReason` and `pageContext.abortStatusCode` values are set by <Link href="/render"><code>throw render(abortStatusCode, abortReason)</code></Link>, and `pageContext.is404` is set by Vike.
 
 The error page is rendered when:
  1. The URL didn't match the route of any of your pages (`404 Page Not Found`).
  2. Your code has a bug (`500 Internal Error`), technically speaking: one of your hooks threw an error.
- 3. One of your hooks used <Link href="/render" text={<code>throw render(abortStatusCode)</code>} />, for example: `throw render(401, "You don't have the permission to access this page.")`.
+ 3. One of your hooks used <Link href="/render"><code>throw render(abortStatusCode)</code></Link>, for example: `throw render(401, "You don't have the permission to access this page.")`.
 
 > Currently, you can define only one error page. See also:
 > - [Feature Request #1038 — Allow multiple error pages](https://github.com/vikejs/vike/issues/1038)
@@ -85,7 +85,7 @@ The error page is rendered when:
 
 ## Pre-rendering
 
-If you use <Link text="pre-rendering" href="/pre-rendering" />, then Vike uses the error page to generate
+If you use <Link href="/pre-rendering">pre-rendering</Link>, then Vike uses the error page to generate
 `/dist/client/404.html`.
 
 > Most Static Hosts follow the convention of using the file `404.html` as 404 page.

--- a/docs/pages/grpc/+Page.mdx
+++ b/docs/pages/grpc/+Page.mdx
@@ -10,7 +10,7 @@ This means you cannot call gRPC endpoints directly from the browser;
 you always need to call gRPC endpoints from your Node.js server.
 
 For fetching data,
-you can simply use a <Link text={<code>onBeforeRender()</code>} href="/data-fetching" /> hook,
+you can simply use a <Link href="/data-fetching"><code>onBeforeRender()</code></Link> hook,
 since `onBeforeRender()` hooks are called in Node.js.
 
 For mutating data:

--- a/docs/pages/hapi/+Page.mdx
+++ b/docs/pages/hapi/+Page.mdx
@@ -16,6 +16,6 @@ This means that in development, Vite is responsible for serving the entire front
 >  - [GitHub > hapi > Express/Connect middleware support (#80)](https://github.com/hapijs/hapi/issues/80)
 
 In production, we use only *one* server:
- 1. Our hapi server that serves the backend *as well* as the frontend: it serves the static files living at `dist/client/` and does server-side rendering by using Vike's <Link text={<code>renderPage()</code>} href="/renderPage" />.
+ 1. Our hapi server that serves the backend *as well* as the frontend: it serves the static files living at `dist/client/` and does server-side rendering by using Vike's <Link href="/renderPage"><code>renderPage()</code></Link>.
 
 > See [GitHub > `vikejs/vike` > hapi (#366)](https://github.com/vikejs/vike/issues/366#issuecomment-1189144446).

--- a/docs/pages/i18n/+Page.mdx
+++ b/docs/pages/i18n/+Page.mdx
@@ -95,7 +95,7 @@ export function Link({ href, locale, ...props }: { locale: string } & AnchorElem
 
 ## Pre-rendering
 
-If you use <Link text="pre-rendering" href="/pre-rendering" /> then, in addition to defining <Link href="/onBeforeRoute">`onBeforeRoute()`</Link>, you also need to
+If you use <Link href="/pre-rendering">pre-rendering</Link> then, in addition to defining <Link href="/onBeforeRoute">`onBeforeRoute()`</Link>, you also need to
 define the <Link href="/onPrerenderStart">`onPrerenderStart()`</Link> hook:
 
 ```ts
@@ -137,7 +137,7 @@ async function onPrerenderStart(prerenderContext: PrerenderContext) {
 
 See <RepoLink path='/examples/i18n/' /> for an example using `onPrerenderStart()`.
 
-Your <Link text={<><code>onBeforePrerenderStart()</code> hooks</>} href="/onBeforePrerenderStart" /> (if you use any) return URLs without any locale (e.g. `onBeforePrerenderStart()` returning `/product/42`). Instead, it's your `onPrerenderStart()` hook that duplicates and modifies URLs for each locale (e.g. duplicating `/product/42` into `/en-US/product/42`, `/de-DE/product/42`, `/fr-FR/product/42`).
+Your <Link href="/onBeforePrerenderStart"><code>onBeforePrerenderStart()</code> hooks</Link> (if you use any) return URLs without any locale (e.g. `onBeforePrerenderStart()` returning `/product/42`). Instead, it's your `onPrerenderStart()` hook that duplicates and modifies URLs for each locale (e.g. duplicating `/product/42` into `/en-US/product/42`, `/de-DE/product/42`, `/fr-FR/product/42`).
 
 ```ts
 // pages/product/+onBeforePrerenderStart.ts

--- a/docs/pages/migration/0.4.134/+Page.mdx
+++ b/docs/pages/migration/0.4.134/+Page.mdx
@@ -4,7 +4,7 @@ The `0.4.134` release soft-deprecates `pageContext.httpResponse.contentType` in 
 
 See the sections below for how to migrate.
 
- > The `0.4.134` release adds built-in support for <Link text="URL redirections" href="/redirect" /> and that's why the new property `pageContext.httpResponse.headers` is needed.
+ > The `0.4.134` release adds built-in support for <Link href="/redirect">URL redirections</Link> and that's why the new property `pageContext.httpResponse.headers` is needed.
 
 ## Express.js
 

--- a/docs/pages/migration/0.4/+Page.mdx
+++ b/docs/pages/migration/0.4/+Page.mdx
@@ -164,6 +164,6 @@ Most users already `export { Page }` in `.page.js` files, but some users use the
 
 ## Multiple `onBeforeRender()`
 
-<Link text={<>Multiple <code>onBeforeRender()</code> hooks</>} href="/onBeforeRender-multiple" /> are deprecated in favor of <Link href="/exports" text="Custom Hooks/Exports"/>.
+<Link href="/onBeforeRender-multiple">Multiple <code>onBeforeRender()</code> hooks</Link> are deprecated in favor of <Link href="/exports">Custom Hooks/Exports</Link>.
 
 > Having one `onBeforeRender()` hook per page is still supported and hasn't changed.

--- a/docs/pages/migration/v1-design/+Page.mdx
+++ b/docs/pages/migration/v1-design/+Page.mdx
@@ -137,7 +137,7 @@ Move your error page (if you defined one):
 
 Apply following additional steps if you've defined:
  - <Link href="#renamed-hooks" />
- - <Link text="Custom hooks/exports" href="#custom-hooks-exports" />
+ - <Link href="#custom-hooks-exports">Custom hooks/exports</Link>
  - [`onBeforeRender` in `.page.js`](#onbeforerender-in-page-js) (instead of `.page.server.js`)
  - <Link href="#client-init-code" />
 
@@ -299,16 +299,16 @@ export default {
 } satisfies Config
 ```
 
-For convenience, you can use <Link text={<code>meta</code>} href="/meta" /> in order to
+For convenience, you can use <Link href="/meta"><code>meta</code></Link> in order to
 [create a new config `dataIsomorph: boolean`](https://github.com/vikejs/vike/blob/43503a4829e4bb0171785bc8fa501c7ca096a150/examples/react-full/renderer/+config.ts#L14-L33) for a
 [page-per-page toggle](https://github.com/vikejs/vike/blob/43503a4829e4bb0171785bc8fa501c7ca096a150/examples/react-full/pages/star-wars/@id/+dataIsomorph.ts).
 
 
 ## Client init code
 
-The new config <Link text={<code>client</code>} href="/client" /> allows you to define client-side initialization code.
+The new config <Link href="/client"><code>client</code></Link> allows you to define client-side initialization code.
 
-> You can also keep using <Link text={<code>onHydrationEnd()</code>} href="/onHydrationEnd" />.
+> You can also keep using <Link href="/onHydrationEnd"><code>onHydrationEnd()</code></Link>.
 
 ```ts
 // +config.ts

--- a/docs/pages/navigate/+Page.mdx
+++ b/docs/pages/navigate/+Page.mdx
@@ -78,7 +78,7 @@ window.addEventListener('popstate', () => {
 
 ## Without `vike-{react,vue,solid}`
 
-If you don't use a <UiFrameworkExtension /> and if you use <Link text="Server Routing" href="/server-routing" /> then use `window.location.href = '/some/url'` instead of `navigate()` (because `navigate()` requires <Link text="Client Routing" href="/client-routing" />).
+If you don't use a <UiFrameworkExtension /> and if you use <Link href="/server-routing">Server Routing</Link> then use `window.location.href = '/some/url'` instead of `navigate()` (because `navigate()` requires <Link href="/client-routing">Client Routing</Link>).
 
 > The <UiFrameworkExtension plural noLink /> use Client Routing.
 

--- a/docs/pages/nextjs/+Page.mdx
+++ b/docs/pages/nextjs/+Page.mdx
@@ -32,13 +32,13 @@ Finally, Vike is a community project: instead of leaning on a framework with bus
 | RSC (React Server Components)                                   | Yes, <Link href="/react#react-server-components">partially</Link> | Yes, experimental       |
 | <p align="center">**Routing**</p>                                                        |                                                            |                               |
 | Filesystem Routing                                              | Yes                                                        | Yes                           |
-| <Link text="Domain-driven Filesystem Routing" href="/file-structure" />                                        | Yes                                                        | No                            |
-| <Link text="Client Routing" href="/client-routing" />           | Yes                                                        | Yes, but [limited](https://github.com/vercel/next.js/discussions/64660) in SPA-only mode ***                           |
-| <Link text="Server Routing" href="/server-routing" />           | Yes                                                        | No                            |
-| <Link text="Base URL" href="/base-url" />                       | Yes                                                        | Limited                       |
+| <Link href="/file-structure">Domain-driven Filesystem Routing</Link>                                        | Yes                                                        | No                            |
+| <Link href="/client-routing">Client Routing</Link>           | Yes                                                        | Yes, but [limited](https://github.com/vercel/next.js/discussions/64660) in SPA-only mode ***                           |
+| <Link href="/server-routing">Server Routing</Link>           | Yes                                                        | No                            |
+| <Link href="/base-url">Base URL</Link>                       | Yes                                                        | Limited                       |
 | <p align="center">**Pre-rendering (SSG)**</p>                                                   |                                                            |                               |
 | Pre-rendering (SSG)                                    | Yes, for pages                                                        | Yes, for pages, or components ([Partial Pre-rendering](https://nextjs.org/learn/dashboard-app/partial-prerendering) using RSC)                               |
-| Incremental Static Regeneration (ISR)                  | No*, use <Link text="@photonjs/vercel" href="/vercel#isr" />        | Yes, in the Node.js runtime, on Vercel    |
+| Incremental Static Regeneration (ISR)                  | No*, use <Link href="/vercel#isr">@photonjs/vercel</Link>        | Yes, in the Node.js runtime, on Vercel    |
 | SPA-only mode (popular for PWAs) ***                   | Yes                                                        | Limited: [no dynamic routing in App Router](https://github.com/vercel/next.js/discussions/64660)                       |
 | <p align="center">**Integrations**</p>                                                    |                                                            |                               |
 HTTP server | No*, bring your own | Baked-in, custom server partially supported with caveats[[1]](https://github.com/vikejs/vike/issues/158#issuecomment-1355306156)[[2]](https://stackoverflow.com/questions/58742343/do-i-have-to-use-express-in-next-js-project/70945468#70945468) |
@@ -47,7 +47,7 @@ HTTP server | No*, bring your own | Baked-in, custom server partially supported 
 | <p align="center">**Extras**</p>                                |                                                            |                               |
 | Head component                                                  | No*, use a tool like [react-helmet](https://github.com/nfl/react-helmet). | Yes, next/head                |
 | Image component                                                 | No*, use an <Link href="/img">image optimizer tool</Link>. | Yes, next/image               |
-| API routes                                                      | No*, use your server or an <Link text="RPC tool" href="/api-routes" />.   | Yes                           |
+| API routes                                                      | No*, use your server or an <Link href="/api-routes">RPC tool</Link>.   | Yes                           |
 | Internationalization (i18n)                                     | Yes                                                         | Limited                       |
 | <Link href="/deploy-sync" />                                    | Yes                                                         | No                            |
 | [Build your own framework](https://land.vike.dev)                   | Yes                                                         | No                            |
@@ -195,7 +195,7 @@ Vike is made by the community and has no incentive to favor any side of the work
 ## UI Framework agnostic
 
 Next.js is deeply tied to React. So if you want to move to another UI framework later, like for instance [SolidJS](https://www.solidjs.com/), then it means a laborious refactor away from NextJS.
-But with Vike, you keep your options open, and can swap out your UI framework rather easily with various <Link text="UI extensions for Vike" href="/extensions" />.
+But with Vike, you keep your options open, and can swap out your UI framework rather easily with various <Link href="/extensions">UI extensions for Vike</Link>.
 
 > Vike is completely agnostic to React and its source code has zero dependency on React. You can actually use Vike with any other UI Framework (Vue, Preact, Solid, etc.).
 >

--- a/docs/pages/onBeforeRender-multiple/+Page.mdx
+++ b/docs/pages/onBeforeRender-multiple/+Page.mdx
@@ -1,5 +1,5 @@
 import { Danger, Link } from '@brillout/docpress'
 
-<Danger>Support for executing more than one `onBeforeRender()` hook is deprecated. Use <Link href="/meta" text="custom configs"/>
+<Danger>Support for executing more than one `onBeforeRender()` hook is deprecated. Use <Link href="/meta">custom configs</Link>
 or the <Link href="/data">`data()`</Link> hook instead. (You can still define multiple `onBeforeRender()` hooks but only
 one will be executed.)</Danger>

--- a/docs/pages/onRenderClient/+Page.mdx
+++ b/docs/pages/onRenderClient/+Page.mdx
@@ -6,7 +6,7 @@ import { Link } from '@brillout/docpress'
   global={null}
 />
 
-The `onRenderClient()` hook defines how pages are rendered/<Link text="hydrated" href="/hydration" /> on the client-side.
+The `onRenderClient()` hook defines how pages are rendered/<Link href="/hydration">hydrated</Link> on the client-side.
 
 The hooks `onRenderClient()` and <Link href="/onRenderHtml">`onRenderHtml()`</Link> are essentially the glue code between Vike and your UI framework (React/Vue/Solid/...).
 
@@ -45,8 +45,8 @@ You can use [`passToClient`](/passToClient) to determine what subset of `pageCon
 ## SPA vs SSR
 
 When implementing SSR, the client-side `onRenderClient()` hook works in tandem with the
-<Link text={<>server-side <code>onRenderHtml()</code> hook</>} href="/onRenderHtml" />: the server-side `onRenderHtml()`
-hook renders the page to HTML and the client-side `onRenderClient()` hook <Link text="hydrates" href="/hydration" /> the
+<Link href="/onRenderHtml">server-side <code>onRenderHtml()</code> hook</Link>: the server-side `onRenderHtml()`
+hook renders the page to HTML and the client-side `onRenderClient()` hook <Link href="/hydration">hydrates</Link> the
 HTML.
 
 When implementing an SPA, then the client-side `onRenderClient()` hook is solely responsible for rendering the page.

--- a/docs/pages/pageContext/+Page.mdx
+++ b/docs/pages/pageContext/+Page.mdx
@@ -323,11 +323,11 @@ Whether the page was navigated by the client-side router.
 
 <Prop name="abortReason" />
 
-Set by <Link href="/render" text={<code>throw render()</code>} /> and used by the <Link text="error page" href="/error-page" />.
+Set by <Link href="/render"><code>throw render()</code></Link> and used by the <Link href="/error-page">error page</Link>.
 
 <Prop name="abortStatusCode" />
 
-Set by <Link href="/render" text={<code>throw render()</code>} /> and used by the <Link text="error page" href="/error-page" />.
+Set by <Link href="/render"><code>throw render()</code></Link> and used by the <Link href="/error-page">error page</Link>.
 
 <Prop name="errorWhileRendering" />
 
@@ -644,7 +644,7 @@ To define properties only for the server-/client-side, use the interfaces `Vike.
 
 ### Server Routing
 
-If you use <Link text="Server Routing" href="/server-routing" />:
+If you use <Link href="/server-routing">Server Routing</Link>:
 
 ```ts ts-only
 import type {

--- a/docs/pages/pre-rendering/+Page.mdx
+++ b/docs/pages/pre-rendering/+Page.mdx
@@ -8,9 +8,9 @@ Pre-rendering means to render the HTML of pages at build-time (when running <Lin
 
 Without pre-rendering, the HTML of a page is rendered at request-time (when the user goes to that page).
 
-If you pre-render all your pages, you don't need a production server: your app consists only of a static assets (HTML, JS, CSS, images, ...) that can be deployed to a static host (<Link href="/github-pages" text="GitHub Pages" />, <Link href="/cloudflare-pages">Cloudflare Pages</Link>, <Link href="/netlify">Netlify</Link>, ...).
+If you pre-render all your pages, you don't need a production server: your app consists only of a static assets (HTML, JS, CSS, images, ...) that can be deployed to a static host (<Link href="/github-pages">GitHub Pages</Link>, <Link href="/cloudflare-pages">Cloudflare Pages</Link>, <Link href="/netlify">Netlify</Link>, ...).
 
-If you don't pre-render, you need a production server to dynamically render your pages' HTML at request-time. (Deploying a [Node.js](https://nodejs.org) server to [AWS](https://aws.amazon.com), <Link href="/cloudflare" text="Cloudflare Workers" />, <Link href="/vercel" text="Vercel" />...)
+If you don't pre-render, you need a production server to dynamically render your pages' HTML at request-time. (Deploying a [Node.js](https://nodejs.org) server to [AWS](https://aws.amazon.com), <Link href="/cloudflare">Cloudflare Workers</Link>, <Link href="/vercel">Vercel</Link>...)
 
 > Tools that pre-render pages are also known as "SSG" (Static-Site Generators).
 
@@ -31,7 +31,7 @@ But **pre-rendering cannot be used for websites with content that changes very f
 
 **Pre-rendering can be used for websites with content that changes only occasionally**. For example, the content of `https://vike.dev` changes only when a maintainer updates the documentation — the entire website `https://vike.dev` can then be pre-rendered again every time there is change.
 
-> This website `https://vike.dev` uses pre-rendering and is deployed to <Link href="/github-pages" text="GitHub Pages" /> — a static host that is completely free, [easy to use](https://github.com/vikejs/vike/blob/main/.github/workflows/website-deploy.yml), and performant.
+> This website `https://vike.dev` uses pre-rendering and is deployed to <Link href="/github-pages">GitHub Pages</Link> — a static host that is completely free, [easy to use](https://github.com/vikejs/vike/blob/main/.github/workflows/website-deploy.yml), and performant.
 
 
 ## Get started

--- a/docs/pages/prefetch/+Page.mdx
+++ b/docs/pages/prefetch/+Page.mdx
@@ -33,7 +33,7 @@ async function onSubmit() {
 
 ## Without `vike-{react,vue,solid}`
 
-If you don't use a <UiFrameworkExtension />, then you need to use <Link text="Client Routing" href="/client-routing" /> to be able to use `prefetch()`. Prefetching doesn't work with <Link text="Server Routing" href="/server-routing" />.
+If you don't use a <UiFrameworkExtension />, then you need to use <Link href="/client-routing">Client Routing</Link> to be able to use `prefetch()`. Prefetching doesn't work with <Link href="/server-routing">Server Routing</Link>.
 
 
 ## See also

--- a/docs/pages/prerender/+Page.mdx
+++ b/docs/pages/prerender/+Page.mdx
@@ -79,7 +79,7 @@ type PrerenderConfigPage = PageSetting | (() => PageSetting | Promise<PageSettin
 
 Stop showing a warning when pages cannot be pre-rendered.
 
-> Vike shows a warning when a page has a parameterized route (e.g. <Link text="Route String" href="/route-string" /> `/movie/@movieId`) while there isn't any <Link text={<><code>onBeforePrerenderStart()</code> hook</>} href="/onBeforePrerenderStart" /> that provides at least one URL matching the page's route (e.g. `/movie/42`).
+> Vike shows a warning when a page has a parameterized route (e.g. <Link href="/route-string">Route String</Link> `/movie/@movieId`) while there isn't any <Link href="/onBeforePrerenderStart"><code>onBeforePrerenderStart()</code> hook</Link> that provides at least one URL matching the page's route (e.g. `/movie/42`).
 This setting doesn't affect the pre-rendering process: it only suppresses the warning.
 
 Alternatively, set `+prerender` to `false` for the pages that cannot be pre-rendered — this also suppresses the warning. See <Link href="/pre-rendering#partial" />.
@@ -88,7 +88,7 @@ Alternatively, set `+prerender` to `false` for the pages that cannot be pre-rend
 >
 > That said, if you cannot or don't want to pre-render all your pages while still deploying to a <Link href="/static-hosts">static host</Link>, then see the workaround at [#1476 - Pre-rendered dynamic routes (static host deployment)](https://github.com/vikejs/vike/issues/1476).
 >
-> With <Link text={<code>vite-plugin-vercel</code>} href="/vercel#vite-plugin-vercel" />, you can statically deploy your pre-rendered pages while using a production server for your non-pre-rendered pages.
+> With <Link href="/vercel#vite-plugin-vercel"><code>vite-plugin-vercel</code></Link>, you can statically deploy your pre-rendered pages while using a production server for your non-pre-rendered pages.
 
 
 ## `redirects`
@@ -140,7 +140,7 @@ Set to `false` (or `1`) to disable concurrency.
 
 `boolean` (default: `false`)
 
-When running `$ vike build`, Vike automatically triggers <Link href="/pre-rendering">pre-rendering</Link>. (If you <Link text="enabled it" href="/pre-rendering#get-started" />.)
+When running `$ vike build`, Vike automatically triggers <Link href="/pre-rendering">pre-rendering</Link>. (If you <Link href="/pre-rendering#get-started">enabled it</Link>.)
 
 You can disable the automatic triggering:
 

--- a/docs/pages/reload/+Page.mdx
+++ b/docs/pages/reload/+Page.mdx
@@ -6,9 +6,9 @@ import { ConfigSpec } from '../../components'
   global={null}
 />
 
-The `reload()` function enables you to reload the page. The difference with [`window.location.reload`](https://developer.mozilla.org/en-US/docs/Web/API/Location/reload) is that `reload()` is much faster as it uses Vike's <Link text="Client Router" href="/client-routing" />.
+The `reload()` function enables you to reload the page. The difference with [`window.location.reload`](https://developer.mozilla.org/en-US/docs/Web/API/Location/reload) is that `reload()` is much faster as it uses Vike's <Link href="/client-routing">Client Router</Link>.
 
-> `reload()` works only with <Link text="Client Routing" href="/client-routing" />. If you use <Link text="Server Routing" href="/server-routing" />, then do `window.location.reload()` instead.
+> `reload()` works only with <Link href="/client-routing">Client Routing</Link>. If you use <Link href="/server-routing">Server Routing</Link>, then do `window.location.reload()` instead.
 
 The most common use case for `reload()` is to refresh the page when an authentication cookie is updated, see <Link href="/auth" />.
 

--- a/docs/pages/render-modes/+Page.mdx
+++ b/docs/pages/render-modes/+Page.mdx
@@ -109,7 +109,7 @@ This is the key difference between SPA and SSR: in SPA `div#root` is empty, wher
 This means that, with SPA, we use our server-side `onRenderHtml()` hook to generate HTML that is just an empty shell:
 the HTML doesn't contain the page's content.
 
-For production, we usually want to <Link text="pre-render" href="/pre-rendering" /> the HTML of our SPA pages in order to remove the need for a production Node.js server.
+For production, we usually want to <Link href="/pre-rendering">pre-render</Link> the HTML of our SPA pages in order to remove the need for a production Node.js server.
 
 We can also use our server-side `onRenderHtml()` hook to render `<head>`:
 

--- a/docs/pages/render/+Page.mdx
+++ b/docs/pages/render/+Page.mdx
@@ -25,7 +25,7 @@ export function someHook() {
 ```
 
 - If the first argument is a URL, then that URL is rendered.
-- If the first argument is a status code, then the <Link text="error page" href="/error-page" /> is rendered.
+- If the first argument is a status code, then the <Link href="/error-page">error page</Link> is rendered.
   - [`401` Unauthorized](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) - Access denied, the user isn't logged in.
   - [`403` Forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) - Access denied, the user is logged in but isn't allowed.
   - [`404` Not Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404) - Page doesn't exist.

--- a/docs/pages/renderPage/+Page.mdx
+++ b/docs/pages/renderPage/+Page.mdx
@@ -84,7 +84,7 @@ async function startServer() {
 ```
 
 The `pageContext.httpResponse.body` value is the HTML string returned by the
-<Link text={<><code>onRenderHtml()</code> hook</>} href="/onRenderHtml" /> with additional `<script>` and `<style>` tags
+<Link href="/onRenderHtml"><code>onRenderHtml()</code> hook</Link> with additional `<script>` and `<style>` tags
 automatically injected by Vike.
 
 > You can control where and what Vike injects using <Link href="/injectFilter" />.
@@ -102,7 +102,7 @@ The `renderPage()` function doesn't depend on Node.js and you can use `renderPag
 
 ## Optional
 
-If you <Link text="pre-render" href="/pre-rendering" /> all your pages then `renderPage()` isn't needed, because:
+If you <Link href="/pre-rendering">pre-render</Link> all your pages then `renderPage()` isn't needed, because:
  - Upon development (`$ vike dev`), Vike automatically embeds itself into Vite's development server.
  - Upon pre-rendering (`$ vike build`/`$ vike prerender`), Vike renders your pages without server.
 

--- a/docs/pages/route-function/+Page.mdx
+++ b/docs/pages/route-function/+Page.mdx
@@ -29,10 +29,10 @@ function route(pageContext: PageContext) {
 
 > The parameter `id` is available at <Link href="/pageContext">`pageContext.routeParams.id`</Link>.
 
-If you merely want to guard your page, then you can use a <Link text="Route String" href="/route-string" /> with a <Link text={<code>guard()</code>} href="/guard" /> hook instead of a Route Function.
+If you merely want to guard your page, then you can use a <Link href="/route-string">Route String</Link> with a <Link href="/guard"><code>guard()</code></Link> hook instead of a Route Function.
 
 You can use any routing tool you want, such as:
- - Vike's <Link text="Route String" href="/route-string" /> resolver [`resolveRoute()`](#resolveroute)
+ - Vike's <Link href="/route-string">Route String</Link> resolver [`resolveRoute()`](#resolveroute)
  - [partRegex](https://github.com/brillout/part-regex)
  - [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) (the router used by Express.js)
  - etc.
@@ -59,7 +59,7 @@ function route(pageContext: PageContext) {
 
 ## `resolveRoute()`
 
-You can use <Link text="Route Strings" href="/route-string" /> inside Route Functions:
+You can use <Link href="/route-string">Route Strings</Link> inside Route Functions:
 
 ```ts
 // /pages/product/edit/+route.ts
@@ -133,7 +133,7 @@ function route(pageContext: PageContext) {
 
 Vike cannot know whether another Route Function will return a higher precedence number, therefore Vike has to execute all Route Functions.
 
-If you use <Link text="Client Routing" href="/client-routing" />, then *all* your Route Functions are loaded in the browser. This means that if a Route Function imports a lot of code, then all that code is loaded on the client-side of *every* page. A heavy Route Function slows down your whole app.
+If you use <Link href="/client-routing">Client Routing</Link>, then *all* your Route Functions are loaded in the browser. This means that if a Route Function imports a lot of code, then all that code is loaded on the client-side of *every* page. A heavy Route Function slows down your whole app.
 
 Route Functions should be lightweight and fast.
 
@@ -150,9 +150,9 @@ export default async () => { /* ... */ }
 ```
 
 The motivation for having an asynchronous Route Function is usually to redirect/protect a private
-page. You can achieve that by using <Link href="/render" text={<code>throw render()</code>} /> / <Link href="/redirect" text={<code>throw redirect()</code>} />
-with an async <Link text={<code>guard()</code>} href="/guard" />, async <Link text={<code>data()</code>} href="/data" />, or
-async <Link text={<code>onBeforeRender()</code>} href="/onBeforeRender" /> hook.
+page. You can achieve that by using <Link href="/render"><code>throw render()</code></Link> / <Link href="/redirect"><code>throw redirect()</code></Link>
+with an async <Link href="/guard"><code>guard()</code></Link>, async <Link href="/data"><code>data()</code></Link>, or
+async <Link href="/onBeforeRender"><code>onBeforeRender()</code></Link> hook.
 
 > An asynchronous Route Function would slow down your entire app: as explained in [Lightweight & fast](#lightweight-fast), every time the user navigates to a new page *all* your Route Functions are called. This means that a single slow Route Function slows down *all* your pages.
 
@@ -198,9 +198,9 @@ export default () => {
 ```
 
 But it isn't recommended: `pageContext.routeParams` is supposed to hold only a minimal amount of information. Instead,
-we recommend to implement complex logic in <Link text={<code>data()</code>} href="/data" />,
-<Link text={<code>onBeforeRender()</code>} href="/onBeforeRender" />, <Link text={<code>guard()</code>} href="/guard" />,
-or in a <Link text="custom hook" href="/meta" />.
+we recommend to implement complex logic in <Link href="/data"><code>data()</code></Link>,
+<Link href="/onBeforeRender"><code>onBeforeRender()</code></Link>, <Link href="/guard"><code>guard()</code></Link>,
+or in a <Link href="/meta">custom hook</Link>.
 
 ## See also
 

--- a/docs/pages/route/+Page.mdx
+++ b/docs/pages/route/+Page.mdx
@@ -6,7 +6,7 @@ import { ConfigSpec } from '../../components'
   global={null}
 />
 
-The `+route` setting determines the page's <Link text="routing" href="/routing" />.
+The `+route` setting determines the page's <Link href="/routing">routing</Link>.
 
 ```ts
 // /pages/product/+config.ts

--- a/docs/pages/server-routing-vs-client-routing/+Page.mdx
+++ b/docs/pages/server-routing-vs-client-routing/+Page.mdx
@@ -44,7 +44,7 @@ For example, on music players such as Spotify, the currently listened song shoul
 
 ### Nested Layouts
 
-Similarly to the previous section, when using <Link text="Nested Layouts" href="/Layout#nested" />, the state of the outer page is preserved, which means Nested Layouts cannot be implemented using Server Routing.
+Similarly to the previous section, when using <Link href="/Layout#nested">Nested Layouts</Link>, the state of the outer page is preserved, which means Nested Layouts cannot be implemented using Server Routing.
 
 *Requirement: Client-side Routing.*
 

--- a/docs/pages/settings/+Page.mdx
+++ b/docs/pages/settings/+Page.mdx
@@ -71,7 +71,7 @@ Settings that alias [Vite](https://vite.dev) settings (see also <Link href="/cli
 - [**`meta`**](/meta): Create new hooks or settings, or modify existing ones.
 - [**`passToClient`**](/passToClient): Determines what `pageContext` values are sent to the client-side.
 - [**`clientRouting`**](/clientRouting): Enable <Link href="/client-routing">Client Routing</Link>.
-- [**`hydrationCanBeAborted`**](/hydrationCanBeAborted): Whether your <Link text="UI framework" href="/ui-frameworks" /> allows the <Link href="/hydration">hydration</Link> to be aborted.
+- [**`hydrationCanBeAborted`**](/hydrationCanBeAborted): Whether your <Link href="/ui-frameworks">UI framework</Link> allows the <Link href="/hydration">hydration</Link> to be aborted.
 - [**`trailingSlash`**](/url-normalization): Whether URLs should end with a trailing slash.
 - [**`disableUrlNormalization`**](/url-normalization): Disable automatic URL normalization.
 - [**`reactStrictMode`**](/reactStrictMode): Whether to use React's `<StrictMode>`.

--- a/docs/pages/why-the-v1-design/+Page.mdx
+++ b/docs/pages/why-the-v1-design/+Page.mdx
@@ -1,6 +1,6 @@
 import { Link } from '@brillout/docpress'
 
-The <Link text="V1 design" href="/migration/v1-design" /> enables the creation of <Link href="/extensions">Vike extensions</Link>.
+The <Link href="/migration/v1-design">V1 design</Link> enables the creation of <Link href="/extensions">Vike extensions</Link>.
 
 ```ts
 // /pages/admin/+config.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.0.87
         version: 0.0.87
       '@brillout/docpress':
-        specifier: ^0.16.50
-        version: 0.16.50(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        specifier: ^0.17.0
+        version: 0.17.0(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       '@classmatejs/react':
         specifier: ^0.2.1
         version: 0.2.1(react@19.2.6)
@@ -2407,10 +2407,6 @@ packages:
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
@@ -2445,12 +2441,6 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/plugin-syntax-jsx@7.28.6':
-    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-jsx@7.29.7':
     resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
@@ -2562,8 +2552,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@brillout/docpress@0.16.50':
-    resolution: {integrity: sha512-Kop78xd1LccxdWYK0soC0Q5XF3Lqg9dCRvvdSR+LvSgk3u/lkGXLM0yV2AJrho45VMtICa1JVB3I1mxcbOvqHA==}
+  '@brillout/docpress@0.17.0':
+    resolution: {integrity: sha512-cezCgnBUh2NmhwFn1d+Qqv5ERelU+imptKIJAlJuGUA5rC0ZQqN2s6MmIFJa/0p4E4/c2UVkOIl4VeAQev4mFQ==}
     peerDependencies:
       '@vitejs/plugin-react': '>=4.0.0'
       react: '>=18.0.0'
@@ -7179,9 +7169,6 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  property-information@7.1.0:
-    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
-
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
@@ -8730,8 +8717,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/helper-plugin-utils@7.28.6': {}
-
   '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
@@ -8765,11 +8750,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -8791,12 +8771,12 @@ snapshots:
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -8880,7 +8860,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@brillout/docpress@0.16.50(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))':
+  '@brillout/docpress@0.17.0(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))':
     dependencies:
       '@brillout/picocolors': 1.0.31
       '@brillout/shiki-transformers': 4.0.2
@@ -11055,7 +11035,7 @@ snapshots:
   '@vercel/nft@1.10.2(rollup@4.43.0)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
-      '@rollup/pluginutils': 5.3.0(rollup@4.43.0)
+      '@rollup/pluginutils': 5.4.0(rollup@4.43.0)
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
       async-sema: 3.1.1
@@ -11414,7 +11394,7 @@ snapshots:
       '@vue/shared': 3.5.18
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.16
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.34':
@@ -11779,7 +11759,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/types': 7.29.7
       html-entities: 2.3.3
       parse5: 7.3.0
@@ -12720,7 +12700,7 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
       unist-util-position: 5.0.0
@@ -13911,8 +13891,6 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  property-information@7.1.0: {}
 
   property-information@7.2.0: {}
 


### PR DESCRIPTION
## What

Bump `@brillout/docpress` from `^0.16.50` to `^0.17.0` in `docs/`.

## Why CI was red

docpress `0.17.0` removed the deprecated `text` prop of `<Link>` — it now throws at build/prerender time:

```
Error: [DocPress][Wrong Usage] The `text` prop of `<Link>` is deprecated, use `<Link>...</Link>` instead of `<Link text="..." />`
```

This broke `pnpm run docs:build` (and therefore the Website Deployment workflow).

## Fix

Migrated all 87 `<Link text=... />` usages across 33 docs files to the children form `<Link>...</Link>`:

- Plain strings: `<Link text="pre-render" href="/x" />` → `<Link href="/x">pre-render</Link>`
- JSX values: `<Link text={<code>data()</code>} href="/x" />` → `<Link href="/x"><code>data()</code></Link>`
- Fragment values: `<Link text={<><code>x()</code> hook</>} href="/y" />` → `<Link href="/y"><code>x()</code> hook</Link>` (fragment wrapper unwrapped)
- Paired tags: `<Link href="/x" text={<code>y</code>}></Link>` → `<Link href="/x"><code>y</code></Link>`

Existing children-form `<Link>` usages were left untouched.

## Verification

- `pnpm run docs:build` — ✅ passes (previously failed with the error above)
- `pnpm run build` (vike package) — ✅ passes
- `grep` confirms no `<Link ... text=` usages remain (URL `:~:text=` fragments and `<Figure text=...>` are unaffected)

`pnpm run docs:test` passes the homepage assertions; the only errors observed locally were `ERR_CERT_AUTHORITY_INVALID` for external GitHub avatar/logo images, which is an artifact of the sandboxed test environment's TLS proxy and not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155zbrFTNCxLTQkgdnwfi3q

---
_Generated by [Claude Code](https://claude.ai/code/session_0155zbrFTNCxLTQkgdnwfi3q)_