### PR TITLE
fix: update to magic-string@1 (closes #3440)

### DIFF
--- a/packages/vike/package.json
+++ b/packages/vike/package.json
@@ -137,7 +137,7 @@
     "es-module-lexer": "^1.0.0",
     "esbuild": ">=0.19.0",
     "json5": "^2.0.0",
-    "magic-string": "^0.30.17",
+    "magic-string": "^1.0.0",
     "picomatch": "^4.0.5",
     "semver": "^7.8.5",
     "sirv": "^3.0.2",

--- a/packages/vike/src/node/vite/shared/getMagicString.ts
+++ b/packages/vike/src/node/vite/shared/getMagicString.ts
@@ -11,7 +11,10 @@ function getMagicString(code: string, id: string) {
     if (!magicString.hasChanged()) return undefined
     return {
       code: magicString.toString(),
-      map: magicString.generateMap({ hires: true, source: id }),
+      // magic-string@1's SourceMap.sourcesContent is typed as (string | null)[], whereas Rollup's
+      // ExistingRawSourceMap expects string[]. We never pass `includeContent`, so sourcesContent is
+      // always undefined at runtime and this cast is safe.
+      map: magicString.generateMap({ hires: true, source: id }) as any,
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -873,8 +873,8 @@ importers:
         specifier: ^2.0.0
         version: 2.2.3
       magic-string:
-        specifier: ^0.30.17
-        version: 0.30.21
+        specifier: ^1.0.0
+        version: 1.0.0
       picomatch:
         specifier: ^4.0.5
         version: 4.0.5
@@ -6577,6 +6577,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.0.0:
+    resolution: {integrity: sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==}
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
@@ -12995,6 +12998,10 @@ snapshots:
       sourcemap-codec: 1.4.8
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.0.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 


### PR DESCRIPTION
## Summary

Dependabot PR #3440 bumps `magic-string` from `0.30.21` to `1.0.0`, but that bump breaks CI on every job because `packages/vike`'s `tsc` build step fails to compile.

Root cause: in `magic-string@1.0.0`, `SourceMap.sourcesContent` is now typed as `Array<string | null> | undefined`, while Rollup's `ExistingRawSourceMap.sourcesContent` (used in Vite's `TransformResult`) is typed as `string[] | undefined`. Several `transform` plugin hooks in `packages/vike` return the object produced by `getMagicString.ts`'s `getMagicStringResult()`, whose `map` field comes straight from `magicString.generateMap(...)`, so the type mismatch surfaces at every one of those call sites.

- Includes the Dependabot commit bumping `magic-string` to `^1.0.0` (`packages/vike/package.json`, `pnpm-lock.yaml`).
- Adds a type-only fix in `packages/vike/src/node/vite/shared/getMagicString.ts`: cast the generated map to satisfy Rollup's stricter type. This is safe at runtime because `includeContent` is never passed to `generateMap`, so `sourcesContent` is always `undefined`, never containing `null` entries.

Verified locally: `packages/vike` now builds (`tsc`) successfully with `magic-string@1.0.0` installed.

## Test plan

- [x] `pnpm install` picks up `magic-string@1.0.0`
- [x] `cd packages/vike && pnpm run build` (`tsc`) completes with no errors
- [ ] CI green across all jobs (was previously failing on every job due to the `tsc` step)


---
_Generated by [Claude Code](https://claude.ai/code/session_011pmxqpMrcAf7JYigK8La2o)_