### PR TITLE
fix: fall back to Server Routing when the browser ignores the History API (fix #3509)

### DIFF
--- a/packages/vike/src/client/runtime-client-routing/history.ts
+++ b/packages/vike/src/client/runtime-client-routing/history.ts
@@ -7,7 +7,7 @@ export type { HistoryInfo }
 export type { ScrollPosition }
 
 import { getCurrentUrl } from '../shared/getCurrentUrl.js'
-import { assert, assertUsage } from '../../utils/assert.js'
+import { assertUsage, assertWarning } from '../../utils/assert.js'
 import { getGlobalObject } from '../../utils/getGlobalObject.js'
 import { isObject } from '../../utils/isObject.js'
 import { redirectHard } from '../../utils/redirectHard.js'
@@ -50,10 +50,10 @@ function getState(): StateEnhanced {
   // *Every* state added to the history needs to go through Vike.
   // - Otherwise Vike's `popstate` listener won't work. (Because, for example, if globalObject.previous is outdated => isHashNavigation faulty => client-side navigation is wrongfully skipped.)
   // - Therefore, we have to monkey patch history.pushState() and history.replaceState()
-  // - Therefore, we need the assert() below to ensure history.state has been enhanced by Vike
-  //   - If users stumble upon this assert() then let's make it a assertUsage()
-  assertIsEnhanced(state)
-  return state
+  // - Therefore, history.state is usually enhanced — if it isn't (another tool overwrote it, or the browser ignores
+  //   the History API) then we treat it as unknown: timestamp 0 => isBackwardNavigation === null
+  if (isEnhanced(state)) return state
+  return { vike: { timestamp: 0, scrollPosition: null, triggeredBy: 'browser' } }
 }
 
 function getScrollPosition(): ScrollPosition {
@@ -91,11 +91,16 @@ function pushHistoryState(url: string, overwriteLastHistoryEntry: boolean) {
   } else {
     replaceHistoryState(getState(), url)
   }
+  if (getCurrentUrl() === url) return
+  // The browser ignored the History API (WebKit does this inside a lazily loaded cross-origin iframe, which it gives
+  // no session history entry) => Client Routing is impossible => fall back to Server Routing. The hard navigation
+  // creates a history entry, restoring the History API. https://github.com/vikejs/vike/issues/3509
+  assertWarning(false, 'The browser ignores the History API => falling back to Server Routing.', { onlyOnce: true })
+  redirectHard(url)
 }
 function replaceHistoryState(state: StateEnhanced, url?: string) {
   const url_ = url ?? null // Passing `undefined` chokes older Edge versions.
   window.history.replaceState(state, '', url_)
-  assertIsEnhanced(window.history.state as unknown)
 }
 function replaceHistoryStateOriginal(state: unknown, url?: Parameters<typeof window.history.replaceState>[2]) {
   // Bypass all monkey patches.
@@ -132,7 +137,6 @@ function monkeyPatchHistoryAPI() {
             },
           }
       funcOriginal(state, ...rest)
-      assertIsEnhanced(window.history.state as unknown)
 
       globalObject.previous = getHistoryInfo()
 
@@ -166,10 +170,6 @@ function isEnhanced(state: unknown): state is StateEnhanced {
     return true
   }
   return false
-}
-function assertIsEnhanced(state: unknown): asserts state is StateEnhanced {
-  if (isEnhanced(state)) return
-  assert(false, { state })
 }
 
 type HistoryInfo = {

--- a/packages/vike/src/client/runtime-client-routing/history.ts
+++ b/packages/vike/src/client/runtime-client-routing/history.ts
@@ -3,11 +3,12 @@ export { replaceHistoryStateOriginal }
 export { onPopStateBegin }
 export { saveScrollPosition }
 export { initHistory }
+export { isHistoryInert }
 export type { HistoryInfo }
 export type { ScrollPosition }
 
 import { getCurrentUrl } from '../shared/getCurrentUrl.js'
-import { assert, assertUsage } from '../../utils/assert.js'
+import { assertUsage, assertWarning } from '../../utils/assert.js'
 import { getGlobalObject } from '../../utils/getGlobalObject.js'
 import { isObject } from '../../utils/isObject.js'
 import { redirectHard } from '../../utils/redirectHard.js'
@@ -16,6 +17,7 @@ import '../assertEnvClient.js'
 const globalObject = getGlobalObject('history.ts', {
   monkeyPatched: false,
   previous: undefined as any as HistoryInfo,
+  isInert: false,
 })
 initHistory() // we redundantly call initHistory() to ensure it's called early
 globalObject.previous = getHistoryInfo()
@@ -50,10 +52,11 @@ function getState(): StateEnhanced {
   // *Every* state added to the history needs to go through Vike.
   // - Otherwise Vike's `popstate` listener won't work. (Because, for example, if globalObject.previous is outdated => isHashNavigation faulty => client-side navigation is wrongfully skipped.)
   // - Therefore, we have to monkey patch history.pushState() and history.replaceState()
-  // - Therefore, we need the assert() below to ensure history.state has been enhanced by Vike
-  //   - If users stumble upon this assert() then let's make it a assertUsage()
-  assertIsEnhanced(state)
-  return state
+  // - Therefore, history.state is always enhanced — unless the browser ignores the History API, see markInert()
+  if (isEnhanced(state)) return state
+  markInert()
+  // timestamp: 0 => isBackwardNavigation === null (unknown), see initOnPopState.ts
+  return { vike: { timestamp: 0, scrollPosition: null, triggeredBy: 'browser' } }
 }
 
 function getScrollPosition(): ScrollPosition {
@@ -95,7 +98,6 @@ function pushHistoryState(url: string, overwriteLastHistoryEntry: boolean) {
 function replaceHistoryState(state: StateEnhanced, url?: string) {
   const url_ = url ?? null // Passing `undefined` chokes older Edge versions.
   window.history.replaceState(state, '', url_)
-  assertIsEnhanced(window.history.state as unknown)
 }
 function replaceHistoryStateOriginal(state: unknown, url?: Parameters<typeof window.history.replaceState>[2]) {
   // Bypass all monkey patches.
@@ -132,7 +134,6 @@ function monkeyPatchHistoryAPI() {
             },
           }
       funcOriginal(state, ...rest)
-      assertIsEnhanced(window.history.state as unknown)
 
       globalObject.previous = getHistoryInfo()
 
@@ -167,9 +168,25 @@ function isEnhanced(state: unknown): state is StateEnhanced {
   }
   return false
 }
-function assertIsEnhanced(state: unknown): asserts state is StateEnhanced {
-  if (isEnhanced(state)) return
-  assert(false, { state })
+// In Safari, inside a cross-origin `<iframe loading="lazy">`, history.pushState() and history.replaceState() are silently
+// ignored and `history.state` stays `null` — also after location.reload(). Client Routing cannot work without the
+// History API, so we fall back to Server Routing (see renderPageClient.ts) instead of crashing hydration: the hard
+// navigation loads a new document, which has a working History API.
+// https://github.com/vikejs/vike/issues/3509
+function markInert() {
+  globalObject.isInert = true
+  assertWarning(
+    false,
+    [
+      'The browser ignores the History API (e.g. Safari inside a cross-origin <iframe loading="lazy">).',
+      'Falling back to Server Routing.',
+      '(Page navigations will use Server Routing instead of Client Routing.)',
+    ].join(' '),
+    { onlyOnce: true },
+  )
+}
+function isHistoryInert(): boolean {
+  return globalObject.isInert
 }
 
 type HistoryInfo = {

--- a/packages/vike/src/client/runtime-client-routing/history.ts
+++ b/packages/vike/src/client/runtime-client-routing/history.ts
@@ -7,7 +7,7 @@ export type { HistoryInfo }
 export type { ScrollPosition }
 
 import { getCurrentUrl } from '../shared/getCurrentUrl.js'
-import { assertUsage, assertWarning } from '../../utils/assert.js'
+import { assert, assertUsage, assertWarning } from '../../utils/assert.js'
 import { getGlobalObject } from '../../utils/getGlobalObject.js'
 import { isObject } from '../../utils/isObject.js'
 import { redirectHard } from '../../utils/redirectHard.js'
@@ -15,6 +15,7 @@ import '../assertEnvClient.js'
 
 const globalObject = getGlobalObject('history.ts', {
   monkeyPatched: false,
+  historyApiBroken: false,
   previous: undefined as any as HistoryInfo,
 })
 initHistory() // we redundantly call initHistory() to ensure it's called early
@@ -47,10 +48,12 @@ function historyApiPushState(state: StateEnhanced, url: string) {
   // Calling the monkey patched history.pushState() (not the original) so that other tools (e.g. user tracking) can listen to Vike's pushState() calls.
   // - https://github.com/vikejs/vike/issues/1582
   window.history.pushState(state, '', url)
+  assertHistoryApi()
 }
 function historyApiReplaceState(state: StateEnhanced, url?: string) {
   const url_ = url ?? null // Passing `undefined` chokes older Edge versions.
   window.history.replaceState(state, '', url_)
+  assertHistoryApi()
 }
 function historyApiReplaceStateOriginal(state: unknown, url?: Parameters<typeof window.history.replaceState>[2]) {
   // Bypass all monkey patches.
@@ -135,6 +138,7 @@ function monkeyPatchHistoryAPI() {
             },
           }
       funcOriginal(state, ...rest)
+      assertHistoryApi()
 
       globalObject.previous = getHistoryInfo()
 
@@ -165,10 +169,19 @@ function getState(): StateEnhanced {
   // *Every* state added to the history needs to go through Vike.
   // - Otherwise Vike's `popstate` listener won't work. (Because, for example, if globalObject.previous is outdated => isHashNavigation faulty => client-side navigation is wrongfully skipped.)
   // - Therefore, we have to monkey patch history.pushState() and history.replaceState()
-  // - Therefore, history.state is usually enhanced — if it isn't (another tool overwrote it, or the browser ignores
-  //   the History API) then we treat it as unknown: timestamp 0 => isBackwardNavigation === null
+  // - Therefore, we need the assert() below to ensure history.state has been enhanced by Vike
+  //   - Unless the History API is broken, see assertHistoryApi() — then an un-enhanced state is expected and we
+  //     treat it as unknown: timestamp 0 => isBackwardNavigation === null
   if (isEnhanced(state)) return state
+  assert(globalObject.historyApiBroken, { state })
   return { vike: { timestamp: 0, scrollPosition: null, triggeredBy: 'browser' } }
+}
+// Called instead of asserting where an un-enhanced history.state isn't a Vike bug: the browser may ignore the
+// History API (https://github.com/vikejs/vike/issues/3509), or another tool may overwrite history.state
+// (https://github.com/vikejs/vike/issues/2504). We remember it so that the assert() in getState() stands down.
+function assertHistoryApi() {
+  if (isEnhanced(window.history.state as unknown)) return
+  globalObject.historyApiBroken = true
 }
 function isEnhanced(state: unknown): state is StateEnhanced {
   if ((state as any)?.vike) {

--- a/packages/vike/src/client/runtime-client-routing/history.ts
+++ b/packages/vike/src/client/runtime-client-routing/history.ts
@@ -7,7 +7,7 @@ export type { HistoryInfo }
 export type { ScrollPosition }
 
 import { getCurrentUrl } from '../shared/getCurrentUrl.js'
-import { assertUsage } from '../../utils/assert.js'
+import { assertUsage, assertWarning } from '../../utils/assert.js'
 import { getGlobalObject } from '../../utils/getGlobalObject.js'
 import { isObject } from '../../utils/isObject.js'
 import { redirectHard } from '../../utils/redirectHard.js'
@@ -93,6 +93,14 @@ function pushHistoryState(url: string, overwriteLastHistoryEntry: boolean) {
   } else {
     replaceHistoryState(getState(), url)
   }
+  if (getCurrentUrl() === url) return
+  // The browser ignored the History API: the URL didn't change. WebKit does this inside a lazily loaded cross-origin
+  // iframe, which it gives no session history entry (https://bugs.webkit.org/show_bug.cgi?id=227474). Client Routing
+  // is impossible without being able to change the URL => fall back to Server Routing. The hard navigation loads a new
+  // document, which does get a history entry and thus a working History API. (Reloading the current URL wouldn't.)
+  // https://github.com/vikejs/vike/issues/3509
+  assertWarning(false, 'The browser ignores the History API => falling back to Server Routing.', { onlyOnce: true })
+  redirectHard(url)
 }
 function replaceHistoryState(state: StateEnhanced, url?: string) {
   const url_ = url ?? null // Passing `undefined` chokes older Edge versions.

--- a/packages/vike/src/client/runtime-client-routing/history.ts
+++ b/packages/vike/src/client/runtime-client-routing/history.ts
@@ -45,6 +45,14 @@ function enhance() {
     },
   }
   replaceHistoryState(stateEnhanced)
+  if (isEnhanced(window.history.state as unknown)) return
+  // Our write didn't stick. Retry while bypassing all monkey patches, to tell apart:
+  // - another tool overwrote the state we just wrote => the retry sticks (and repairs it), see
+  //   https://github.com/vikejs/vike/issues/2504
+  // - the browser ignores the History API => the retry doesn't stick either, see markInert()
+  replaceHistoryStateOriginal(stateEnhanced)
+  if (isEnhanced(window.history.state as unknown)) return
+  markInert()
 }
 
 function getState(): StateEnhanced {
@@ -52,10 +60,10 @@ function getState(): StateEnhanced {
   // *Every* state added to the history needs to go through Vike.
   // - Otherwise Vike's `popstate` listener won't work. (Because, for example, if globalObject.previous is outdated => isHashNavigation faulty => client-side navigation is wrongfully skipped.)
   // - Therefore, we have to monkey patch history.pushState() and history.replaceState()
-  // - Therefore, history.state is always enhanced — unless the browser ignores the History API, see markInert()
+  // - Therefore, history.state is usually enhanced. When it isn't — the browser ignores the History API (see
+  //   markInert()), or another tool overwrote it (https://github.com/vikejs/vike/issues/2504) — we treat it as
+  //   unknown instead of crashing: timestamp 0 => isBackwardNavigation === null (see initOnPopState.ts)
   if (isEnhanced(state)) return state
-  markInert()
-  // timestamp: 0 => isBackwardNavigation === null (unknown), see initOnPopState.ts
   return { vike: { timestamp: 0, scrollPosition: null, triggeredBy: 'browser' } }
 }
 
@@ -168,17 +176,18 @@ function isEnhanced(state: unknown): state is StateEnhanced {
   }
   return false
 }
-// In Safari, inside a cross-origin `<iframe loading="lazy">`, history.pushState() and history.replaceState() are silently
-// ignored and `history.state` stays `null` — also after location.reload(). Client Routing cannot work without the
-// History API, so we fall back to Server Routing (see renderPageClient.ts) instead of crashing hydration: the hard
-// navigation loads a new document, which has a working History API.
-// https://github.com/vikejs/vike/issues/3509
+// WebKit gives a lazily loaded cross-origin iframe no session history entry, so history.pushState() and
+// history.replaceState() are silently ignored and `history.state` stays `null` — location.reload() doesn't help
+// either. Client Routing cannot work without the History API (the URL would never change), so we fall back to Server
+// Routing (see renderPageClient.ts) instead of crashing hydration: navigating to another URL loads a new document,
+// which does get a history entry and thus a working History API.
+// https://github.com/vikejs/vike/issues/3509 https://bugs.webkit.org/show_bug.cgi?id=227474
 function markInert() {
   globalObject.isInert = true
   assertWarning(
     false,
     [
-      'The browser ignores the History API (e.g. Safari inside a cross-origin <iframe loading="lazy">).',
+      'The browser ignores the History API (e.g. Safari inside a lazily loaded cross-origin iframe).',
       'Falling back to Server Routing.',
       '(Page navigations will use Server Routing instead of Client Routing.)',
     ].join(' '),

--- a/packages/vike/src/client/runtime-client-routing/history.ts
+++ b/packages/vike/src/client/runtime-client-routing/history.ts
@@ -3,12 +3,11 @@ export { replaceHistoryStateOriginal }
 export { onPopStateBegin }
 export { saveScrollPosition }
 export { initHistory }
-export { isHistoryInert }
 export type { HistoryInfo }
 export type { ScrollPosition }
 
 import { getCurrentUrl } from '../shared/getCurrentUrl.js'
-import { assertUsage, assertWarning } from '../../utils/assert.js'
+import { assertUsage } from '../../utils/assert.js'
 import { getGlobalObject } from '../../utils/getGlobalObject.js'
 import { isObject } from '../../utils/isObject.js'
 import { redirectHard } from '../../utils/redirectHard.js'
@@ -17,7 +16,6 @@ import '../assertEnvClient.js'
 const globalObject = getGlobalObject('history.ts', {
   monkeyPatched: false,
   previous: undefined as any as HistoryInfo,
-  isInert: false,
 })
 initHistory() // we redundantly call initHistory() to ensure it's called early
 globalObject.previous = getHistoryInfo()
@@ -45,14 +43,6 @@ function enhance() {
     },
   }
   replaceHistoryState(stateEnhanced)
-  if (isEnhanced(window.history.state as unknown)) return
-  // Our write didn't stick. Retry while bypassing all monkey patches, to tell apart:
-  // - another tool overwrote the state we just wrote => the retry sticks (and repairs it), see
-  //   https://github.com/vikejs/vike/issues/2504
-  // - the browser ignores the History API => the retry doesn't stick either, see markInert()
-  replaceHistoryStateOriginal(stateEnhanced)
-  if (isEnhanced(window.history.state as unknown)) return
-  markInert()
 }
 
 function getState(): StateEnhanced {
@@ -60,9 +50,10 @@ function getState(): StateEnhanced {
   // *Every* state added to the history needs to go through Vike.
   // - Otherwise Vike's `popstate` listener won't work. (Because, for example, if globalObject.previous is outdated => isHashNavigation faulty => client-side navigation is wrongfully skipped.)
   // - Therefore, we have to monkey patch history.pushState() and history.replaceState()
-  // - Therefore, history.state is usually enhanced. When it isn't — the browser ignores the History API (see
-  //   markInert()), or another tool overwrote it (https://github.com/vikejs/vike/issues/2504) — we treat it as
-  //   unknown instead of crashing: timestamp 0 => isBackwardNavigation === null (see initOnPopState.ts)
+  // - Therefore, history.state is usually enhanced. When it isn't — another tool overwrote it
+  //   (https://github.com/vikejs/vike/issues/2504), or the browser ignores the History API
+  //   (https://github.com/vikejs/vike/issues/3509) — we treat it as unknown instead of crashing:
+  //   timestamp 0 => isBackwardNavigation === null (see initOnPopState.ts)
   if (isEnhanced(state)) return state
   return { vike: { timestamp: 0, scrollPosition: null, triggeredBy: 'browser' } }
 }
@@ -175,27 +166,6 @@ function isEnhanced(state: unknown): state is StateEnhanced {
     return true
   }
   return false
-}
-// WebKit gives a lazily loaded cross-origin iframe no session history entry, so history.pushState() and
-// history.replaceState() are silently ignored and `history.state` stays `null` — location.reload() doesn't help
-// either. Client Routing cannot work without the History API (the URL would never change), so we fall back to Server
-// Routing (see renderPageClient.ts) instead of crashing hydration: navigating to another URL loads a new document,
-// which does get a history entry and thus a working History API.
-// https://github.com/vikejs/vike/issues/3509 https://bugs.webkit.org/show_bug.cgi?id=227474
-function markInert() {
-  globalObject.isInert = true
-  assertWarning(
-    false,
-    [
-      'The browser ignores the History API (e.g. Safari inside a lazily loaded cross-origin iframe).',
-      'Falling back to Server Routing.',
-      '(Page navigations will use Server Routing instead of Client Routing.)',
-    ].join(' '),
-    { onlyOnce: true },
-  )
-}
-function isHistoryInert(): boolean {
-  return globalObject.isInert
 }
 
 type HistoryInfo = {

--- a/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
+++ b/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
@@ -37,7 +37,7 @@ import {
   loadPageConfigsLazyClientSide,
   PageContext_loadPageConfigsLazyClientSide,
 } from '../shared/loadPageConfigsLazyClientSide.js'
-import { isHistoryInert, pushHistoryState, saveScrollPosition } from './history.js'
+import { pushHistoryState, saveScrollPosition } from './history.js'
 import {
   addNewPageContextAborted,
   type ErrorAbort,
@@ -139,11 +139,7 @@ async function renderPageClient(renderArgs: RenderArgs) {
     isFirstRender,
   }
 
-  // Fall back to Server Routing when:
-  // - Client Routing is disabled, see disableClientRouting()
-  // - The browser ignores the History API, see isHistoryInert(). Only a URL change needs the History API (see changeUrl()):
-  //   a same-URL re-render stays client-side — a hard navigation to the current URL wouldn't fix the History API anyway.
-  if (globalObject.clientRoutingIsDisabled || (isHistoryInert() && urlOriginal !== getCurrentUrl())) {
+  if (globalObject.clientRoutingIsDisabled) {
     redirectHard(urlOriginal)
     return
   }
@@ -513,7 +509,7 @@ async function renderPageClient(renderArgs: RenderArgs) {
       }
     }
 
-    changeUrl(urlOriginal, overwriteLastHistoryEntry)
+    if (!changeUrl(urlOriginal, overwriteLastHistoryEntry)) return
     globalObject.previousPageContext = pageContext
     // There should never be concurrent onRenderClient() calls
     assert(globalObject.onRenderClientPreviousPromise === undefined)
@@ -667,9 +663,26 @@ declare global {
   var _vike: VikeGlobalInternal
 }
 
-function changeUrl(url: string, overwriteLastHistoryEntry: boolean) {
-  if (getCurrentUrl() === url) return
+/** Returns `false` if Client Routing had to be abandoned in favor of Server Routing. */
+function changeUrl(url: string, overwriteLastHistoryEntry: boolean): boolean {
+  if (getCurrentUrl() === url) return true
   pushHistoryState(url, overwriteLastHistoryEntry)
+  if (getCurrentUrl() === url) return true
+  // The browser ignored the History API: the URL didn't change. WebKit does this inside a lazily loaded cross-origin
+  // iframe, which it gives no session history entry. Client Routing is impossible without being able to change the
+  // URL, so we fall back to Server Routing. The hard navigation loads a new document, which does get a history entry
+  // and thus a working History API. (Reloading the current URL wouldn't: it doesn't create an entry either.)
+  // https://github.com/vikejs/vike/issues/3509 https://bugs.webkit.org/show_bug.cgi?id=227474
+  assertWarning(
+    false,
+    [
+      'The browser ignores the History API (e.g. Safari inside a lazily loaded cross-origin iframe).',
+      'Falling back to Server Routing.',
+    ].join(' '),
+    { onlyOnce: true },
+  )
+  redirectHard(url)
+  return false
 }
 
 function disableClientRouting(err: unknown, log: boolean) {

--- a/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
+++ b/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
@@ -509,7 +509,7 @@ async function renderPageClient(renderArgs: RenderArgs) {
       }
     }
 
-    if (!changeUrl(urlOriginal, overwriteLastHistoryEntry)) return
+    changeUrl(urlOriginal, overwriteLastHistoryEntry)
     globalObject.previousPageContext = pageContext
     // There should never be concurrent onRenderClient() calls
     assert(globalObject.onRenderClientPreviousPromise === undefined)
@@ -663,26 +663,9 @@ declare global {
   var _vike: VikeGlobalInternal
 }
 
-/** Returns `false` if Client Routing had to be abandoned in favor of Server Routing. */
-function changeUrl(url: string, overwriteLastHistoryEntry: boolean): boolean {
-  if (getCurrentUrl() === url) return true
+function changeUrl(url: string, overwriteLastHistoryEntry: boolean) {
+  if (getCurrentUrl() === url) return
   pushHistoryState(url, overwriteLastHistoryEntry)
-  if (getCurrentUrl() === url) return true
-  // The browser ignored the History API: the URL didn't change. WebKit does this inside a lazily loaded cross-origin
-  // iframe, which it gives no session history entry. Client Routing is impossible without being able to change the
-  // URL, so we fall back to Server Routing. The hard navigation loads a new document, which does get a history entry
-  // and thus a working History API. (Reloading the current URL wouldn't: it doesn't create an entry either.)
-  // https://github.com/vikejs/vike/issues/3509 https://bugs.webkit.org/show_bug.cgi?id=227474
-  assertWarning(
-    false,
-    [
-      'The browser ignores the History API (e.g. Safari inside a lazily loaded cross-origin iframe).',
-      'Falling back to Server Routing.',
-    ].join(' '),
-    { onlyOnce: true },
-  )
-  redirectHard(url)
-  return false
 }
 
 function disableClientRouting(err: unknown, log: boolean) {

--- a/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
+++ b/packages/vike/src/client/runtime-client-routing/renderPageClient.ts
@@ -37,7 +37,7 @@ import {
   loadPageConfigsLazyClientSide,
   PageContext_loadPageConfigsLazyClientSide,
 } from '../shared/loadPageConfigsLazyClientSide.js'
-import { pushHistoryState, saveScrollPosition } from './history.js'
+import { isHistoryInert, pushHistoryState, saveScrollPosition } from './history.js'
 import {
   addNewPageContextAborted,
   type ErrorAbort,
@@ -139,7 +139,11 @@ async function renderPageClient(renderArgs: RenderArgs) {
     isFirstRender,
   }
 
-  if (globalObject.clientRoutingIsDisabled) {
+  // Fall back to Server Routing when:
+  // - Client Routing is disabled, see disableClientRouting()
+  // - The browser ignores the History API, see isHistoryInert(). Only a URL change needs the History API (see changeUrl()):
+  //   a same-URL re-render stays client-side — a hard navigation to the current URL wouldn't fix the History API anyway.
+  if (globalObject.clientRoutingIsDisabled || (isHistoryInert() && urlOriginal !== getCurrentUrl())) {
     redirectHard(urlOriginal)
     return
   }


### PR DESCRIPTION
fix #3509. Supersedes #3510.

WebKit gives a lazily loaded cross-origin iframe no session history entry ([WebKit bug 227474](https://bugs.webkit.org/show_bug.cgi?id=227474)), so `history.pushState()` and `history.replaceState()` are silently ignored and `history.state` stays `null`.

Two changes, both in `history.ts`:

**1. Hard-navigate when a URL change doesn't take effect.** `changeUrl()` checks, right after the History API call, whether the URL actually changed. If it didn't, Client Routing is impossible, so Vike falls back to Server Routing. The new document does get a history entry, restoring the History API.

**2. `assertHistoryApi()` replaces the assert where an un-enhanced `history.state` isn't a Vike bug** — the three places where Vike itself calls the History API. There, a state that didn't get enhanced means either the browser ignored the call (#3509) or another tool overwrote `history.state` (#2504). It records that in `historyApiBroken` instead of throwing. `getState()` keeps a real `assert()`, conditional on that flag, so a normal browser keeps the canary at full strength.

The two signals are deliberately kept apart: **the flag only suppresses asserts, the URL check alone decides the fallback.** The two failure modes are indistinguishable by state, but they differ by URL — when the browser ignores the History API the URL doesn't change, whereas a third-party state clobber (#2504) doesn't stop the URL from changing. Deciding the fallback from the flag would hard-navigate #2504 users on every navigation.

The assert during `initHistory()` was what threw before hydration ever ran, which is the blank frame reported in #3509. An unknown state is now treated as unknown (`timestamp: 0` ⇒ `isBackwardNavigation === null`), like Next.js, SvelteKit, Vue Router and React Router do. Reloading the current URL isn't a fix either, since it creates no history entry — which is why only a change to a *different* URL triggers the fallback, and why there's no reload loop.

Rebased onto #3512: since that refactoring merged the push and replace branches into a single `changeUrl()`, the URL check covers `replaceState` too. That's intended — when the browser ignores the History API, `replaceState` is ignored as well. The early `if (getCurrentUrl() === url) return` at the top of `changeUrl()` still guarantees Vike never hard-navigates to the URL it's already on.

## Verification

No WebKit available here, so both failure modes were simulated in Chromium with Playwright init scripts.

| Scenario | `historyApiBroken` | Result |
|---|---|---|
| No stub (normal browser) | **never set** | asserts fully live; no warning; Client Routing and `history.state.vike` intact; back/forward works |
| History API stubbed inert, base branch | — | hydration throws `[vike][Bug] … {"state":null}`, as reported |
| History API stubbed inert, this branch | set | hydration succeeds; a click to another URL hard-navigates and hydrates there, warning once; a same-URL click stays client-side with no reload loop; hash navigation and user-land `history.pushState()` don't throw |
| Third-party wrapper clobbering `history.state` while the URL change still lands (#2504) | set (asserts stand down) | the URL check keeps it on Client Routing; state repaired by the existing `queueMicrotask()` workaround; no warning, no fallback |

Note that the last row also fails on `main` today: the assert after `funcOriginal()` throws before the `queueMicrotask()` repair below it can run.

`pnpm build` (tsc), biome, lint and the `test/playground` e2e suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgGBqRcXX1trb3NxiToHY3