### PR TITLE
fix: don't let autoImporter point at dist/server/ when pre-rendering removes it

### DIFF
--- a/packages/vike/src/node/prerender/resolvePrerenderConfig.ts
+++ b/packages/vike/src/node/prerender/resolvePrerenderConfig.ts
@@ -1,5 +1,6 @@
 export { resolvePrerenderConfigGlobal }
 export { resolvePrerenderConfigLocal }
+export { isDistServerRemoved }
 
 import { VikeConfigInternal } from '../vite/shared/resolveVikeConfigInternal.js'
 import { assert, assertUsage } from '../../utils/assert.js'
@@ -83,6 +84,11 @@ async function resolvePrerenderConfigLocal(pageConfig: PageConfigBuildTime) {
   )
   const prerenderConfigLocal = { value }
   return prerenderConfigLocal
+}
+
+// Whether pre-rendering removes dist/server/ once it's done (https://vike.dev/prerender#keepDistServer)
+function isDistServerRemoved(prerenderConfigGlobal: { keepDistServer: boolean }): boolean {
+  return !prerenderConfigGlobal.keepDistServer
 }
 
 function isObject2<T extends Record<string, unknown>>(value: T | boolean | undefined): value is T {

--- a/packages/vike/src/node/prerender/runPrerender.ts
+++ b/packages/vike/src/node/prerender/runPrerender.ts
@@ -59,7 +59,11 @@ import type { HookTimeout } from '../../shared-server-client/hooks/getHook.js'
 import { execHookSingleWithoutPageContext, isUserHookError } from '../../shared-server-client/hooks/execHook.js'
 import type { ApiOptions } from '../api/types.js'
 import { setWasPrerenderRun } from './context.js'
-import { resolvePrerenderConfigGlobal, resolvePrerenderConfigLocal } from './resolvePrerenderConfig.js'
+import {
+  resolvePrerenderConfigGlobal,
+  resolvePrerenderConfigLocal,
+  isDistServerRemoved,
+} from './resolvePrerenderConfig.js'
 import { getOutDirsAllFromRootNormalized } from '../vite/shared/getOutDirs.js'
 import fs from 'node:fs'
 import { getPublicProxy } from '../../shared-server-client/getPublicProxy.js'
@@ -261,7 +265,7 @@ async function runPrerender(options: PrerenderOptions = {}, trigger: PrerenderTr
   objectAssign(vikeConfig.prerenderContext, prerenderContextPublic, true)
   setGlobalContext_prerenderContext(prerenderContextPublic)
 
-  if (!prerenderConfigGlobal.keepDistServer) {
+  if (isDistServerRemoved(prerenderConfigGlobal)) {
     fs.rmSync(outDirServer, { recursive: true })
   }
 }

--- a/packages/vike/src/node/vite/plugins/build/pluginProdBuildEntry.ts
+++ b/packages/vike/src/node/vite/plugins/build/pluginProdBuildEntry.ts
@@ -14,8 +14,6 @@ import { isUsingClientRouter } from '../pluginExtractExportNames.js'
 import { assertBuildInfo, type BuildInfo } from '../../../../server/runtime/globalContext.js'
 import { getOutDirs } from '../../shared/getOutDirs.js'
 import { getViteConfigRuntime } from '../../shared/getViteConfigRuntime.js'
-import { getVikeConfigInternal } from '../../shared/resolveVikeConfigInternal.js'
-import { resolvePrerenderConfigGlobal } from '../../../prerender/resolvePrerenderConfig.js'
 import '../../assertEnvVite.js'
 type Bundle = Rollup.OutputBundle
 const ASSETS_MANIFEST = `__VITE_ASSETS_MANIFEST_${
@@ -41,16 +39,8 @@ function pluginProdBuildEntry(): Plugin[] {
       getServerProductionEntry: () => {
         return getServerProductionEntryCode(config)
       },
-      // If pre-rendering is going to remove dist/server/ then don't let the autoImporter point at it: runtimes then fall back gracefully (crawling outDir, or e.g. Telefunc's telefunction registration) instead of importing a file that doesn't exist anymore (https://github.com/vikejs/vike/pull/3483).
-      getServerEntryWillBeRemoved: async () => {
-        const vikeConfig = await getVikeConfigInternal()
-        const prerenderConfigGlobal = await resolvePrerenderConfigGlobal(vikeConfig)
-        // Same condition as the dist/server/ removal in runPrerender()
-        return !prerenderConfigGlobal.keepDistServer
-      },
       libraryName: 'Vike',
-      // TO-DO/after-dep-bump: remove this cast once the @brillout/vite-plugin-server-entry dependency is guaranteed to include the getServerEntryWillBeRemoved() setting (older plugin versions simply ignore it)
-    } as Parameters<typeof serverProductionEntryPlugin>[0]),
+    }),
   ]
 }
 

--- a/packages/vike/src/node/vite/plugins/build/pluginProdBuildEntry.ts
+++ b/packages/vike/src/node/vite/plugins/build/pluginProdBuildEntry.ts
@@ -14,6 +14,8 @@ import { isUsingClientRouter } from '../pluginExtractExportNames.js'
 import { assertBuildInfo, type BuildInfo } from '../../../../server/runtime/globalContext.js'
 import { getOutDirs } from '../../shared/getOutDirs.js'
 import { getViteConfigRuntime } from '../../shared/getViteConfigRuntime.js'
+import { getVikeConfigInternal } from '../../shared/resolveVikeConfigInternal.js'
+import { resolvePrerenderConfigGlobal } from '../../../prerender/resolvePrerenderConfig.js'
 import '../../assertEnvVite.js'
 type Bundle = Rollup.OutputBundle
 const ASSETS_MANIFEST = `__VITE_ASSETS_MANIFEST_${
@@ -39,8 +41,16 @@ function pluginProdBuildEntry(): Plugin[] {
       getServerProductionEntry: () => {
         return getServerProductionEntryCode(config)
       },
+      // If pre-rendering is going to remove dist/server/ then don't let the autoImporter point at it: runtimes then fall back gracefully (crawling outDir, or e.g. Telefunc's telefunction registration) instead of importing a file that doesn't exist anymore (https://github.com/vikejs/vike/pull/3483).
+      getServerEntryWillBeRemoved: async () => {
+        const vikeConfig = await getVikeConfigInternal()
+        const prerenderConfigGlobal = await resolvePrerenderConfigGlobal(vikeConfig)
+        // Same condition as the dist/server/ removal in runPrerender()
+        return !prerenderConfigGlobal.keepDistServer
+      },
       libraryName: 'Vike',
-    }),
+      // TO-DO/after-dep-bump: remove this cast once the @brillout/vite-plugin-server-entry dependency is guaranteed to include the getServerEntryWillBeRemoved() setting (older plugin versions simply ignore it)
+    } as Parameters<typeof serverProductionEntryPlugin>[0]),
   ]
 }
 

--- a/packages/vike/src/node/vite/plugins/pluginCommon.ts
+++ b/packages/vike/src/node/vite/plugins/pluginCommon.ts
@@ -13,6 +13,7 @@ import { assertResolveAlias } from './pluginCommon/assertResolveAlias.js'
 import { getVikeConfigInternal, setVikeConfigContext } from '../shared/resolveVikeConfigInternal.js'
 import { assertViteRoot, getViteRoot, normalizeViteRoot } from '../../api/resolveViteConfigUser.js'
 import { temp_disablePrerenderAutoRun } from '../../prerender/context.js'
+import { resolvePrerenderConfigGlobal } from '../../prerender/resolvePrerenderConfig.js'
 import type { VitePluginServerEntryOptions } from '@brillout/vite-plugin-server-entry/plugin'
 import { version as viteVersionVike } from 'vite'
 import '../assertEnvVite.js'
@@ -98,9 +99,21 @@ function pluginCommon(vikeVitePluginOptions: unknown): Plugin[] {
       },
       config: {
         order: 'post',
-        async handler(configFromUser) {
+        async handler(configFromUser, env) {
           const configFromVike: UserConfig = { server: {}, preview: {} }
           const vikeConfig = await getVikeConfigInternal()
+
+          // Don't let @brillout/vite-plugin-server-entry's autoImporter point at dist/server/ when pre-rendering is going to remove it: the plugin resets the autoImporter (status 'UNSET') instead, so that runtimes fall back gracefully (crawling outDir, or e.g. Telefunc's telefunction registration) instead of importing a file that doesn't exist anymore (https://github.com/vikejs/vike/pull/3483).
+          if (env.command === 'build') {
+            const prerenderConfigGlobal = await resolvePrerenderConfigGlobal(vikeConfig)
+            // Same condition as the dist/server/ removal in runPrerender()
+            if (!prerenderConfigGlobal.keepDistServer) {
+              // TO-DO/after-dep-bump: remove cast once the @brillout/vite-plugin-server-entry dependency includes the serverEntryWillBeRemoved setting (older plugin versions simply ignore it)
+              ;(
+                configFromVike as { vitePluginServerEntry?: { serverEntryWillBeRemoved?: boolean } }
+              ).vitePluginServerEntry = { serverEntryWillBeRemoved: true }
+            }
+          }
 
           // A value the user set through Vike (+config.js, CLI option, or VIKE_CONFIG) overrides vite.config.js:
           // Vike's config has higher precedence than vite.config.js (see precedence list at resolveViteConfigUser.ts).

--- a/packages/vike/src/node/vite/plugins/pluginCommon.ts
+++ b/packages/vike/src/node/vite/plugins/pluginCommon.ts
@@ -13,7 +13,7 @@ import { assertResolveAlias } from './pluginCommon/assertResolveAlias.js'
 import { getVikeConfigInternal, setVikeConfigContext } from '../shared/resolveVikeConfigInternal.js'
 import { assertViteRoot, getViteRoot, normalizeViteRoot } from '../../api/resolveViteConfigUser.js'
 import { temp_disablePrerenderAutoRun } from '../../prerender/context.js'
-import { resolvePrerenderConfigGlobal } from '../../prerender/resolvePrerenderConfig.js'
+import { resolvePrerenderConfigGlobal, isDistServerRemoved } from '../../prerender/resolvePrerenderConfig.js'
 import type { VitePluginServerEntryOptions } from '@brillout/vite-plugin-server-entry/plugin'
 import { version as viteVersionVike } from 'vite'
 import '../assertEnvVite.js'
@@ -219,8 +219,7 @@ async function disableAutoImportIfNeeded(isBuild: boolean): Promise<UserConfig |
   if (!isBuild) return
   const vikeConfig = await getVikeConfigInternal()
   const prerenderConfigGlobal = await resolvePrerenderConfigGlobal(vikeConfig)
-  // Same condition as the dist/server/ removal in runPrerender()
-  if (!prerenderConfigGlobal.keepDistServer) {
+  if (isDistServerRemoved(prerenderConfigGlobal)) {
     return { vitePluginServerEntry: { disableAutoImport: true } }
   }
 }

--- a/packages/vike/src/node/vite/plugins/pluginCommon.ts
+++ b/packages/vike/src/node/vite/plugins/pluginCommon.ts
@@ -214,7 +214,7 @@ async function emitServerEntryOnlyIfNeeded(config: ResolvedConfig) {
   }
 }
 
-// Don't let @brillout/vite-plugin-server-entry's autoImporter point at dist/server/ when pre-rendering is going to remove it — a dangling pointer crashes runtimes consulting it (https://github.com/vikejs/vike/pull/3483)
+// Don't let @brillout/vite-plugin-server-entry's autoImporter.js point at dist/server/entry.js when pre-rendering is going to remove dist/server/ — a dangling pointer crashes runtimes consulting it
 async function disableAutoImportIfNeeded(isBuild: boolean): Promise<UserConfig | undefined> {
   if (!isBuild) return
   const vikeConfig = await getVikeConfigInternal()

--- a/packages/vike/src/node/vite/plugins/pluginCommon.ts
+++ b/packages/vike/src/node/vite/plugins/pluginCommon.ts
@@ -64,6 +64,7 @@ function pluginCommon(vikeVitePluginOptions: unknown): Plugin[] {
             configVikePromise: Promise.resolve({
               prerender: vikeConfig.prerenderContext.isPrerenderingEnabled,
             }),
+            ...(await disableAutoImportIfNeeded(isBuild)),
           }
         },
       },
@@ -99,18 +100,9 @@ function pluginCommon(vikeVitePluginOptions: unknown): Plugin[] {
       },
       config: {
         order: 'post',
-        async handler(configFromUser, env) {
+        async handler(configFromUser) {
           const configFromVike: UserConfig = { server: {}, preview: {} }
           const vikeConfig = await getVikeConfigInternal()
-
-          // Don't let @brillout/vite-plugin-server-entry's autoImporter point at dist/server/ when pre-rendering is going to remove it: runtimes then fall back gracefully (crawling outDir, or e.g. Telefunc's telefunction registration) instead of importing a file that doesn't exist anymore (https://github.com/vikejs/vike/pull/3483). The plugin also resets the pointer a previous build may have written (see brillout/vite-plugin-server-entry#36 — older plugin versions merely leave the autoImporter untouched, which already suffices for fresh installs).
-          if (env.command === 'build') {
-            const prerenderConfigGlobal = await resolvePrerenderConfigGlobal(vikeConfig)
-            // Same condition as the dist/server/ removal in runPrerender()
-            if (!prerenderConfigGlobal.keepDistServer) {
-              configFromVike.vitePluginServerEntry = { disableAutoImport: true }
-            }
-          }
 
           // A value the user set through Vike (+config.js, CLI option, or VIKE_CONFIG) overrides vite.config.js:
           // Vike's config has higher precedence than vite.config.js (see precedence list at resolveViteConfigUser.ts).
@@ -219,5 +211,16 @@ async function emitServerEntryOnlyIfNeeded(config: ResolvedConfig) {
   const vikeConfig = await getVikeConfigInternal()
   if (config.vitePluginServerEntry?.inject && !vikeConfig.prerenderContext.isPrerenderingEnabled) {
     config.vitePluginServerEntry.disableServerEntryEmit = true
+  }
+}
+
+// Don't let @brillout/vite-plugin-server-entry's autoImporter point at dist/server/ when pre-rendering is going to remove it — a dangling pointer crashes runtimes consulting it (https://github.com/vikejs/vike/pull/3483)
+async function disableAutoImportIfNeeded(isBuild: boolean): Promise<UserConfig | undefined> {
+  if (!isBuild) return
+  const vikeConfig = await getVikeConfigInternal()
+  const prerenderConfigGlobal = await resolvePrerenderConfigGlobal(vikeConfig)
+  // Same condition as the dist/server/ removal in runPrerender()
+  if (!prerenderConfigGlobal.keepDistServer) {
+    return { vitePluginServerEntry: { disableAutoImport: true } }
   }
 }

--- a/packages/vike/src/node/vite/plugins/pluginCommon.ts
+++ b/packages/vike/src/node/vite/plugins/pluginCommon.ts
@@ -103,15 +103,12 @@ function pluginCommon(vikeVitePluginOptions: unknown): Plugin[] {
           const configFromVike: UserConfig = { server: {}, preview: {} }
           const vikeConfig = await getVikeConfigInternal()
 
-          // Don't let @brillout/vite-plugin-server-entry's autoImporter point at dist/server/ when pre-rendering is going to remove it: the plugin resets the autoImporter (status 'UNSET') instead, so that runtimes fall back gracefully (crawling outDir, or e.g. Telefunc's telefunction registration) instead of importing a file that doesn't exist anymore (https://github.com/vikejs/vike/pull/3483).
+          // Don't let @brillout/vite-plugin-server-entry's autoImporter point at dist/server/ when pre-rendering is going to remove it: runtimes then fall back gracefully (crawling outDir, or e.g. Telefunc's telefunction registration) instead of importing a file that doesn't exist anymore (https://github.com/vikejs/vike/pull/3483). The plugin also resets the pointer a previous build may have written (see brillout/vite-plugin-server-entry#36 — older plugin versions merely leave the autoImporter untouched, which already suffices for fresh installs).
           if (env.command === 'build') {
             const prerenderConfigGlobal = await resolvePrerenderConfigGlobal(vikeConfig)
             // Same condition as the dist/server/ removal in runPrerender()
             if (!prerenderConfigGlobal.keepDistServer) {
-              // TO-DO/after-dep-bump: remove cast once the @brillout/vite-plugin-server-entry dependency includes the serverEntryWillBeRemoved setting (older plugin versions simply ignore it)
-              ;(
-                configFromVike as { vitePluginServerEntry?: { serverEntryWillBeRemoved?: boolean } }
-              ).vitePluginServerEntry = { serverEntryWillBeRemoved: true }
+              configFromVike.vitePluginServerEntry = { disableAutoImport: true }
             }
           }
 


### PR DESCRIPTION
Since the `dist/server/` removal (#2297, v0.4.227), a fully pre-rendered build ended with `@brillout/vite-plugin-server-entry`'s `autoImporter.js` (in `node_modules`, shared with e.g. Telefunc) still pointing at the removed `dist/server/entry.mjs`. Any runtime consulting it then crashed with `ERR_MODULE_NOT_FOUND` — e.g. Telefunc served in-process by a server in the same monorepo, which never got to its registration fallback.

Alternative to #3483, paired with brillout/vite-plugin-server-entry#36. When pre-rendering is going to remove `dist/server/`, Vike sets the plugin's **existing** `disableAutoImport` setting — no new plugin setting, no cast. The whole Vike side is `disableAutoImportIfNeeded()`, a function next to `emitServerEntryOnlyIfNeeded()` in `pluginCommon.ts`, applied by the earliest `config` hook (`order: 'pre'`) so the setting is merged into the config before any other hook can read it. The condition is `isDistServerRemoved()` — a function shared with the `dist/server/` removal in `runPrerender()`, so the two can't drift apart. The autoImporter then never points at a file that won't exist at runtime, and runtimes fall back gracefully:

- Pre-rendering itself passes `outDir` explicitly (`globalContext.ts` → `loadProdBuildEntry(false, viteConfigRuntime?.build.outDir)`) and the server entry file is still emitted, so pre-rendering loads it by crawling `outDir`.
- Telefunc-style consumers (`tolerateDoesNotExist: true`) get `false` and fall back to telefunction registration, instead of crashing.
- Apps that keep `dist/server/` (partial pre-rendering, `keepDistServer: true`, no pre-rendering, old design) get a `SET` autoImporter exactly as before.

Rollout: with the current `^0.7.20` dependency this already covers fresh installs (the pristine autoImporter is simply left untouched). brillout/vite-plugin-server-entry#36 closes the remaining hole — it makes `disableAutoImport` *reset* the pointer a previous build may have written (e.g. a build made before the user enabled pre-rendering), writing only when such a stale pointer exists.

Compared to #3483's `clearAutoImporters()`: the pointer is never dangling by construction (no window between build and pre-rendering, nothing left dangling if pre-rendering crashes or runs later in a separate process), no out-of-band write to the shared `autoImporter.js` after pre-rendering, and no new runtime-callable plugin API.

The earlier commits on the branch are previous iterations, kept for review history.

## Verification

`pnpm exec tsc --noEmit` passes. End-to-end with this branch built locally + the plugin branch substituted into the dependency, on a minimal V1-design app (2 pages, vanilla renderer):

| App | `dist/server/` after `vike build` | autoImporter | Telefunc-style consultation |
| --- | --- | --- | --- |
| fresh install, `+prerender: true` | removed | `UNSET` — pristine npm file untouched (zero writes) | returns `false` — graceful (previously: `ERR_MODULE_NOT_FOUND` crash) |
| `keepDistServer: true` build, then switch to `+prerender: true` | removed | stale `SET` converged to `UNSET` | returns `false` — graceful |
| `+prerender: { keepDistServer: true }` | kept | `SET` | loads the entry |
| partial (`pages/about/+prerender.js` → `false`) | kept | `SET` | loads the entry |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NG4aV24yykzPom4nFknUmP