### PR TITLE
fix: correct setting name in VIKE_CRAWL error message

### DIFF
--- a/packages/vike/src/utils/crawlFiles.ts
+++ b/packages/vike/src/utils/crawlFiles.ts
@@ -221,7 +221,7 @@ function getUserSettings() {
     hasProp(userSettings, 'ignore', 'string[]') ||
       hasProp(userSettings, 'ignore', 'string') ||
       hasProp(userSettings, 'ignore', 'undefined'),
-    wrongUsage('git', 'string or an array of strings'),
+    wrongUsage('ignore', 'string or an array of strings'),
   )
   assertUsage(
     hasProp(userSettings, 'ignoreBuiltIn', 'boolean') || hasProp(userSettings, 'ignoreBuiltIn', 'undefined'),


### PR DESCRIPTION
The `VIKE_CRAWL` validation for the `ignore` setting reports the wrong setting name: it says `git` instead of `ignore`.

For example, `VIKE_CRAWL="{ignore:123}"` currently fails with:

> Setting git in VIKE_CRAWL should be a string or an array of strings

This fixes `getUserSettings()` in `packages/vike/src/utils/crawlFiles.ts` (the code's location since #3474) to report `ignore`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRfXYAX675K9S9xQUoAmyr)_