### PR TITLE
docs: fix hydration error on /start (React error #418)

### DIFF
--- a/docs/pages/start/+Page.mdx
+++ b/docs/pages/start/+Page.mdx
@@ -40,7 +40,7 @@ npm install
 npm run dev
 ```
 
-You can now go to [localhost:3000](http://localhost:3000) <span class="gray">(or [localhost:3001](http://localhost:3001) if `localhost:3000` is busy)</span>.
+You can now go to [localhost\:3000](http://localhost:3000) <span className="gray">(or [localhost\:3001](http://localhost:3001) if `localhost:3000` is busy)</span>.
 
 You created your first Vike app 🎉
 


### PR DESCRIPTION
Found while sweeping all vike.dev pages for hydration errors (investigation of the React error #418 on `/ai`, fixed in brillout/docpress#195): https://vike.dev/start also throws React error #418 (`args[]=HTML`) for everyone.

## Root cause

In `pages/start/+Page.mdx`:

```md
You can now go to [localhost:3000](http://localhost:3000) <span class="gray">(or [localhost:3001](http://localhost:3001) if `localhost:3000` is busy)</span>.
```

`remark-directive` parses `:3000` / `:3001` inside the link texts as text directives, which end up rendered as an empty `<div>`: the pre-rendered HTML contains `<a href="http://localhost:3000">localhost<div></div></a>` inside a `<p>`. Since a `<div>` isn't allowed inside `<p>`, the browser's HTML parser restructures the paragraph, and hydration fails (React in dev mode: "In HTML, <div> cannot be a descendant of <p>. This will cause a hydration error.").

## Fix

Escape the colons (`localhost\:3000`), which renders the intended link text again. Also `class` → `className` on the raw `<span>` (React warns about `class` in JSX).

Verified with `vike dev`: the paragraph renders as `<a href="http://localhost:3000">localhost:3000</a> …` and `/start` hydrates without errors. No other page has a prose `:<digits>` outside code spans.

## Sweep results

All 353 pre-rendered pages of the docs, loaded in headless Chromium with a production build (`vike build && vike preview`): `/ai` (docpress, fixed by brillout/docpress#195 once released) and `/start` (this PR) are the only pages with hydration errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMCkUB7RMEKj9c2wPgTZUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMCkUB7RMEKj9c2wPgTZUK)_