### PR TITLE
fix: don't inject line breaks inside inline &lt;script&gt; (closes #3457)

### DIFF
--- a/packages/vike/src/server/runtime/renderPageServer/html/injectAssets/injectHtmlTags.spec.ts
+++ b/packages/vike/src/server/runtime/renderPageServer/html/injectAssets/injectHtmlTags.spec.ts
@@ -21,6 +21,10 @@ const htmlBody3 = `<html>
 
 const tag1 = '<link href="/foo.ttf">'
 const tag2 = '<script src="/foo.js"></script>'
+// https://github.com/vikejs/vike/issues/3457
+const tag3 = `<script type="module">i.contentWindow?.document.write('<h1>Hello</h1>')</script>`
+const tag4 = '<style>a::before { content: "<" }</style>'
+const tag5 = '<meta name="foo" content="a < b">'
 
 describe('injectHtmlTags', () => {
   it('injectAtOpeningTag()', () => {
@@ -78,6 +82,22 @@ describe('injectHtmlTags', () => {
           <script src="/foo.js"></script>
           <link href="/foo.ttf">
           <script src="/foo.js"></script>
+        </body>
+      </html>"
+    `,
+    )
+  })
+
+  // https://github.com/vikejs/vike/issues/3457
+  it("doesn't inject line breaks inside inline <script>/<style> nor inside attributes", () => {
+    expect(injectAtClosingTag('body', htmlBody3, `${tag3}${tag4}${tag5}${tag1}`)).toMatchInlineSnapshot(
+      `
+      "<html>
+        <body>
+          <script type="module">i.contentWindow?.document.write('<h1>Hello</h1>')</script>
+          <style>a::before { content: "<" }</style>
+          <meta name="foo" content="a < b">
+          <link href="/foo.ttf">
         </body>
       </html>"
     `,

--- a/packages/vike/src/server/runtime/renderPageServer/html/injectAssets/injectHtmlTags.ts
+++ b/packages/vike/src/server/runtime/renderPageServer/html/injectAssets/injectHtmlTags.ts
@@ -122,7 +122,9 @@ function injectBreakLines(htmlFragment: string, before: string, after: string) {
   const whitespace = `${paddingParent}${whitespaceExtra}`
   const padding = `\n${whitespace}`
 
-  htmlFragment = htmlFragment.replace(/<[^\/]/g, (match) => `${padding}${match}`)
+  // Match whole tags, and whole raw text elements (their content isn't markup): injecting a line break inside `<script>document.write('<div>')</script>` or inside an attribute value would corrupt it. https://github.com/vikejs/vike/issues/3457
+  const tagRE = /<(script|style|textarea|title)\b[^>]*>[\s\S]*?<\/\1>|<[^\/][^>]*>/gi
+  htmlFragment = htmlFragment.replace(tagRE, (match) => `${padding}${match}`)
   if (isBlankLine) {
     assert(htmlFragment.startsWith(padding), { htmlFragment })
     htmlFragment = whitespaceExtra + htmlFragment.slice(padding.length)


### PR DESCRIPTION
Fixes #3457.

## Problem

`injectBreakLines()` indents the injected tags by inserting a line break before every `<` that isn't followed by `/`:

```js
htmlFragment.replace(/<[^\/]/g, (match) => `${padding}${match}`)
```

That regex has no notion of where markup starts and stops, so it also matches `<` characters that aren't tags — in particular inside inline `<script>` code. A script containing:

```js
i.contentWindow?.document.write('<div>')
```

comes out as:

```js
i.contentWindow?.document.write('
    <div>')
```

A line break inside a JS string literal is a syntax error, so the browser reports `Uncaught SyntaxError: Invalid or unexpected token` and hydration never starts.

This is reachable in dev: a Vite plugin injects such a script via `transformIndexHtml()`, Vike collects it (`getViteDevScript()`), merges the module scripts into a single inline `<script>` (`mergeScriptTags()`), and that fragment is then passed through `injectBreakLines()`. The reporter's workaround — making the closing `</body>` flush-left — only works because it makes `injectBreakLines()` bail out early.

Inline `<style>` (`content: "<"`) and `<` inside attribute values (`<meta content="a < b">`) are corrupted the same way.

## Solution

Match whole tags instead of a bare `<`, plus whole raw text elements whose content isn't markup:

```js
/<(script|style|textarea|title)\b[^>]*>[\s\S]*?<\/\1>|<[^\/][^>]*>/gi
```

The first alternative consumes a raw text element (open tag → content → closing tag) in one go, so `<` inside inline JS/CSS is never visited — like browsers do, the content ends at the first `</tagName>`. The second alternative consumes an entire tag, so `<` and `>` inside attribute values are skipped too. Closing tags still don't match, so they stay on the same line as before, and the replacement itself is unchanged.

Behavior for well-formed fragments is identical — the existing snapshots pass untouched.

## Testing

New test case in `injectHtmlTags.spec.ts`. It fails on `main` with exactly the corruption from the issue:

```diff
- <script type="module">i.contentWindow?.document.write('<h1>Hello</h1>')</script>
+ <script type="module">i.contentWindow?.document.write('
+ <h1>Hello</h1>')</script>
- <style>a::before { content: "<" }</style>
+ <style>a::before { content: "
+ <" }</style>
- <meta name="foo" content="a < b">
+ <meta name="foo" content="a 
+ < b">
```

Full unit suite (`vitest run --project unit`): 206 passed. `tsc --noEmit` and `biome check` are clean.
