### PR TITLE
fix: don't pull the Client Routing runtime into Server Routing apps upon importing vike/getPageContext

### DIFF
--- a/packages/vike/src/client/runtime-client-routing/getPageContext.ts
+++ b/packages/vike/src/client/runtime-client-routing/getPageContext.ts
@@ -4,7 +4,7 @@ export { providePageContext }
 // TO-DO/eventually: create new setting `+asyncHook: true` that sets the default value of the `asyncHook` parameter below to `true`
 
 import { getPageContext_sync, providePageContext } from '../../shared-server-client/hooks/execHook.js'
-import { getPageContextClient } from './renderPageClient.js'
+import { getPageContextClient } from './getPageContextClient.js'
 import type { GetPageContextParams } from '../../server/runtime/getPageContext.js'
 import '../assertEnvClient.js'
 

--- a/packages/vike/src/client/runtime-client-routing/getPageContextClient.ts
+++ b/packages/vike/src/client/runtime-client-routing/getPageContextClient.ts
@@ -1,0 +1,33 @@
+export { getPageContextClient }
+export { setPageContextClient }
+
+// This module deliberately lives outside renderPageClient.ts: the browser entry of vike/getPageContext
+// imports getPageContextClient(), and importing it from renderPageClient.ts would pull the whole Client
+// Routing runtime (including shared-server-client/route/index.js and its module-level assertClientRouting())
+// into every browser bundle that imports vike/getPageContext — including Server Routing apps, e.g. upon
+// vike-react's onRenderClient() importing vike/getPageContext.
+// https://github.com/vikejs/vike/issues/3471
+
+import { getGlobalObject } from '../../utils/getGlobalObject.js'
+import { getPageContextPublicClient } from './getPageContextPublicClient.js'
+import type { PageContextClient } from '../../types/PageContext.js'
+import '../assertEnvClient.js'
+
+const globalObject = getGlobalObject('getPageContextClient.ts', {
+  currentPageContext: null as null | Record<string, unknown>,
+})
+
+/**
+ * Get the `pageContext` object on the client-side.
+ *
+ * https://vike.dev/getPageContextClient
+ */
+function getPageContextClient(): PageContextClient | null {
+  const pageContext = globalObject.currentPageContext
+  if (!pageContext) return null
+  return getPageContextPublicClient(pageContext as any) as any
+}
+
+function setPageContextClient(pageContext: Record<string, unknown>): void {
+  globalObject.currentPageContext = pageContext
+}

--- a/packages/vike/src/client/runtime-client-routing/index.ts
+++ b/packages/vike/src/client/runtime-client-routing/index.ts
@@ -6,7 +6,7 @@
 
 export { navigate, reload } from './navigate.js'
 export { prefetch } from './prefetch.js'
-export { getPageContextClient } from './renderPageClient.js'
+export { getPageContextClient } from './getPageContextClient.js'
 export { PROJECT_VERSION as version } from '../../utils/PROJECT_VERSION.js'
 
 // TO-DO/next-major-release: remove this

--- a/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
+++ b/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
@@ -1,7 +1,6 @@
 export { renderPageClient }
 export { getRenderCount }
 export { disableClientRouting }
-export { getPageContextClient }
 export type { PageContextBegin }
 export type { PageContextInternalClientAfterRender }
 
@@ -54,9 +53,10 @@ import { scrollRestoration_initialRenderIsDone } from './scrollRestoration.js'
 import { getErrorPageId, isErrorPage } from '../../shared-server-client/error-page.js'
 import type { PageContextConfig } from '../../shared-server-client/getPageFiles.js'
 import { setPageContextCurrent } from './getPageContextCurrent.js'
+import { setPageContextClient } from './getPageContextClient.js'
 import { getRouteStringParameterList } from '../../shared-server-client/route/resolveRouteString.js'
 import { getCurrentUrl } from '../shared/getCurrentUrl.js'
-import type { PageContextClient, PageContextInternalClient } from '../../types/PageContext.js'
+import type { PageContextInternalClient } from '../../types/PageContext.js'
 import { execHookList, execHook } from '../../shared-server-client/hooks/execHook.js'
 import { type PageContextPublicClient, getPageContextPublicClient } from './getPageContextPublicClient.js'
 import { getHooksFromPageContextNew } from '../../shared-server-client/hooks/getHook.js'
@@ -76,7 +76,6 @@ const globalObject = getGlobalObject<{
   //https://vike.dev/pageContext#previousPageContext
   previousPageContext?: PreviousPageContext
   renderedPageContext?: PageContextInternalClient & PageContext_loadPageConfigsLazyClientSide
-  currentPageContext?: Record<string, unknown>
   hydrationAwaitPromise: Promise<void>
   hydrationAwaitPromiseResolve: () => void
 }>(
@@ -631,7 +630,7 @@ async function getPageContextBegin(
     ...pageContextInitClient,
   })
 
-  globalObject.currentPageContext = pageContext
+  setPageContextClient(pageContext)
 
   // TO-DO/next-major-release: remove
   Object.defineProperty(pageContext, '_previousPageContext', {
@@ -759,17 +758,6 @@ function areKeysEqual(key1: string | string[], key2: string | string[]): boolean
   if (key1 === key2) return true
   if (!Array.isArray(key1) || !Array.isArray(key2)) return false
   return key1.length === key2.length && key1.every((_, i) => key1[i] === key2[i])
-}
-
-/**
- * Get the `pageContext` object on the client-side.
- *
- * https://vike.dev/getPageContextClient
- */
-function getPageContextClient(): PageContextClient | null {
-  const pageContext = globalObject.currentPageContext
-  if (!pageContext) return null
-  return getPageContextPublicClient(pageContext as any) as any
 }
 
 type PageContextExecuteHook = Omit<


### PR DESCRIPTION
Fixes #3471.

## Problem

The `browser` condition of `exports["./getPageContext"]` resolves to `client/runtime-client-routing/getPageContext.js`, which imported `getPageContextClient()` from `renderPageClient.ts` — dragging the **entire Client Routing runtime** into the bundle, including `shared-server-client/route/index.js` whose module-level `if (isBrowser()) assertClientRouting()` contradicts the Server Routing entry's `assertServerRouting()`.

Consequence for every Server Routing app whose browser bundle imports `vike/getPageContext` — which is **every Server Routing + vike-react app**, since vike-react's `onRenderClient` → `callCumulativeHooks` → `import { providePageContext } from 'vike/getPageContext'`:

1. This warning on every page load, with no way to act on it from application code (the app imports nothing from `vike/client/router`):
   ```
   [vike][Warning] You shouldn't `import { something } from 'vike/client/router'` when using Server Routing.
   ```
2. ~28 kB (uncompressed) of unused Client Routing runtime shipped to the browser — the very bloat the warning text warns about.

This is the same class of problem the #1423 fix addressed for `exports["./routing"]` (whose conditions now all resolve to a standalone module that never imports `route/index.js`) — it just was never applied to `getPageContext`.

## Fix

Pure code motion, no behavior change: move `getPageContextClient()` and its `currentPageContext` slot out of `renderPageClient.ts` into a new dependency-light module `getPageContextClient.ts` — the same pattern as the existing `getPageContextCurrent.ts` (which stays separate: its slot is set at a different lifecycle point, lines 264/424 vs. `getPageContextBegin`).

- `getPageContextClient.ts` (new): owns the slot + getter + setter. Full transitive closure: `getGlobalObject`, `getPageContextPublicClient` (23 modules), `assertEnvClient` — never reaches `route/index.js`, `renderPageClient.js`, nor even `assertRoutingType.js`.
- `renderPageClient.ts`: calls `setPageContextClient(pageContext)` at the exact same point where it previously assigned `globalObject.currentPageContext`.
- `getPageContext.ts` and `runtime-client-routing/index.ts`: import/re-export `getPageContextClient` from the new module — `vike/client/router`'s public surface is unchanged.

## Verification

**Server Routing repro** (`vike@0.4.260` + `vike-react@0.6.26`, `clientRouting: false`, one page):
- Before: warning fires on page load; client bundle contains the CR route runtime; 265,453 B total client JS.
- After: **zero console output**; CR route runtime absent; **236,589 B** (−28,864 B, −10.9%); page renders and hydrates.
- Also confirmed on a real production app (Server Routing + vike-react, ~3.3 MB client JS): warning gone, −27,994 B.

**Client Routing regression checks** (all against the patched build):
- `pnpm exec vitest run --project unit` — 38 files, 206/206 pass
- `test/vike-react` e2e (dev + preview) — **pass** (exercises the exact moved path: vike-react `useConfig` → `getPageContext({ asyncHook: true })` → `getPageContextClient()`)
- `examples/react-full` e2e (dev + preview) — pass (classic Client Routing)
- `examples/react-minimal` e2e (dev + preview) — pass (Server Routing control)
- `biome check` on changed files — clean; `pnpm run lint` (assertEnv discipline) — clean

**Structural check** on the built `dist/`: the browser `getPageContext.js` import closure went from 170 modules (including the whole CR runtime) to 37, none of which touch `assertRoutingType.js`; the `vike/client/router` entry's closure is unchanged.
