### PR TITLE
fix: don't keep process alive because of logging timers

### DIFF
--- a/packages/vike/src/node/vite/shared/loggerVite.ts
+++ b/packages/vike/src/node/vite/shared/loggerVite.ts
@@ -10,6 +10,7 @@ import { removeEmptyLines } from '../../../utils/removeEmptyLines.js'
 import { trimWithAnsi, trimWithAnsiTrailOnly } from '../../../utils/trimWithAnsi.js'
 import { assert } from '../../../utils/assert.js'
 import { getGlobalObject } from '../../../utils/getGlobalObject.js'
+import { setTimeoutUnref } from '../../../utils/setTimeoutUnref.js'
 import { getRequestId_withAsyncHook } from '../../../server/runtime/asyncHook.js'
 import { logErrorServerDev, logVite } from './loggerDev.js'
 import type { LogType as LoggerType, ResolvedConfig, LogErrorOptions } from 'vite'
@@ -32,7 +33,7 @@ function interceptViteLogs(config: ResolvedConfig) {
 
 function intercept(loggerType: LoggerType, config: ResolvedConfig) {
   let isBeginning = true
-  setTimeout(() => (isBeginning = false), 10 * 1000)
+  setTimeoutUnref(() => (isBeginning = false), 10 * 1000)
 
   config.logger[loggerType] = (msg, options: LogErrorOptions = {}) => {
     assert(!isDebugError())
@@ -139,7 +140,7 @@ function swallowViteLogConnected(): void {
   globalObject.swallowViteLogConnected_originalConsoleLog = console.log
   // The message `[vite] connected.` doesn't go through Vite's logger thus we must monkey patch console.log()
   console.log = swallowViteLogConnected_logPatch
-  setTimeout(swallowViteLogConnected_clean, 3000)
+  setTimeoutUnref(swallowViteLogConnected_clean, 3000)
 }
 // Remove console.log() monkey patch
 function swallowViteLogConnected_clean(): void {

--- a/packages/vike/src/utils/setTimeoutUnref.ts
+++ b/packages/vike/src/utils/setTimeoutUnref.ts
@@ -1,0 +1,13 @@
+export { setTimeoutUnref }
+
+// Same as setTimeout() but the timer never keeps the Node.js process alive (e.g. upon programmatic dev server usage that exits quickly, the process shouldn't linger because of some pending bookkeeping timer).
+//  - https://nodejs.org/api/timers.html#timeoutunref
+//  - Only use it for auxiliary timers (bookkeeping, diagnostics, background work) — never for:
+//    - Timers that resume the main flow (e.g. sleep()): the process could exit before the timer fires.
+//    - Watchdog timers (e.g. hooksTimeout, genPromise() timeout): their purpose is to fire when everything else hangs — being the last thing that keeps the process alive is their job (without them Node.js would silently exit with code 0).
+function setTimeoutUnref(callback: () => void, milliseconds: number): ReturnType<typeof setTimeout> {
+  const timeout = setTimeout(callback, milliseconds)
+  // In the browser (and, e.g., Cloudflare Workers) the timer is a number => there isn't any unref() method (nor any process to keep alive).
+  ;(timeout as unknown as { unref?: () => unknown }).unref?.()
+  return timeout
+}


### PR DESCRIPTION
Follow-up to the `timeout.unref()` discussion in #3465 — a sweep of all `setTimeout()` usage in `packages/vike/src` (there's no `setInterval()`) found two more timers that can needlessly keep the process alive. Both are in `loggerVite.ts`, both dev-only, never cleared, and pure bookkeeping:

- the `isBeginning` flag flip (10 seconds, created three times — once per intercepted log type)
- the `console.log()` monkey-patch removal `swallowViteLogConnected_clean()` (3 seconds)

Programmatic dev server usage that exits quickly (e.g. `createServer()` + immediate `close()`) was kept alive for up to 10 seconds because of them.

## New util `setTimeoutUnref()`

As suggested, the pattern is now a util (`utils/setTimeoutUnref.ts`) instead of inline `.unref()` calls — named `setTimeoutUnref` rather than `setTimeoutSafe` since "Safe" already means "stricter typing" in this codebase (`objectAssignSafe`), whereas `Unref` says exactly what it does.

- Isomorphic: the util is a regular `setTimeout()` in the browser (and e.g. Cloudflare Workers), where the timer is a number — the cast is needed because the package compiles against DOM typings (`types: ["vite/client"]`, no `@types/node` globals).
- Its JSDoc documents when *not* to use it: timers that resume the main flow (`sleep()`), and watchdog timers (`+hooksTimeout` in `execHook.ts`, `genPromise()`'s diagnostic timeout) — for those, being the last thing keeping the process alive is the point: they turn a silent `exit 0` into an actionable error/warning. Those sites are deliberately left untouched.

After this merges, #3465's inline `timeout.unref()` in `pluginDev.ts` can switch to the util.

## Validation

- `pnpm run build` (tsc) passes
- `biome ci` and `lint-assertenv` pass
- unit tests: 206 passed (38 files)
- runtime smoke test: a Node.js script whose only pending handle is a `setTimeoutUnref()` timer (5s) exits in 36ms without firing the callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H518vy57dvhY4WBgaXENip

---
_Generated by [Claude Code](https://claude.ai/code/session_01H518vy57dvhY4WBgaXENip)_