### PR TITLE
refactor: move ignorePatternsBuiltIn to a standalone file

### DIFF
--- a/docs/pages/filesystem-routing/+Page.mdx
+++ b/docs/pages/filesystem-routing/+Page.mdx
@@ -95,7 +95,7 @@ Vike crawls:
 - Files inside [Vite's `root` directory](https://vitejs.dev/config/shared-options.html#root).
   > Consequently, all your <Link href="/config#files">`+` files</Link> must live inside `root`.
   > To make a directory or file outside of `root` crawlable, use a symlink (e.g. `$ ln -s`) and set `VIKE_CRAWL="{git:false}"`.
-- Skips [built-in ignore patterns](https://github.com/vikejs/vike/blob/main/packages/vike/src/utils/crawlFiles.ts) such as `**/node_modules/**`.
+- Skips [built-in ignore patterns](https://github.com/vikejs/vike/blob/main/packages/vike/src/utils/crawlFiles/ignorePatternsBuiltIn.ts) such as `**/node_modules/**`.
   > To add custom ignore patterns, see [#2228](https://github.com/vikejs/vike/issues/2228).
 - Skips `.gitignore` files (if you use Git).
   > If you want to also crawl these then set `VIKE_CRAWL="{git:false}"`.

--- a/packages/vike/src/utils/crawlFiles.ts
+++ b/packages/vike/src/utils/crawlFiles.ts
@@ -16,31 +16,13 @@ import { promisify } from 'node:util'
 import { getEnvVarObject } from './getEnvVarObject.js'
 import pc from '@brillout/picocolors'
 import picomatch, { type Matcher } from 'picomatch'
+import { ignorePatternsBuiltIn } from './crawlFiles/ignorePatternsBuiltIn.js'
 assertIsNotProductionRuntime()
 const execA = promisify(exec)
 const debug = createDebug('vike:crawl')
 const globalObject = getGlobalObject('crawlFiles.ts', {
   gitIsNotUsable: false,
 })
-
-const ignorePatternsBuiltIn = [
-  '**/node_modules/**',
-  // Ejected Vike extensions, see https://github.com/snake-py/eject
-  '**/ejected/**',
-  // Allow:
-  // ```bash
-  // +Page.js
-  // +Page.telefunc.js
-  // ```
-  '**/*.telefunc.*',
-  // https://github.com/vikejs/vike/issues/1589#issuecomment-2031925598
-  '**/.history/**',
-  // https://github.com/vikejs/vike/discussions/2222
-  '**/*.generated.*',
-  // https://github.com/vikejs/vike/issues/2347
-  '**/*.spec.*',
-  '**/*.test.*',
-] as const
 
 async function crawlFiles(userRootDir: string) {
   const userSettings = getUserSettings()

--- a/packages/vike/src/utils/crawlFiles/ignorePatternsBuiltIn.ts
+++ b/packages/vike/src/utils/crawlFiles/ignorePatternsBuiltIn.ts
@@ -1,0 +1,18 @@
+export const ignorePatternsBuiltIn = [
+  '**/node_modules/**',
+  // Ejected Vike extensions, see https://github.com/snake-py/eject
+  '**/ejected/**',
+  // Allow:
+  // ```bash
+  // +Page.js
+  // +Page.telefunc.js
+  // ```
+  '**/*.telefunc.*',
+  // https://github.com/vikejs/vike/issues/1589#issuecomment-2031925598
+  '**/.history/**',
+  // https://github.com/vikejs/vike/discussions/2222
+  '**/*.generated.*',
+  // https://github.com/vikejs/vike/issues/2347
+  '**/*.spec.*',
+  '**/*.test.*',
+] as const


### PR DESCRIPTION
`ignorePatternsBuiltIn` had its own file until #3474 inlined it into `utils/crawlFiles.ts`. This restores it as a standalone file.

## Changes

- Extract the `ignorePatternsBuiltIn` const out of `utils/crawlFiles.ts` into `utils/crawlFiles/ignorePatternsBuiltIn.ts`, and import it back.
- Point the docs link back at that file: `docs/pages/filesystem-routing/+Page.mdx` links "built-in ignore patterns" at the source, and #3474 had redirected it to `crawlFiles.ts` when the patterns were inlined.

Placed in `utils/crawlFiles/` — the directory next to `crawlFiles.ts` that already holds the spec and its test fixtures — mirroring the previous `crawlPlusFilePaths.ts` + `crawlPlusFilePaths/` layout. The old file carried an `import '../../../assertEnvVite.js'`; that's dropped here since `src/utils/**` is whitelisted by the assertEnv linter and `crawlFiles.ts` itself relies on `assertIsNotProductionRuntime()` instead.

No behavior change — the patterns and their comments are byte-for-byte identical.

## Testing

- `tsc --noEmit` clean, and a full `tsc` build emits `dist/utils/crawlFiles/ignorePatternsBuiltIn.js` as expected.
- `node scripts/lint-assertenv.mjs` — 411 files checked, all pass.
- `pnpm exec vitest run --project unit` — 38 files, 206 tests passing.
- `biome check` clean on the touched `.ts` files (biome doesn't process `.mdx`).
- Searched the repo for references to `crawlFiles` / `ignorePatternsBuiltIn`; the filesystem-routing page was the only doc linking to the source.