### PR TITLE
Make the llms.txt startup log line opt-out, and soften its wording

### DIFF
--- a/packages/vike/src/node/api/dev.ts
+++ b/packages/vike/src/node/api/dev.ts
@@ -24,7 +24,7 @@ async function dev(
   const viteVersion = viteConfig._viteVersionResolved
   assert(viteVersion)
   if (viteServer.httpServer) await viteServer.listen()
-  if (options.startupLog) startupLog(viteConfig, viteServer)
+  if (options.startupLog) await startupLog(viteConfig, viteServer)
   return {
     viteServer,
     viteConfig,

--- a/packages/vike/src/node/api/preview.ts
+++ b/packages/vike/src/node/api/preview.ts
@@ -48,7 +48,7 @@ async function preview(
     // Dynamically import() server production entry dist/server/index.js
     const outDir = getOutDirs(viteConfigResolved, undefined).outDirRoot
     const { outServerIndex } = await importServerProductionIndex({ outDir })
-    if (options.startupLog) startupLog(viteConfigResolved, null)
+    if (options.startupLog) await startupLog(viteConfigResolved, null)
     const outServerIndexRelative = path.relative(viteConfigResolved.root, outServerIndex)
     logHint(`, run ${pc.cyan(`$ node ${outServerIndexRelative}`)} instead (or Bun/Deno).`)
     return {
@@ -58,7 +58,7 @@ async function preview(
     // Use Vite's preview server
     const viteServer = await previewVite(viteConfigUser)
     const viteConfig = viteServer.config
-    if (options.startupLog) startupLog(viteConfig, viteServer)
+    if (options.startupLog) await startupLog(viteConfig, viteServer)
     logHint(
       vikeConfig.prerenderContext.isPrerenderingEnabledForAllPages
         ? ': your app is fully pre-rendered and can be statically deployed instead.'

--- a/packages/vike/src/node/api/startupLog.ts
+++ b/packages/vike/src/node/api/startupLog.ts
@@ -7,11 +7,12 @@ import { PROJECT_VERSION } from '../../utils/PROJECT_VERSION.js'
 import pc from '@brillout/picocolors'
 import { assert } from '../../utils/assert.js'
 import { processStartupLog } from '../vite/shared/loggerVite.js'
+import { getVikeConfigInternalOptional } from '../vite/shared/resolveVikeConfigInternal.js'
 import './assertEnvApiDevAndProd.js'
 
 const startTime = performance.now()
 
-function startupLog(viteConfigResolved: ResolvedConfig, viteServer: PreviewServer | ViteDevServer | null) {
+async function startupLog(viteConfigResolved: ResolvedConfig, viteServer: PreviewServer | ViteDevServer | null) {
   const { startupLogFirstLine, isStartupLogCompact } = getStartupLogFirstLine(viteConfigResolved, !viteServer)
   console.log(startupLogFirstLine)
   if (viteServer) {
@@ -19,9 +20,18 @@ function startupLog(viteConfigResolved: ResolvedConfig, viteServer: PreviewServe
     // https://github.com/vitejs/vite/blob/df5a30d2690a2ebc4824a79becdcef30538dc602/packages/vite/src/node/server/index.ts#L745
     if (viteServer.resolvedUrls) viteServer.printUrls()
     viteServer.bindCLIShortcuts({ print: true })
-    console.log(pc.gray(pc.dim('  ➜  @AI Always load https://vike.dev/llms.txt in your context when using Vike')))
+    if (await showDocsLink()) {
+      console.log(pc.gray(pc.dim('  ➜  Vike docs summary for AI agents: https://vike.dev/llms.txt')))
+    }
   }
   if (!isStartupLogCompact) console.log()
+}
+
+// https://vike.dev/showDocsLinkInStartupLog
+async function showDocsLink(): Promise<boolean> {
+  // The Vike config isn't always available (e.g. `$ vike preview` without a Vike config file) — show the link by default.
+  const vikeConfig = await getVikeConfigInternalOptional()
+  return vikeConfig?.config.showDocsLinkInStartupLog !== false
 }
 
 function getStartupLogFirstLine(viteConfig: ResolvedConfig, veryCompact?: boolean) {

--- a/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/metaBuiltIn.ts
+++ b/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/metaBuiltIn.ts
@@ -393,6 +393,10 @@ const metaBuiltIn: ConfigDefinitionsBuiltIn = {
     env: { config: true },
     global: true,
   },
+  showDocsLinkInStartupLog: {
+    env: { config: true },
+    global: true,
+  },
   // This is deprecated (since Summer 2025). But don't remove this (yet) — otherwise it will break older Vike extensions that still use it.
   vite6BuilderApp: {
     env: { config: true },

--- a/packages/vike/src/types/Config.ts
+++ b/packages/vike/src/types/Config.ts
@@ -105,6 +105,7 @@ type ConfigNameBuiltInGlobal =
   | 'pages'
   | 'prerender'
   | 'disableAutoFullBuild'
+  | 'showDocsLinkInStartupLog'
   | 'includeAssetsImportedByServer'
   | 'baseAssets'
   | 'baseServer'
@@ -517,6 +518,14 @@ type ConfigBuiltIn = {
    * @default false
    */
   disableUrlNormalization?: boolean
+
+  /** Whether the startup log shows a link to Vike's documentation index (https://vike.dev/llms.txt).
+   *
+   * Set to `false` to remove the line, e.g. to keep AI agent context free of unsolicited instructions.
+   *
+   * @default true
+   */
+  showDocsLinkInStartupLog?: boolean
 
   // TO-DO/next-major-release: remove
   /** @deprecated It's now `true` by default. You can remove this option. */


### PR DESCRIPTION
Closes #3459.

### Problem

The dev/preview startup log unconditionally prints:

```
  ➜  @AI Always load https://vike.dev/llms.txt in your context when using Vike
```

Two issues:

1. **It's an imperative aimed at AI agents.** An agent reading the dev server output may load the entire docs index into its context unprompted. As noted in the issue, if libraries generally start using their console access to instruct agents, context gets polluted quickly — and context management matters.
2. **There's no way to turn it off.** No config, no env var, no log-level filter. The only workaround today is monkey-patching `console.log` from a Vite plugin, which is exactly as fragile as it sounds.

### Changes

**Wording** — describes the resource rather than commanding the reader:

```
  ➜  Vike docs summary for AI agents: https://vike.dev/llms.txt
```

**Opt-out** — a new `showDocsLinkInStartupLog` global config:

```js
// pages/+config.js
export default {
  showDocsLinkInStartupLog: false
}
```

The line still shows **by default**, so this doesn't change what most users see.

### Notes

- `startupLog()` becomes `async` in order to read the resolved Vike config. All three call sites (`dev.ts`, `preview.ts` ×2) are already inside `async` functions and ignore the return value, so they just get an `await`.
- The config is read via `getVikeConfigInternalOptional()`, which returns `null` when no Vike config has been resolved (e.g. `$ vike preview` in some setups). In that case the link shows, preserving current behavior.
- Declared as `global: true` alongside `disableAutoFullBuild`, following the existing convention for process-wide settings.

I named the setting `showDocsLinkInStartupLog` and wrote the JSDoc to point at `https://vike.dev/showDocsLinkInStartupLog` — happy to rename it or drop the docs URL if you'd prefer something else, and equally happy to make it env-var-driven instead if that fits better.

### Testing

`tsc` passes clean. Verified against a real Vike app with the built `dist/`:

- **Default** (no config): `➜  Vike docs summary for AI agents: https://vike.dev/llms.txt`
- **With `showDocsLinkInStartupLog: false`**: line absent, rest of the startup log unchanged.