### PR TITLE
fix: don't emit dist/server/entry.mjs when unnecessary (vike-server)

### DIFF
--- a/packages/vike/src/node/vite/plugins/pluginCommon.ts
+++ b/packages/vike/src/node/vite/plugins/pluginCommon.ts
@@ -129,7 +129,9 @@ function pluginCommon(vikeVitePluginOptions: unknown): Plugin[] {
             configFromVike.optimizeDeps.force = vikeConfig.config.force
           }
 
-          return { ...configFromVike, ...(await disableServerEntryEmitIfNeeded(configFromUser)) }
+          await disableServerEntryEmitIfNeeded(configFromUser, configFromVike)
+
+          return configFromVike
         },
       },
     },
@@ -207,10 +209,10 @@ function temp_supportOldInterface(config: ResolvedConfig) {
 
 // Only emit dist/server/entry.mjs if necessary.
 // Set over the config hook: setting it at configResolved (like previously) is too late — Vite runs configResolved hooks concurrently (Promise.all) and @brillout/vite-plugin-server-entry reads the setting in its synchronous configResolved hook before our asynchronous mutation lands.
-async function disableServerEntryEmitIfNeeded(configFromUser: UserConfig): Promise<UserConfig | undefined> {
+async function disableServerEntryEmitIfNeeded(configFromUser: UserConfig, configFromVike: UserConfig) {
   const vikeConfig = await getVikeConfigInternal()
   if (configFromUser.vitePluginServerEntry?.inject && !vikeConfig.prerenderContext.isPrerenderingEnabled) {
-    return { vitePluginServerEntry: { disableServerEntryEmit: true } }
+    configFromVike.vitePluginServerEntry = { disableServerEntryEmit: true }
   }
 }
 

--- a/packages/vike/src/node/vite/plugins/pluginCommon.ts
+++ b/packages/vike/src/node/vite/plugins/pluginCommon.ts
@@ -95,7 +95,6 @@ function pluginCommon(vikeVitePluginOptions: unknown): Plugin[] {
           assertRollupInput(config)
           assertResolveAlias(config)
           temp_supportOldInterface(config)
-          await emitServerEntryOnlyIfNeeded(config)
         },
       },
       config: {
@@ -130,7 +129,7 @@ function pluginCommon(vikeVitePluginOptions: unknown): Plugin[] {
             configFromVike.optimizeDeps.force = vikeConfig.config.force
           }
 
-          return configFromVike
+          return { ...configFromVike, ...(await disableServerEntryEmitIfNeeded(configFromUser)) }
         },
       },
     },
@@ -206,11 +205,12 @@ function temp_supportOldInterface(config: ResolvedConfig) {
   assert(false)
 }
 
-// Only emit dist/server/entry.mjs if necessary
-async function emitServerEntryOnlyIfNeeded(config: ResolvedConfig) {
+// Only emit dist/server/entry.mjs if necessary.
+// Set over the config hook: setting it at configResolved (like previously) is too late — Vite runs configResolved hooks concurrently (Promise.all) and @brillout/vite-plugin-server-entry reads the setting in its synchronous configResolved hook before our asynchronous mutation lands.
+async function disableServerEntryEmitIfNeeded(configFromUser: UserConfig): Promise<UserConfig | undefined> {
   const vikeConfig = await getVikeConfigInternal()
-  if (config.vitePluginServerEntry?.inject && !vikeConfig.prerenderContext.isPrerenderingEnabled) {
-    config.vitePluginServerEntry.disableServerEntryEmit = true
+  if (configFromUser.vitePluginServerEntry?.inject && !vikeConfig.prerenderContext.isPrerenderingEnabled) {
+    return { vitePluginServerEntry: { disableServerEntryEmit: true } }
   }
 }
 


### PR DESCRIPTION
Follow-up to #3484 — the ordering issue found there turns out to also break `emitServerEntryOnlyIfNeeded()`: the "Only emit dist/server/entry.mjs if necessary" optimization for vike-server apps has been a silent no-op — `dist/server/entry.mjs` was always emitted.

## Root cause

Vite runs `configResolved` hooks **concurrently** (`await Promise.all(...)` — `vite/dist/node/chunks/config.js`, `resolveConfig`). All handlers start in plugin order, but `@brillout/vite-plugin-server-entry`'s `config:post` handler is fully synchronous — it copies `config.vitePluginServerEntry` into its resolved state and decides the rollup input injection in one go — while `pluginCommon.ts`'s handler `await`s `getVikeConfigInternal()` *before* mutating `config.vitePluginServerEntry.disableServerEntryEmit`. The mutation therefore always landed after the plugin had already injected the entry input, in every build pass. (Same root cause that bit the first `disableAutoImport` attempt in #3484; a probe plugin confirmed the ordering empirically.)

## Fix

Set the setting over the `config` hook instead — Vite merges `config` hook results sequentially before resolution, so the plugin reliably sees it. Mirrors `disableAutoImportIfPrerendering()`; applied by the post-ordered `config` hook because vike-server provides `inject` over its own `config` hook, which must run first.

## Verification

Real vike-server app (Hono adapter, `vike-server@1.0.25`, 2 pages):

| Scenario | `dist/server/entry.mjs` |
| --- | --- |
| main (unfixed), vike-server, no pre-rendering | emitted — the bug |
| **this PR**, vike-server, no pre-rendering | **not emitted** |
| this PR, vike-server + `prerender: { keepDistServer: true }` | emitted (pre-rendering needs it) |
| this PR, plain Vike app (no vike-server) | emitted (unchanged) |

Runtime smoke test on the entry-suppressed build: `node dist/server/index.js` serves both pages correctly — the server entry code (including the assets manifest) is bundled into `dist/server/index.js` via vike-server's injected import of the server-entry virtual module, and `handleAssetsManifest`'s `assert(!noop)` passes since the `ASSETS_MANIFEST` macro lives in `index.js`'s chunk graph.

One behavior note: manually setting `vitePluginServerEntry: { inject: true }` *without* vike-server's import injection now fails the build (the `assert(!noop)` in `handleAssetsManifest.ts` fires, since nothing carries the assets manifest) — previously it "worked" only because the suppression was a no-op. `inject` is documented as vike-server-internal communication, so no supported setup is affected; happy to turn that assert into an `assertUsage` in a follow-up if you'd like a friendlier error for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NG4aV24yykzPom4nFknUmP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NG4aV24yykzPom4nFknUmP)_