### PR TITLE
fix: temporarily disable automatically adding `vike/SKILL.md`

### DIFF
--- a/packages/vike/src/node/vite/plugins/pluginDev.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev.ts
@@ -4,10 +4,10 @@ export { logDockerHint }
 import { type Plugin, type ResolvedConfig, type UserConfig } from 'vite'
 import { optimizeDeps, resolveOptimizeDeps } from './pluginDev/optimizeDeps.js'
 import { determineFsAllowList } from './pluginDev/determineFsAllowList.js'
-import { autoAddVikeSkill } from './pluginDev/autoAddVikeSkill.js'
+// import { autoAddVikeSkill } from './pluginDev/autoAddVikeSkill.js'
 import { addSsrMiddleware } from '../shared/addSsrMiddleware.js'
 import { isDebugError } from '../../../utils/debug.js'
-import { setTimeoutUnref } from '../../../utils/setTimeoutUnref.js'
+// import { setTimeoutUnref } from '../../../utils/setTimeoutUnref.js'
 import { applyDev } from '../../../utils/isDev.js'
 import { isDocker } from '../../../utils/isDocker.js'
 import { assertWarning } from '../../../utils/assert.js'
@@ -39,12 +39,16 @@ function pluginDev(): Plugin[] {
           logDockerHint(config.server.host)
         },
       },
+      // TODO/soon: re-enable automatically adding vike/SKILL.md (https://vike.dev/ai#skill).
+      // Temporarily disabled — https://github.com/vikejs/vike/pull/3465 got some backlash, let's find a better solution first.
+      /*
       configureServer: {
         handler() {
           // Apply late — after the dev server is up and running — so that it doesn't slow down dev start
           setTimeoutUnref(() => autoAddVikeSkill(config.root), 15 * 1000)
         },
       },
+      */
     },
     {
       name: 'vike:pluginDev:post',


### PR DESCRIPTION
Temporarily disables the feature added by https://github.com/vikejs/vike/pull/3465 (automatically adding & Git-committing `vike/SKILL.md` upon dev), following the backlash it received — until a better solution is found.

## Changes

Only the trigger is commented out, in `packages/vike/src/node/vite/plugins/pluginDev.ts`:

- The `configureServer` handler that scheduled `autoAddVikeSkill()` 15s after dev start.
- Its two now-unused imports (`autoAddVikeSkill`, `setTimeoutUnref`) — required, since `noUnusedLocals` is on.

Everything else is left untouched, so re-enabling is just uncommenting:

- `pluginDev/autoAddVikeSkill.ts` (still type-checked, since `tsconfig.json` includes all of `src/`)
- The `+ai.skill` setting (`Config.ts`, `metaBuiltIn.ts`) — still valid config, now simply inert
- The docs (`vike.dev/ai`, settings index, `llms.txt`)

> [!NOTE]
> `vike.dev/ai` still documents the skill file as being added automatically. Left as-is on purpose to keep this a one-line revert, but worth a temporary docs tweak if this stays disabled for a while.

## Testing

- `tsc` build of `packages/vike` — passes
- `biome check` on the changed file — passes
- `node scripts/lint-assertenv.mjs` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTcZ28NgaahebajN63bEDs)_