### PR TITLE
Bump typescript to ^7.0.2

### DIFF
--- a/.github/workflows/ci/package.json
+++ b/.github/workflows/ci/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "@types/node": "^24.10.2",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/.github/workflows/sync-github-releases/package.json
+++ b/.github/workflows/sync-github-releases/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@types/node": "^24.10.2",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/docs/global.d.ts
+++ b/docs/global.d.ts
@@ -1,0 +1,2 @@
+declare module '@brillout/docpress/style'
+declare module '@docsearch/css'

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^19.2.6",
     "react-tabs": "^6.1.0",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^7.3.1",
     "vite-plugin-svgr": "^4.3.0"

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2022",
     "moduleResolution": "Bundler",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["@brillout/docpress/types"],
+    "types": ["@brillout/docpress/types", "vite/client"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -16,7 +16,7 @@
     "express": "5.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vike-react": "^0.6.26",
     "vite": "^6.3.2"

--- a/examples/auth/tsconfig.json
+++ b/examples/auth/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "jsx": "preserve",
     "esModuleInterop": true,
-    "lib": ["DOM"]
+    "lib": ["DOM"],
+    "types": ["vite/client"]
   }
 }

--- a/examples/cloudflare-workers-react/package.json
+++ b/examples/cloudflare-workers-react/package.json
@@ -10,7 +10,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^7.0.6",
     "wrangler": "^4.56.0"

--- a/examples/html-fragments/package.json
+++ b/examples/html-fragments/package.json
@@ -4,7 +4,7 @@
     "preview": "vike build && vike preview"
   },
   "dependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/examples/path-aliases/package.json
+++ b/examples/path-aliases/package.json
@@ -23,7 +23,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "serve": "^14.2.5",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/examples/react-full/package.json
+++ b/examples/react-full/package.json
@@ -18,7 +18,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-streaming": "^0.4.20",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^7.2.6"
   },

--- a/examples/telefunc/package.json
+++ b/examples/telefunc/package.json
@@ -15,7 +15,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "telefunc": "^0.2.23",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^7.1.5"
   },

--- a/examples/vue-full/package.json
+++ b/examples/vue-full/package.json
@@ -12,7 +12,7 @@
     "@vue/server-renderer": "^3.4.27",
     "cross-fetch": "^4.0.0",
     "node-fetch": "^3.3.2",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "unplugin-vue-markdown": "^0.26.2",
     "vike": "0.4.260",
     "vite": "^6.3.2",

--- a/examples/vue-full/package.json
+++ b/examples/vue-full/package.json
@@ -12,12 +12,12 @@
     "@vue/server-renderer": "^3.4.27",
     "cross-fetch": "^4.0.0",
     "node-fetch": "^3.3.2",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.2",
     "unplugin-vue-markdown": "^0.26.2",
     "vike": "0.4.260",
     "vite": "^6.3.2",
     "vue": "^3.4.27",
-    "vue-tsc": "^2.0.19"
+    "vue-tsc": "^3.3.11"
   },
   "type": "module"
 }

--- a/packages/create-vike-core/boilerplate-react-ts/package.json
+++ b/packages/create-vike-core/boilerplate-react-ts/package.json
@@ -15,7 +15,7 @@
     "node-fetch": "^3.3.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "^0.4.260",
     "vite": "^6.3.2"
   },

--- a/packages/create-vike-core/boilerplate-vue-ts/package.json
+++ b/packages/create-vike-core/boilerplate-vue-ts/package.json
@@ -13,11 +13,11 @@
     "cross-env": "^7.0.3",
     "hono": "^4.8.4",
     "node-fetch": "^3.3.2",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.2",
     "vike": "^0.4.260",
     "vite": "^6.3.2",
     "vue": "^3.5.13",
-    "vue-tsc": "^2.1.10"
+    "vue-tsc": "^3.3.11"
   },
   "type": "module"
 }

--- a/packages/create-vike-core/boilerplate-vue-ts/package.json
+++ b/packages/create-vike-core/boilerplate-vue-ts/package.json
@@ -13,7 +13,7 @@
     "cross-env": "^7.0.3",
     "hono": "^4.8.4",
     "node-fetch": "^3.3.2",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "^0.4.260",
     "vite": "^6.3.2",
     "vue": "^3.5.13",

--- a/packages/vike/package.json
+++ b/packages/vike/package.json
@@ -269,7 +269,7 @@
     "react-streaming": "^0.4.20",
     "rimraf": "^6.1.3",
     "rolldown": "1.0.0-rc.17",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vite": "^7.2.6"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 0.6.23
       '@brillout/test-types':
         specifier: ^0.1.13
-        version: 0.1.15(typescript@6.0.2)
+        version: 0.1.15(typescript@7.0.2)
       playwright-chromium:
         specifier: 1.57.0
         version: 1.57.0
@@ -36,8 +36,8 @@ importers:
         specifier: ^24.10.2
         version: 24.10.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
   .github/workflows/sync-github-releases:
     devDependencies:
@@ -45,8 +45,8 @@ importers:
         specifier: ^24.10.2
         version: 24.10.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
   docs:
     dependencies:
@@ -55,7 +55,7 @@ importers:
         version: 0.0.94
       '@brillout/docpress':
         specifier: ^0.17.4
-        version: 0.17.4(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        version: 0.17.4(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@7.0.2)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       '@classmatejs/react':
         specifier: ^0.2.1
         version: 0.2.1(react@19.2.6)
@@ -99,8 +99,8 @@ importers:
         specifier: ^4.1.18
         version: 4.2.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../packages/vike
@@ -109,7 +109,7 @@ importers:
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.43.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        version: 4.3.0(rollup@4.43.0)(typescript@7.0.2)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
 
   examples/auth:
     dependencies:
@@ -141,8 +141,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -246,8 +246,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -301,13 +301,13 @@ importers:
         version: 0.4.2
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))
+        version: 6.0.1(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.5.18
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.5.18
-        version: 3.5.18(vue@3.5.18(typescript@6.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -316,7 +316,7 @@ importers:
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.5.18
-        version: 3.5.18(typescript@6.0.2)
+        version: 3.5.18(typescript@7.0.2)
       wrangler:
         specifier: ^4.56.0
         version: 4.81.0
@@ -360,8 +360,8 @@ importers:
   examples/html-fragments:
     dependencies:
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -423,8 +423,8 @@ importers:
         specifier: ^14.2.5
         version: 14.2.5
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -474,8 +474,8 @@ importers:
         specifier: ^0.4.20
         version: 0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -591,8 +591,8 @@ importers:
         specifier: ^0.2.23
         version: 0.2.23(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.8)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.12.5)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -610,13 +610,13 @@ importers:
         version: 2.6.12
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@5.9.3))
+        version: 6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.4.27
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.4.27
-        version: 3.5.18(vue@3.5.18(typescript@5.9.3))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       cross-fetch:
         specifier: ^4.0.0
         version: 4.1.0
@@ -624,8 +624,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       unplugin-vue-markdown:
         specifier: ^0.26.2
         version: 0.26.3(rollup@4.43.0)(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -637,22 +637,22 @@ importers:
         version: 6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.4.27
-        version: 3.5.18(typescript@5.9.3)
+        version: 3.5.18(typescript@7.0.2)
       vue-tsc:
         specifier: ^2.0.19
-        version: 2.2.10(typescript@5.9.3)
+        version: 2.2.10(typescript@7.0.2)
 
   examples/vue-minimal:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.2.47
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.2.47
-        version: 3.5.18(vue@3.5.18(typescript@6.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -661,7 +661,7 @@ importers:
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.2.47
-        version: 3.5.18(typescript@6.0.2)
+        version: 3.5.18(typescript@7.0.2)
 
   packages/create-vike-core:
     dependencies:
@@ -741,8 +741,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: ^0.4.260
         version: link:../../vike
@@ -757,13 +757,13 @@ importers:
         version: 0.2.1(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.12.5)(vike@packages+vike)
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.5.13
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.5.13
-        version: 3.5.18(vue@3.5.18(typescript@6.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -781,7 +781,7 @@ importers:
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.5.13
-        version: 3.5.18(typescript@6.0.2)
+        version: 3.5.18(typescript@7.0.2)
 
   packages/create-vike-core/boilerplate-vue-ts:
     dependencies:
@@ -793,13 +793,13 @@ importers:
         version: 0.2.1(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.12.5)(vike@packages+vike)
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@5.9.3))
+        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.5.13
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.5.13
-        version: 3.5.18(vue@3.5.18(typescript@5.9.3))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -810,8 +810,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: ^0.4.260
         version: link:../../vike
@@ -820,10 +820,10 @@ importers:
         version: 6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.5.13
-        version: 3.5.18(typescript@5.9.3)
+        version: 3.5.18(typescript@7.0.2)
       vue-tsc:
         specifier: ^2.1.10
-        version: 2.2.10(typescript@5.9.3)
+        version: 2.2.10(typescript@7.0.2)
 
   packages/vike:
     dependencies:
@@ -928,8 +928,8 @@ importers:
         specifier: 1.0.0-rc.17
         version: 1.0.0-rc.17
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
   test:
     dependencies:
@@ -937,8 +937,8 @@ importers:
         specifier: ^24.3.0
         version: 24.10.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
   test-deprecated-design/base-url:
     dependencies:
@@ -1085,13 +1085,13 @@ importers:
         version: 0.2.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.2.47
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.2.47
-        version: 3.5.18(vue@3.5.18(typescript@6.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1100,7 +1100,7 @@ importers:
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.2.47
-        version: 3.5.18(typescript@6.0.2)
+        version: 3.5.18(typescript@7.0.2)
       wrangler:
         specifier: ^4.56.0
         version: 4.81.0
@@ -1126,8 +1126,8 @@ importers:
   test-deprecated-design/html-fragments:
     dependencies:
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1190,10 +1190,10 @@ importers:
         version: 14.2.5
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@7.0.2)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1297,8 +1297,8 @@ importers:
         specifier: ^0.2.23
         version: 0.2.23(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.8)(react-streaming@0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(srvx@0.12.5)(vite@6.3.0(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1310,13 +1310,13 @@ importers:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.2.47
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.2.47
-        version: 3.5.18(vue@3.5.18(typescript@6.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1325,7 +1325,7 @@ importers:
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.2.47
-        version: 3.5.18(typescript@6.0.2)
+        version: 3.5.18(typescript@7.0.2)
 
   test-deprecated-design/vue-full:
     dependencies:
@@ -1351,8 +1351,8 @@ importers:
         specifier: ^2.6.1
         version: 2.7.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       unplugin-vue-markdown:
         specifier: ^0.24.3
         version: 0.24.3(rollup@4.43.0)(vite@6.3.0(@types/node@17.0.45)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -1367,7 +1367,7 @@ importers:
         version: 3.2.33
       vue-tsc:
         specifier: 2.0.11
-        version: 2.0.11(typescript@5.9.3)
+        version: 2.0.11(typescript@7.0.2)
 
   test/@cloudflare_vite-plugin:
     dependencies:
@@ -1403,8 +1403,8 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.2.7
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1446,8 +1446,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6))
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.7
         version: 8.0.7(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.38.1)(tsx@4.20.6)
@@ -1482,8 +1482,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1623,8 +1623,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1675,8 +1675,8 @@ importers:
         specifier: ^5.1.3
         version: 5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1718,8 +1718,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.2.7
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1760,8 +1760,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1797,8 +1797,8 @@ importers:
         specifier: ^5.1.3
         version: 5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -1815,8 +1815,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1828,16 +1828,16 @@ importers:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.2.31
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.2.37
-        version: 3.5.18(vue@3.5.18(typescript@6.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
       pinia:
         specifier: ^2.0.14
-        version: 2.3.1(typescript@6.0.2)(vue@3.5.18(typescript@6.0.2))
+        version: 2.3.1(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1846,7 +1846,7 @@ importers:
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.2.37
-        version: 3.5.18(typescript@6.0.2)
+        version: 3.5.18(typescript@7.0.2)
 
   test/universal-deploy:
     dependencies:
@@ -1885,8 +1885,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.15)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1928,8 +1928,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vavite:
         specifier: ^5.1.0
         version: 5.1.0(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -1961,8 +1961,8 @@ importers:
         specifier: ^0.4.20
         version: 0.4.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -1997,8 +1997,8 @@ importers:
         specifier: ^9.2.0
         version: 9.2.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -2033,8 +2033,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -2097,8 +2097,8 @@ importers:
         version: 0.8.4(solid-js@1.9.10)(vike@packages+vike)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))
     devDependencies:
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.0.6
         version: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -2116,13 +2116,13 @@ importers:
         version: 2.6.12
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@5.9.3))
+        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       unplugin-vue-markdown:
         specifier: ^28.3.1
         version: 28.3.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -2131,7 +2131,7 @@ importers:
         version: link:../../packages/vike
       vike-vue:
         specifier: ^0.9.13
-        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@5.9.3))
+        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -2140,44 +2140,44 @@ importers:
         version: 2.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       vue:
         specifier: ^3.5.13
-        version: 3.5.18(typescript@5.9.3)
+        version: 3.5.18(typescript@7.0.2)
       vue-toast-notification:
         specifier: ^3.1.3
-        version: 3.1.3(vue@3.5.18(typescript@5.9.3))
+        version: 3.1.3(vue@3.5.18(typescript@7.0.2))
       vue-tsc:
         specifier: ^2.2.10
-        version: 2.2.10(typescript@5.9.3)
+        version: 2.2.10(typescript@7.0.2)
 
   test/vike-vue-pinia:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@5.9.3))
+        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
       pinia:
         specifier: ^3.0.1
-        version: 3.0.3(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3))
+        version: 3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
       vike-vue:
         specifier: ^0.9.13
-        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@5.9.3))
+        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
       vike-vue-pinia:
         specifier: ^0.2.6
-        version: 0.2.6(pinia@3.0.3(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@5.9.3)))(vike@packages+vike)(vue@3.5.18(typescript@5.9.3))
+        version: 0.2.6(pinia@3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)))(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
       vite:
         specifier: ^6.1.0
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.5.13
-        version: 3.5.18(typescript@5.9.3)
+        version: 3.5.18(typescript@7.0.2)
     devDependencies:
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vue-tsc:
         specifier: ^2.0.13
-        version: 2.2.10(typescript@5.9.3)
+        version: 2.2.10(typescript@7.0.2)
 
   test/vite-plugin-vercel:
     dependencies:
@@ -2207,8 +2207,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -2231,8 +2231,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -4808,6 +4808,126 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -7876,14 +7996,9 @@ packages:
   type-level-regexp@0.1.17:
     resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uc.micro@1.0.6:
@@ -8909,7 +9024,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@brillout/docpress@0.17.4(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@5.9.3)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))':
+  '@brillout/docpress@0.17.4(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@7.0.2)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))':
     dependencies:
       '@brillout/picocolors': 1.0.31
       '@brillout/shiki-transformers': 4.0.2
@@ -8929,7 +9044,7 @@ snapshots:
       remark-directive: 4.0.0
       remark-gfm: 4.0.0
       shiki: 1.2.0
-      typescript: 5.9.3
+      typescript: 7.0.2
       unist-util-visit: 5.1.0
       vike: link:packages/vike
       vite: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -8993,12 +9108,12 @@ snapshots:
       source-map-support: 0.5.21
       strip-ansi: 6.0.1
 
-  '@brillout/test-types@0.1.15(typescript@6.0.2)':
+  '@brillout/test-types@0.1.15(typescript@7.0.2)':
     dependencies:
       '@brillout/picocolors': 1.0.31
       fast-glob: 3.3.3
       source-map-support: 0.5.21
-      typescript: 6.0.2
+      typescript: 7.0.2
 
   '@brillout/vite-plugin-server-entry@0.7.18':
     dependencies:
@@ -10439,12 +10554,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.7
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@7.0.2)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -10455,11 +10570,11 @@ snapshots:
       '@babel/types': 7.29.8
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@7.0.2))':
     dependencies:
       '@babel/core': 7.29.7
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@7.0.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -10780,6 +10895,66 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -11396,35 +11571,29 @@ snapshots:
       vite: 6.3.0(@types/node@17.0.45)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue: 3.2.33
 
-  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
-      vue: 3.5.18(typescript@5.9.3)
+      vue: 3.5.18(typescript@7.0.2)
 
-  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
-      vue: 3.5.18(typescript@5.9.3)
+      vue: 3.5.18(typescript@7.0.2)
 
-  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
-      vue: 3.5.18(typescript@5.9.3)
+      vue: 3.5.18(typescript@7.0.2)
 
-  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
-      vue: 3.5.18(typescript@6.0.2)
-
-  '@vitejs/plugin-vue@6.0.1(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
-      vue: 3.5.18(typescript@6.0.2)
+      vue: 3.5.18(typescript@7.0.2)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -11637,7 +11806,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@2.0.11(typescript@5.9.3)':
+  '@vue/language-core@2.0.11(typescript@7.0.2)':
     dependencies:
       '@volar/language-core': 2.2.5
       '@vue/compiler-dom': 3.5.34
@@ -11647,9 +11816,9 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
-  '@vue/language-core@2.2.10(typescript@5.9.3)':
+  '@vue/language-core@2.2.10(typescript@7.0.2)':
     dependencies:
       '@volar/language-core': 2.4.11
       '@vue/compiler-dom': 3.5.34
@@ -11660,7 +11829,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   '@vue/reactivity-transform@3.2.33':
     dependencies:
@@ -11707,17 +11876,11 @@ snapshots:
       '@vue/shared': 3.2.33
       vue: 3.2.33
 
-  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@7.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.18
       '@vue/shared': 3.5.18
-      vue: 3.5.18(typescript@5.9.3)
-
-  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@6.0.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.18
-      '@vue/shared': 3.5.18
-      vue: 3.5.18(typescript@6.0.2)
+      vue: 3.5.18(typescript@7.0.2)
 
   '@vue/shared@3.2.33': {}
 
@@ -12240,14 +12403,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@8.3.6(typescript@5.9.3):
+  cosmiconfig@8.3.6(typescript@7.0.2):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   create-require@1.1.1: {}
 
@@ -14010,22 +14173,22 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  pinia@2.3.1(typescript@6.0.2)(vue@3.5.18(typescript@6.0.2)):
+  pinia@2.3.1(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@6.0.2)
-      vue-demi: 0.14.10(vue@3.5.18(typescript@6.0.2))
+      vue: 3.5.18(typescript@7.0.2)
+      vue-demi: 0.14.10(vue@3.5.18(typescript@7.0.2))
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  pinia@3.0.3(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3)):
+  pinia@3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2)):
     dependencies:
       '@vue/devtools-api': 7.7.7
-      vue: 3.5.18(typescript@5.9.3)
+      vue: 3.5.18(typescript@7.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
 
   pixelmatch@5.3.0:
     dependencies:
@@ -14920,7 +15083,7 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@7.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -14934,7 +15097,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 7.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -14962,9 +15125,28 @@ snapshots:
 
   type-level-regexp@0.1.17: {}
 
-  typescript@5.9.3: {}
-
-  typescript@6.0.2: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@1.0.6: {}
 
@@ -15235,20 +15417,20 @@ snapshots:
       vike: link:packages/vike
       vite-plugin-solid: 2.11.10(solid-js@1.9.10)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
 
-  vike-vue-pinia@0.2.6(pinia@3.0.3(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@5.9.3)))(vike@packages+vike)(vue@3.5.18(typescript@5.9.3)):
+  vike-vue-pinia@0.2.6(pinia@3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)))(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)):
     dependencies:
-      pinia: 3.0.3(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3))
+      pinia: 3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2))
       vike: link:packages/vike
-      vike-vue: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@5.9.3))
-      vue: 3.5.18(typescript@5.9.3)
+      vike-vue: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
+      vue: 3.5.18(typescript@7.0.2)
 
-  vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@5.9.3)):
+  vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)):
     dependencies:
       magic-string: 0.30.21
       oxc-parser: 0.104.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       oxc-walker: 0.6.0(oxc-parser@0.104.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
       vike: link:packages/vike
-      vue: 3.5.18(typescript@5.9.3)
+      vue: 3.5.18(typescript@7.0.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -15277,11 +15459,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-svgr@4.3.0(rollup@4.43.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
+  vite-plugin-svgr@4.3.0(rollup@4.43.0)(typescript@7.0.2)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.43.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@svgr/core': 8.1.0(typescript@7.0.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))
       vite: 7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
     transitivePeerDependencies:
       - rollup
@@ -15504,31 +15686,31 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-demi@0.14.10(vue@3.5.18(typescript@6.0.2)):
+  vue-demi@0.14.10(vue@3.5.18(typescript@7.0.2)):
     dependencies:
-      vue: 3.5.18(typescript@6.0.2)
+      vue: 3.5.18(typescript@7.0.2)
 
   vue-template-compiler@2.7.16:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-toast-notification@3.1.3(vue@3.5.18(typescript@5.9.3)):
+  vue-toast-notification@3.1.3(vue@3.5.18(typescript@7.0.2)):
     dependencies:
-      vue: 3.5.18(typescript@5.9.3)
+      vue: 3.5.18(typescript@7.0.2)
 
-  vue-tsc@2.0.11(typescript@5.9.3):
+  vue-tsc@2.0.11(typescript@7.0.2):
     dependencies:
       '@volar/typescript': 2.2.5
-      '@vue/language-core': 2.0.11(typescript@5.9.3)
+      '@vue/language-core': 2.0.11(typescript@7.0.2)
       semver: 7.8.4
-      typescript: 5.9.3
+      typescript: 7.0.2
 
-  vue-tsc@2.2.10(typescript@5.9.3):
+  vue-tsc@2.2.10(typescript@7.0.2):
     dependencies:
       '@volar/typescript': 2.4.11
-      '@vue/language-core': 2.2.10(typescript@5.9.3)
-      typescript: 5.9.3
+      '@vue/language-core': 2.2.10(typescript@7.0.2)
+      typescript: 7.0.2
 
   vue@3.2.33:
     dependencies:
@@ -15538,25 +15720,15 @@ snapshots:
       '@vue/server-renderer': 3.2.33(vue@3.2.33)
       '@vue/shared': 3.2.33
 
-  vue@3.5.18(typescript@5.9.3):
+  vue@3.5.18(typescript@7.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.18
       '@vue/compiler-sfc': 3.5.18
       '@vue/runtime-dom': 3.5.18
-      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@7.0.2))
       '@vue/shared': 3.5.18
     optionalDependencies:
-      typescript: 5.9.3
-
-  vue@3.5.18(typescript@6.0.2):
-    dependencies:
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-sfc': 3.5.18
-      '@vue/runtime-dom': 3.5.18
-      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@6.0.2))
-      '@vue/shared': 3.5.18
-    optionalDependencies:
-      typescript: 6.0.2
+      typescript: 7.0.2
 
   walk-up-path@3.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,13 +610,13 @@ importers:
         version: 2.6.12
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.3))
       '@vue/compiler-sfc':
         specifier: ^3.4.27
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.4.27
-        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@6.0.3))
       cross-fetch:
         specifier: ^4.0.0
         version: 4.1.0
@@ -624,8 +624,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.2
+        version: 6.0.3
       unplugin-vue-markdown:
         specifier: ^0.26.2
         version: 0.26.3(rollup@4.43.0)(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -637,10 +637,10 @@ importers:
         version: 6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.4.27
-        version: 3.5.18(typescript@7.0.2)
+        version: 3.5.18(typescript@6.0.3)
       vue-tsc:
-        specifier: ^2.0.19
-        version: 2.2.10(typescript@7.0.2)
+        specifier: ^3.3.11
+        version: 3.3.11(typescript@6.0.3)
 
   examples/vue-minimal:
     dependencies:
@@ -793,13 +793,13 @@ importers:
         version: 0.2.1(@hattip/core@0.0.49)(@types/express@5.0.6)(hono@4.10.4)(srvx@0.12.5)(vike@packages+vike)
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.3))
       '@vue/compiler-sfc':
         specifier: ^3.5.13
         version: 3.5.34
       '@vue/server-renderer':
         specifier: ^3.5.13
-        version: 3.5.18(vue@3.5.18(typescript@7.0.2))
+        version: 3.5.18(vue@3.5.18(typescript@6.0.3))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -810,8 +810,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.2
+        version: 6.0.3
       vike:
         specifier: ^0.4.260
         version: link:../../vike
@@ -820,10 +820,10 @@ importers:
         version: 6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.5.13
-        version: 3.5.18(typescript@7.0.2)
+        version: 3.5.18(typescript@6.0.3)
       vue-tsc:
-        specifier: ^2.1.10
-        version: 2.2.10(typescript@7.0.2)
+        specifier: ^3.3.11
+        version: 3.3.11(typescript@6.0.3)
 
   packages/vike:
     dependencies:
@@ -1351,8 +1351,8 @@ importers:
         specifier: ^2.6.1
         version: 2.7.0
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.2
+        version: 6.0.3
       unplugin-vue-markdown:
         specifier: ^0.24.3
         version: 0.24.3(rollup@4.43.0)(vite@6.3.0(@types/node@17.0.45)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -1367,7 +1367,7 @@ importers:
         version: 3.2.33
       vue-tsc:
         specifier: 2.0.11
-        version: 2.0.11(typescript@7.0.2)
+        version: 2.0.11(typescript@6.0.3)
 
   test/@cloudflare_vite-plugin:
     dependencies:
@@ -2116,13 +2116,13 @@ importers:
         version: 2.6.12
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.3))
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.2
+        version: 6.0.3
       unplugin-vue-markdown:
         specifier: ^28.3.1
         version: 28.3.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
@@ -2131,7 +2131,7 @@ importers:
         version: link:../../packages/vike
       vike-vue:
         specifier: ^0.9.13
-        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
+        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@6.0.3))
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
@@ -2140,44 +2140,44 @@ importers:
         version: 2.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       vue:
         specifier: ^3.5.13
-        version: 3.5.18(typescript@7.0.2)
+        version: 3.5.18(typescript@6.0.3)
       vue-toast-notification:
         specifier: ^3.1.3
-        version: 3.1.3(vue@3.5.18(typescript@7.0.2))
+        version: 3.1.3(vue@3.5.18(typescript@6.0.3))
       vue-tsc:
-        specifier: ^2.2.10
-        version: 2.2.10(typescript@7.0.2)
+        specifier: ^3.3.11
+        version: 3.3.11(typescript@6.0.3)
 
   test/vike-vue-pinia:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))
+        version: 6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.3))
       pinia:
         specifier: ^3.0.1
-        version: 3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2))
+        version: 3.0.3(typescript@6.0.3)(vue@3.5.18(typescript@6.0.3))
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
       vike-vue:
         specifier: ^0.9.13
-        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
+        version: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@6.0.3))
       vike-vue-pinia:
         specifier: ^0.2.6
-        version: 0.2.6(pinia@3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)))(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
+        version: 0.2.6(pinia@3.0.3(typescript@6.0.3)(vue@3.5.18(typescript@6.0.3)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@6.0.3)))(vike@packages+vike)(vue@3.5.18(typescript@6.0.3))
       vite:
         specifier: ^6.1.0
         version: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue:
         specifier: ^3.5.13
-        version: 3.5.18(typescript@7.0.2)
+        version: 3.5.18(typescript@6.0.3)
     devDependencies:
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.2
+        version: 6.0.3
       vue-tsc:
-        specifier: ^2.0.13
-        version: 2.2.10(typescript@7.0.2)
+        specifier: ^3.3.11
+        version: 3.3.11(typescript@6.0.3)
 
   test/vite-plugin-vercel:
     dependencies:
@@ -5246,20 +5246,20 @@ packages:
   '@volar/language-core@2.2.5':
     resolution: {integrity: sha512-2htyAuxRrAgETmFeUhT4XLELk3LiEcqoW/B8YUXMF6BrGWLMwIR09MFaZYvrA2UhbdAeSyeQ726HaWSWkexUcQ==}
 
-  '@volar/language-core@2.4.11':
-    resolution: {integrity: sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==}
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
   '@volar/source-map@2.2.5':
     resolution: {integrity: sha512-wrOEIiZNf4E+PWB0AxyM4tfhkfldPsb3bxg8N6FHrxJH2ohar7aGu48e98bp3pR9HUA7P/pR9VrLmkTrgCCnWQ==}
 
-  '@volar/source-map@2.4.11':
-    resolution: {integrity: sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==}
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
   '@volar/typescript@2.2.5':
     resolution: {integrity: sha512-eSV/n75+ppfEVugMC/salZsI44nXDPAyL6+iTYCNLtiLHGJsnMv9GwiDMujrvAUj/aLQyqRJgYtXRoxop2clCw==}
 
-  '@volar/typescript@2.4.11':
-    resolution: {integrity: sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==}
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
   '@vue/compiler-core@3.2.33':
     resolution: {integrity: sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==}
@@ -5309,9 +5309,6 @@ packages:
   '@vue/compiler-ssr@3.5.39':
     resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
 
-  '@vue/compiler-vue2@2.7.16':
-    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
-
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
@@ -5332,13 +5329,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@2.2.10':
-    resolution: {integrity: sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@vue/language-core@3.3.11':
+    resolution: {integrity: sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==}
 
   '@vue/reactivity-transform@3.2.33':
     resolution: {integrity: sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==}
@@ -5513,8 +5505,8 @@ packages:
     resolution: {integrity: sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==}
     engines: {node: '>= 14.0.0'}
 
-  alien-signals@1.0.13:
-    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -7996,6 +7988,11 @@ packages:
   type-level-regexp@0.1.17:
     resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -8480,8 +8477,8 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  vue-tsc@2.2.10:
-    resolution: {integrity: sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==}
+  vue-tsc@3.3.11:
+    resolution: {integrity: sha512-gOb0B9rtU2+f1dszwPqSH5kAieIF9ReeLhD3kSRNHv5WZZUQz/JdVXW0RTdqhNTMlQkqKzrTTviqKr/4FYZraQ==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -11571,17 +11568,23 @@ snapshots:
       vite: 6.3.0(@types/node@17.0.45)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
       vue: 3.2.33
 
-  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 6.3.5(@types/node@20.17.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
-      vue: 3.5.18(typescript@7.0.2)
+      vue: 3.5.18(typescript@6.0.3)
 
-  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 6.3.5(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
-      vue: 3.5.18(typescript@7.0.2)
+      vue: 3.5.18(typescript@6.0.3)
+
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@6.0.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.29
+      vite: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)
+      vue: 3.5.18(typescript@6.0.3)
 
   '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))(vue@3.5.18(typescript@7.0.2))':
     dependencies:
@@ -11640,24 +11643,24 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.2.5
 
-  '@volar/language-core@2.4.11':
+  '@volar/language-core@2.4.28':
     dependencies:
-      '@volar/source-map': 2.4.11
+      '@volar/source-map': 2.4.28
 
   '@volar/source-map@2.2.5':
     dependencies:
       muggle-string: 0.4.1
 
-  '@volar/source-map@2.4.11': {}
+  '@volar/source-map@2.4.28': {}
 
   '@volar/typescript@2.2.5':
     dependencies:
       '@volar/language-core': 2.2.5
       path-browserify: 1.0.1
 
-  '@volar/typescript@2.4.11':
+  '@volar/typescript@2.4.28':
     dependencies:
-      '@volar/language-core': 2.4.11
+      '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
@@ -11781,11 +11784,6 @@ snapshots:
       '@vue/compiler-dom': 3.5.39
       '@vue/shared': 3.5.39
 
-  '@vue/compiler-vue2@2.7.16':
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-
   '@vue/devtools-api@6.6.4': {}
 
   '@vue/devtools-api@7.7.7':
@@ -11806,7 +11804,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@2.0.11(typescript@7.0.2)':
+  '@vue/language-core@2.0.11(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.2.5
       '@vue/compiler-dom': 3.5.34
@@ -11816,20 +11814,17 @@ snapshots:
       path-browserify: 1.0.1
       vue-template-compiler: 2.7.16
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
 
-  '@vue/language-core@2.2.10(typescript@7.0.2)':
+  '@vue/language-core@3.3.11':
     dependencies:
-      '@volar/language-core': 2.4.11
-      '@vue/compiler-dom': 3.5.34
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.34
-      alien-signals: 1.0.13
-      minimatch: 9.0.6
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
+      alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 7.0.2
+      picomatch: 4.0.5
 
   '@vue/reactivity-transform@3.2.33':
     dependencies:
@@ -11875,6 +11870,12 @@ snapshots:
       '@vue/compiler-ssr': 3.2.33
       '@vue/shared': 3.2.33
       vue: 3.2.33
+
+  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.18
+      '@vue/shared': 3.5.18
+      vue: 3.5.18(typescript@6.0.3)
 
   '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@7.0.2))':
     dependencies:
@@ -12047,7 +12048,7 @@ snapshots:
       '@algolia/requester-fetch': 5.55.1
       '@algolia/requester-node-http': 5.55.1
 
-  alien-signals@1.0.13: {}
+  alien-signals@3.2.1: {}
 
   ansi-align@3.0.1:
     dependencies:
@@ -14183,12 +14184,12 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  pinia@3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2)):
+  pinia@3.0.3(typescript@6.0.3)(vue@3.5.18(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 7.7.7
-      vue: 3.5.18(typescript@7.0.2)
+      vue: 3.5.18(typescript@6.0.3)
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
 
   pixelmatch@5.3.0:
     dependencies:
@@ -15125,6 +15126,8 @@ snapshots:
 
   type-level-regexp@0.1.17: {}
 
+  typescript@6.0.3: {}
+
   typescript@7.0.2:
     optionalDependencies:
       '@typescript/typescript-aix-ppc64': 7.0.2
@@ -15417,20 +15420,20 @@ snapshots:
       vike: link:packages/vike
       vite-plugin-solid: 2.11.10(solid-js@1.9.10)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
 
-  vike-vue-pinia@0.2.6(pinia@3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)))(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)):
+  vike-vue-pinia@0.2.6(pinia@3.0.3(typescript@6.0.3)(vue@3.5.18(typescript@6.0.3)))(vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@6.0.3)))(vike@packages+vike)(vue@3.5.18(typescript@6.0.3)):
     dependencies:
-      pinia: 3.0.3(typescript@7.0.2)(vue@3.5.18(typescript@7.0.2))
+      pinia: 3.0.3(typescript@6.0.3)(vue@3.5.18(typescript@6.0.3))
       vike: link:packages/vike
-      vike-vue: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2))
-      vue: 3.5.18(typescript@7.0.2)
+      vike-vue: 0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@6.0.3))
+      vue: 3.5.18(typescript@6.0.3)
 
-  vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@7.0.2)):
+  vike-vue@0.9.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vike@packages+vike)(vue@3.5.18(typescript@6.0.3)):
     dependencies:
       magic-string: 0.30.21
       oxc-parser: 0.104.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       oxc-walker: 0.6.0(oxc-parser@0.104.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
       vike: link:packages/vike
-      vue: 3.5.18(typescript@7.0.2)
+      vue: 3.5.18(typescript@6.0.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -15695,22 +15698,22 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-toast-notification@3.1.3(vue@3.5.18(typescript@7.0.2)):
+  vue-toast-notification@3.1.3(vue@3.5.18(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.18(typescript@7.0.2)
+      vue: 3.5.18(typescript@6.0.3)
 
-  vue-tsc@2.0.11(typescript@7.0.2):
+  vue-tsc@2.0.11(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.2.5
-      '@vue/language-core': 2.0.11(typescript@7.0.2)
+      '@vue/language-core': 2.0.11(typescript@6.0.3)
       semver: 7.8.4
-      typescript: 7.0.2
+      typescript: 6.0.3
 
-  vue-tsc@2.2.10(typescript@7.0.2):
+  vue-tsc@3.3.11(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.11
-      '@vue/language-core': 2.2.10(typescript@7.0.2)
-      typescript: 7.0.2
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.11
+      typescript: 6.0.3
 
   vue@3.2.33:
     dependencies:
@@ -15719,6 +15722,16 @@ snapshots:
       '@vue/runtime-dom': 3.2.33
       '@vue/server-renderer': 3.2.33(vue@3.2.33)
       '@vue/shared': 3.2.33
+
+  vue@3.5.18(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.18
+      '@vue/compiler-sfc': 3.5.18
+      '@vue/runtime-dom': 3.5.18
+      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@6.0.3))
+      '@vue/shared': 3.5.18
+    optionalDependencies:
+      typescript: 6.0.3
 
   vue@3.5.18(typescript@7.0.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1190,10 +1190,10 @@ importers:
         version: 14.2.5
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@7.0.2)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@6.0.3)
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.2
+        version: 6.0.3
       vike:
         specifier: 0.4.260
         version: link:../../packages/vike
@@ -15084,7 +15084,7 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@7.0.2):
+  ts-node@10.9.2(@swc/core@1.13.5)(@types/node@17.0.45)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -15098,7 +15098,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 7.0.2
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:

--- a/test-deprecated-design/html-fragments/package.json
+++ b/test-deprecated-design/html-fragments/package.json
@@ -3,7 +3,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/test-deprecated-design/path-aliases/package.json
+++ b/test-deprecated-design/path-aliases/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^19.2.6",
     "serve": "^14.2.5",
     "ts-node": "^10.9.1",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/test-deprecated-design/path-aliases/package.json
+++ b/test-deprecated-design/path-aliases/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^19.2.6",
     "serve": "^14.2.5",
     "ts-node": "^10.9.1",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/test-deprecated-design/path-aliases/tsconfig.json
+++ b/test-deprecated-design/path-aliases/tsconfig.json
@@ -9,6 +9,7 @@
     "jsx": "react",
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "rootDir": ".",
     "paths": {
       "#root/*": ["./*"]
     }

--- a/test-deprecated-design/telefunc/package.json
+++ b/test-deprecated-design/telefunc/package.json
@@ -15,7 +15,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "telefunc": "^0.2.23",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "6.3.0"
   },

--- a/test-deprecated-design/vue-full/package.json
+++ b/test-deprecated-design/vue-full/package.json
@@ -12,7 +12,7 @@
     "@vue/server-renderer": "3.2.33",
     "cross-fetch": "^3.1.5",
     "node-fetch": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "unplugin-vue-markdown": "^0.24.3",
     "vike": "0.4.260",
     "vite": "6.3.0",

--- a/test-deprecated-design/vue-full/package.json
+++ b/test-deprecated-design/vue-full/package.json
@@ -12,7 +12,7 @@
     "@vue/server-renderer": "3.2.33",
     "cross-fetch": "^3.1.5",
     "node-fetch": "^2.6.1",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.2",
     "unplugin-vue-markdown": "^0.24.3",
     "vike": "0.4.260",
     "vite": "6.3.0",

--- a/test/@cloudflare_vite-plugin/package.json
+++ b/test/@cloudflare_vite-plugin/package.json
@@ -20,7 +20,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "build-worker": "^0.3.4",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vite": "^7.2.7",
     "wrangler": "^4.68.1"
   },

--- a/test/@cloudflare_vite-plugin_ud/package.json
+++ b/test/@cloudflare_vite-plugin_ud/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "vite": "^8.0.7",
     "wrangler": "^4.81.0"
   },

--- a/test/abort/package.json
+++ b/test/abort/package.json
@@ -17,7 +17,7 @@
     "express": "^5.2.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/test/abort/tsconfig.json
+++ b/test/abort/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "esModuleInterop": true,
-    "jsx": "react"
+    "jsx": "react",
+    "types": ["vite/client"]
   },
   "include": [
     "**/*",

--- a/test/hook-override/package.json
+++ b/test/hook-override/package.json
@@ -10,7 +10,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@types/node": "^24.3.0",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/test/photon-cloudflare/package.json
+++ b/test/photon-cloudflare/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.3",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "vite": "^7.3.1",
     "wrangler": "^4.81.0"
   },

--- a/test/photon-vercel/package.json
+++ b/test/photon-vercel/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vite": "^7.2.7"
   },
   "type": "module"

--- a/test/playground/package.json
+++ b/test/playground/package.json
@@ -18,7 +18,7 @@
     "node-fetch": "^3.3.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vike-react": "^0.6.26",
     "vite": "^7.0.6"

--- a/test/plusMiddlewares/package.json
+++ b/test/plusMiddlewares/package.json
@@ -14,7 +14,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.3",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vite": "^7.3.1"
   },
   "type": "module"

--- a/test/preload/package.json
+++ b/test/preload/package.json
@@ -3,7 +3,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^6.3.2"
   },

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"]
   },
   "include": ["utils.ts"]
 }

--- a/test/universal-deploy/package.json
+++ b/test/universal-deploy/package.json
@@ -16,7 +16,7 @@
     "vike-react": "^0.6.26"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vite": "^7.3.0",
     "@types/express": "^5.0.6",

--- a/test/vavite/package.json
+++ b/test/vavite/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vavite": "^5.1.0",
     "vite": "^7.2.7"
   },

--- a/test/vike-react-redux/package.json
+++ b/test/vike-react-redux/package.json
@@ -13,7 +13,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-redux": "^9.2.0",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vike-react": "^0.6.26",
     "vike-react-redux": "0.1.3",

--- a/test/vike-react-zustand/package.json
+++ b/test/vike-react-zustand/package.json
@@ -12,7 +12,7 @@
     "immer": "^10.2.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vike-react": "^0.6.26",
     "vike-react-zustand": "^0.1.11",

--- a/test/vike-react/package.json
+++ b/test/vike-react/package.json
@@ -12,7 +12,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-streaming": "^0.4.20",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vike-react": "^0.6.26",
     "vite": "^7.1.2"

--- a/test/vike-solid/package.json
+++ b/test/vike-solid/package.json
@@ -13,7 +13,7 @@
     "vike-solid": "^0.8.4"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vite": "^7.0.6",
     "vite-plugin-solid": "^2.11.10"
   },

--- a/test/vike-vue-pinia/package.json
+++ b/test/vike-vue-pinia/package.json
@@ -16,7 +16,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vue-tsc": "^2.0.13"
   }
 }

--- a/test/vike-vue-pinia/package.json
+++ b/test/vike-vue-pinia/package.json
@@ -16,7 +16,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "typescript": "^7.0.2",
-    "vue-tsc": "^2.0.13"
+    "typescript": "^6.0.2",
+    "vue-tsc": "^3.3.11"
   }
 }

--- a/test/vike-vue/package.json
+++ b/test/vike-vue/package.json
@@ -9,7 +9,7 @@
     "@types/node-fetch": "^2.6.11",
     "@vitejs/plugin-vue": "^6.0.1",
     "node-fetch": "^3.3.2",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.2",
     "unplugin-vue-markdown": "^28.3.1",
     "vike": "0.4.260",
     "vike-vue": "^0.9.13",
@@ -17,7 +17,7 @@
     "vite-plugin-cjs-interop": "^2.3.0",
     "vue": "^3.5.13",
     "vue-toast-notification": "^3.1.3",
-    "vue-tsc": "^2.2.10"
+    "vue-tsc": "^3.3.11"
   },
   "type": "module"
 }

--- a/test/vike-vue/package.json
+++ b/test/vike-vue/package.json
@@ -9,7 +9,7 @@
     "@types/node-fetch": "^2.6.11",
     "@vitejs/plugin-vue": "^6.0.1",
     "node-fetch": "^3.3.2",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "unplugin-vue-markdown": "^28.3.1",
     "vike": "0.4.260",
     "vike-vue": "^0.9.13",

--- a/test/vite-plugin-vercel/package.json
+++ b/test/vite-plugin-vercel/package.json
@@ -17,7 +17,7 @@
     "@vitejs/plugin-react-swc": "^3.11.0",
     "hono": "^4.8.4",
     "react": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vike-react": "^0.6.26",
     "vite": "^7.0.6"

--- a/test/vitest/package.json
+++ b/test/vitest/package.json
@@ -3,7 +3,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vike": "0.4.260",
     "vike-react": "^0.6.26",
     "vite": "^6.3.2"


### PR DESCRIPTION
## Summary
- Bump `typescript` to `^7.0.2` across the monorepo (packages, examples, tests, docs, CI workflows).
- **Exception:** the 5 Vue packages (`examples/vue-full`, `test/vike-vue`, `test/vike-vue-pinia`, `packages/create-vike-core/boilerplate-vue-ts`, `test-deprecated-design/vue-full`) stay on `typescript ^6.0.2`. TS 7's package.json no longer exports `typescript/lib/tsc` (a from-scratch package restructuring), and `vue-tsc` — even at its latest `3.3.11` — still reaches into that path, so it hard-crashes under TS 7 with no working release available yet. TS 6.0.2 still exposes that path, so `vue-tsc` works fine there.
- Fixed two real TS 7 breaking changes surfaced by `test-types` in the non-Vue packages:
  - New `TS2882` diagnostic flags side-effect imports (e.g. CSS) with no resolvable type declarations. Fixed by adding `"vite/client"` to the affected tsconfigs (`test/abort`, `examples/auth`, `docs`) and an ambient module declaration (`docs/global.d.ts`) for `docs`' non-`.css` package-subpath style imports (`@brillout/docpress/style`, `@docsearch/css`).
  - Implicit `@types/node` auto-inclusion no longer kicks in for `test/tsconfig.json` given its narrow `"include"`; added explicit `"types": ["node"]`.
- Updated `pnpm-lock.yaml` accordingly.

## Test plan
- [x] `pnpm install` succeeds with the new lockfile
- [x] `pnpm exec test-types` passes across every package in the monorepo (all ✅)
- [x] `packages/vike` typechecks and builds cleanly (`pnpm run build`)
- [ ] Full `test:e2e` suite (not run here — CI will cover it)
