### PR TITLE
fix: improve vike skill hint

### DIFF
--- a/packages/vike/src/node/vite/plugins/pluginDev/logSkillHint.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/logSkillHint.ts
@@ -41,7 +41,7 @@ const skillName = 'vike'
 // The skill file shipped by the vike npm package: node_modules/vike/skills/vike/SKILL.md (see packages/vike/scripts/copySkill.mjs)
 const skillFilePathInsidePackage = 'skills/vike/SKILL.md'
 // Cache entry at node_modules/.vike/cache.json, see cache.ts
-// - The Vike version (e.g. `"0.4.266"`) => the check didn't log anything last time, with that Vike version => skip the check until Vike is upgraded (the official skill file may change between Vike versions) or node_modules/ is removed
+// - `{ skip: true, version }` => the check didn't log anything last time, with that Vike version => skip the check until Vike is upgraded (the official skill file may change between Vike versions) or node_modules/ is removed
 // - Nothing is written as long as the hint is logged => the check is re-run upon every dev start
 const cacheKey = 'logSkillHint'
 
@@ -99,7 +99,8 @@ async function checkSkillUnsafe(userRootDir: string): Promise<void> {
   globalObject.alreadyChecked = true
 
   // The check is skipped once it didn't log anything, until Vike is upgraded (or node_modules/ is removed) — see cacheKey
-  if ((await getCacheValue(userRootDir, cacheKey)) === PROJECT_VERSION) return
+  const cached = await getCacheValue(userRootDir, cacheKey)
+  if (isObject(cached) && cached.skip === true && cached.version === PROJECT_VERSION) return
 
   const skillState = await getSkillState(userRootDir)
   if (skillState.state === 'missing') {
@@ -115,7 +116,7 @@ async function checkSkillUnsafe(userRootDir: string): Promise<void> {
     skillState.state === 'not-using-ai-agents' ||
     skillState.state === 'vike-not-from-npm'
   ) {
-    await setCacheValue(userRootDir, cacheKey, PROJECT_VERSION)
+    await setCacheValue(userRootDir, cacheKey, { skip: true, version: PROJECT_VERSION })
     return
   }
   checkType<never>(skillState)

--- a/packages/vike/src/node/vite/plugins/pluginDev/logSkillHint.ts
+++ b/packages/vike/src/node/vite/plugins/pluginDev/logSkillHint.ts
@@ -17,6 +17,7 @@ import { requireResolveOptional } from '../../../../utils/requireResolve.js'
 import { setTimeoutUnref } from '../../../../utils/setTimeoutUnref.js'
 import { isObject } from '../../../../utils/isObject.js'
 import { toPosixPath } from '../../../../utils/path.js'
+import { PROJECT_VERSION } from '../../../../utils/PROJECT_VERSION.js'
 import { unique } from '../../../../utils/unique.js'
 import { getVikeConfigInternal, type VikeConfigInternal } from '../../shared/resolveVikeConfigInternal.js'
 import { getCacheValue, setCacheValue } from '../../shared/cache.js'
@@ -40,7 +41,7 @@ const skillName = 'vike'
 // The skill file shipped by the vike npm package: node_modules/vike/skills/vike/SKILL.md (see packages/vike/scripts/copySkill.mjs)
 const skillFilePathInsidePackage = 'skills/vike/SKILL.md'
 // Cache entry at node_modules/.vike/cache.json, see cache.ts
-// - `false` => the check didn't log anything last time => skip the check (forever, until node_modules/ is removed)
+// - The Vike version (e.g. `"0.4.266"`) => the check didn't log anything last time, with that Vike version => skip the check until Vike is upgraded (the official skill file may change between Vike versions) or node_modules/ is removed
 // - Nothing is written as long as the hint is logged => the check is re-run upon every dev start
 const cacheKey = 'logSkillHint'
 
@@ -97,8 +98,8 @@ async function checkSkillUnsafe(userRootDir: string): Promise<void> {
   if (!getConfigValueAiSkill(vikeConfig)) return
   globalObject.alreadyChecked = true
 
-  // The check is skipped forever once it didn't log anything (until node_modules/ is removed) — see cacheKey
-  if ((await getCacheValue(userRootDir, cacheKey)) === false) return
+  // The check is skipped once it didn't log anything, until Vike is upgraded (or node_modules/ is removed) — see cacheKey
+  if ((await getCacheValue(userRootDir, cacheKey)) === PROJECT_VERSION) return
 
   const skillState = await getSkillState(userRootDir)
   if (skillState.state === 'missing') {
@@ -114,7 +115,7 @@ async function checkSkillUnsafe(userRootDir: string): Promise<void> {
     skillState.state === 'not-using-ai-agents' ||
     skillState.state === 'vike-not-from-npm'
   ) {
-    await setCacheValue(userRootDir, cacheKey, false)
+    await setCacheValue(userRootDir, cacheKey, PROJECT_VERSION)
     return
   }
   checkType<never>(skillState)
@@ -162,10 +163,7 @@ function getConfigValueAiSkill(vikeConfig: VikeConfigInternal): boolean {
   assertKeys(configAi, ['skill'] as const, `Setting ${pc.cyan('ai')}:`)
   const skill: unknown = configAi.skill
   if (skill === undefined) return true
-  assertUsage(
-    typeof skill === 'boolean',
-    `${pc.cyan('+ai.skill')} should be a boolean, see ${pc.underline(docsUrl)}`,
-  )
+  assertUsage(typeof skill === 'boolean', `${pc.cyan('+ai.skill')} should be a boolean, see ${pc.underline(docsUrl)}`)
   return skill
 }
 


### PR DESCRIPTION
Follow-up to #3501.

## Problem

Once the skill check had nothing to log, `node_modules/.vike/cache.json` got `{ "logSkillHint": false }` and the check never ran again until `node_modules/` was removed. Package managers keep `node_modules/.vike/` across upgrades, so after a Vike upgrade whose shipped `skills/vike/SKILL.md` changed, users who had installed the skill were never told their copy is outdated.

## Change

The cache entry now records the Vike version for which the check last had nothing to log:

```json
{ "logSkillHint": { "skip": true, "version": "0.4.266" } }
```

The check is skipped only while the installed Vike version matches the cached one. An upgrade (or downgrade) re-runs the check once; if it has nothing to log, the new version is written. As before, nothing is written as long as the hint is logged, so the check re-runs on every dev start until the skill is installed or updated.

A legacy `{ "logSkillHint": false }` written by v0.4.266 isn't an object, so those users get exactly one re-check, after which the new entry is stored.

## Testing

`tsc` build, Biome, and `lint-assertenv` pass. Smoke runs with a scratch app installing the packed tarball (v0.4.266):

- installed skill, no cache → silent, cache becomes `{ "logSkillHint": { "skip": true, "version": "0.4.266" } }`
- `AGENTS.md` only, cache holds the current version → silent (skipped)
- `AGENTS.md` only, cache holds an older version → missing hint, cache left unchanged
- `AGENTS.md` only, legacy cache `false` → missing hint
- installed skill, cache holds an older version plus another key → silent, entry updated, other key preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEH1KiHwHwqZjtRQjfxs8E