### PR TITLE
refactor: remove docs/global.d.ts, obsoleted by DocPress 0.17.5

### DIFF
--- a/docs/global.d.ts
+++ b/docs/global.d.ts
@@ -1,2 +1,0 @@
-declare module '@brillout/docpress/style'
-declare module '@docsearch/css'

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@batijs/elements": "^0.0.94",
-    "@brillout/docpress": "^0.17.4",
+    "@brillout/docpress": "^0.17.5",
     "@classmatejs/react": "^0.2.1",
     "@gsap/react": "^2.1.2",
     "@tailwindcss/vite": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.0.94
         version: 0.0.94
       '@brillout/docpress':
-        specifier: ^0.17.4
-        version: 0.17.4(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@7.0.2)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
+        specifier: ^0.17.5
+        version: 0.17.5(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@7.0.2)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))
       '@classmatejs/react':
         specifier: ^0.2.1
         version: 0.2.1(react@19.2.6)
@@ -2552,8 +2552,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@brillout/docpress@0.17.4':
-    resolution: {integrity: sha512-so+B6ZLX7Xa+NaRd2PQBc31z9Hvni44UifCivvgiAmXBzZiUVElScUe9+zdd2kD+0HVwp/8bBl6Zz6D2tls+qg==}
+  '@brillout/docpress@0.17.5':
+    resolution: {integrity: sha512-MfYFQuw83wKKuS3GX2Q0Wwal3oNAE/F0N7iYyRMFP7DAdQhk84F4kYIo1z5JxT+gkKFeCB1DimV17mE2EnHwUw==}
     peerDependencies:
       '@vitejs/plugin-react': '>=4.0.0'
       react: '>=18.0.0'
@@ -9021,7 +9021,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@brillout/docpress@0.17.4(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@7.0.2)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))':
+  '@brillout/docpress@0.17.5(@algolia/client-search@5.55.1)(@types/react@19.2.15)(@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.43.0)(search-insights@2.17.3)(typescript@7.0.2)(vike@packages+vike)(vite@7.3.1(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.38.1)(tsx@4.20.6))':
     dependencies:
       '@brillout/picocolors': 1.0.31
       '@brillout/shiki-transformers': 4.0.2


### PR DESCRIPTION
## Summary

#3480 added ambient module declarations in `docs/global.d.ts` to work around `TS2882`, a new TypeScript 7 diagnostic that flags side-effect imports with no resolvable type declarations:

```ts
declare module '@brillout/docpress/style'
declare module '@docsearch/css'
```

Both belonged in DocPress rather than here, and now live there (brillout/docpress#193, released as `0.17.5`):

- **`@brillout/docpress/style`** mapped straight to `./css/index.css`, so there was nothing for TypeScript to resolve. It now has a `types` export condition pointing at a `style.d.ts`.

- **`@docsearch/css`** is imported by DocPress's own `ExternalLinks.tsx`. Since DocPress is `noExternal` and ships its TypeScript sources, our `tsc` type checks that file, and the error surfaced inside `node_modules` — where an ambient declaration on our side was the only available fix. DocPress now declares the module itself, in the `types.d.ts` we already pull in via `"types": ["@brillout/docpress/types"]`.

So this PR bumps `@brillout/docpress` to `^0.17.5` and deletes `docs/global.d.ts`.

## Note on `"vite/client"`

#3480 also added `"vite/client"` to `docs/tsconfig.json`. I checked whether that could go too, and it's **a no-op for `TS2882`** — the errors are byte-identical with and without it.

It's still worth keeping: `docs/` imports its own `.css` and `.svg` files, and was previously getting `vite/client` only transitively through DocPress's `types.d.ts`. Declaring it explicitly is the correct thing regardless, so I left it in place.

## Test plan

- [x] `pnpm install` succeeds with the updated lockfile
- [x] `pnpm exec test-types` passes across the whole monorepo (all ✅), including `docs/`
- [x] Verified `docs/` type checks against the real `@brillout/docpress@0.17.5` from npm — the previously locally-patched `0.17.4` copy was removed from the store first, so nothing stale could mask the result

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3YgJXgFkz9Dg8T9adLVpw)_